### PR TITLE
fix: preflight daemon-restart autofix drops incompatible --device flag

### DIFF
--- a/skills/sim-use/scripts/preflight.py
+++ b/skills/sim-use/scripts/preflight.py
@@ -144,7 +144,13 @@ def check_ui_responds(ctx: Ctx) -> bool:
 
 
 def autofix_daemon_restart(ctx: Ctx) -> bool:
-    ctx.run_sim_use("daemon", "stop", "--all")
+    # `daemon stop --all` is mutually exclusive with `--device`, so bypass
+    # run_sim_use (which appends --device when a device is set and would make
+    # the command fail with "Specify either --device <id> or --all").
+    subprocess.run(
+        [ctx.sim_use_bin, "daemon", "stop", "--all"],
+        capture_output=True, text=True,
+    )
     return True
 
 


### PR DESCRIPTION
## Summary

`autofix_daemon_restart` in `skills/sim-use/scripts/preflight.py` runs
`daemon stop --all` through `Ctx.run_sim_use`, which appends `--device <id>`
whenever a device is set. `daemon stop` treats `--all` and `--device` as
mutually exclusive:

    $ sim-use daemon stop --all --device <UDID>
    Error: Specify either --device <id> or --all (not both, not neither).
    # exit 64

The command errors out and the daemon is never stopped, yet the function
ignores the result and returns `True`. So in the documented
`preflight.py --device <UDID>` invocation the daemon-restart self-heal is a
silent no-op: when `ui_responds` fails against a stale daemon, the autofix
prints "attempting autofix...", does nothing, and preflight still fails.

This is the same class of bug that 2fc67cf fixed for the `devices` call —
that commit fixed one call site and missed this one.

## Fix

Call `daemon stop --all` via `subprocess.run` directly (without `--device`),
mirroring the approach `check_device_listed` already uses after 2fc67cf.

## Verification

With a running daemon, calling the real `autofix_daemon_restart(Ctx(device=UDID))`:

- **before:** `daemon status` still lists the daemon (pid unchanged) after the autofix
- **after:** `daemon status` returns `{"daemons":[]}` — the daemon is actually stopped

Verified end-to-end against a booted iOS simulator (iPhone 17 Pro, iOS 26.5, sim-use 0.9.0).

## Notes

The bundled skill scripts under `skills/sim-use/scripts/` have no test harness
(`make test` runs `swift test`), so no automated test is added, matching
2fc67cf. This host-side Python change does not affect `swift test`.
