### PR TITLE
docs: fix e2e test runner command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ make e2e        # end-to-end tests against a booted simulator
 ```
 
 For the full build-and-test harness (simulator setup, the SimUsePlayground app,
-test-plan execution), use `./test-runner.sh` (run with `--help` for options
+test-plan execution), use `./scripts/test-runner.sh` (run with `--help` for options
 such as build-only / test-only modes and verbose output).
 
 Please add or update tests for any behavior change, and make sure the suite

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
-.PHONY: help build test clean viewer
+.PHONY: help build test e2e clean viewer
 
 help:
 	@echo "Common sim-use commands"
 	@echo "  make build   Build sim-use"
 	@echo "  make viewer  Rebuild the Viewer SPA into Sources/SimUse/Resources/viewer/"
 	@echo "  make test    Run default tests"
+	@echo "  make e2e     Run simulator end-to-end tests"
 	@echo "  make clean   Clean Swift build artifacts"
 
 build:
@@ -20,6 +21,9 @@ viewer:
 
 test:
 	swift test
+
+e2e:
+	./scripts/test-runner.sh
 
 clean:
 	swift package clean

--- a/Tests/TestUtilities.swift
+++ b/Tests/TestUtilities.swift
@@ -310,7 +310,7 @@ struct TestHelpers {
 
     static func requireE2EEnabled() throws {
         if !isE2EEnabled {
-            throw TestError.commandError("E2E simulator tests are disabled. Run via ./test-runner.sh or set SIM_USE_E2E=1.")
+            throw TestError.commandError("E2E simulator tests are disabled. Run via ./scripts/test-runner.sh or set SIM_USE_E2E=1.")
         }
     }
 


### PR DESCRIPTION
## Summary
- Add the documented `make e2e` target as a wrapper around `./scripts/test-runner.sh`.
- Update contributor/test guidance that still pointed at `./test-runner.sh`.

## Validation
- `git diff --check`
- `make -n e2e`
- `make help`