### PR TITLE
docs: enhance skills with batch reference, multi-touch gestures, and dev-install skill

### DIFF
--- a/.agents/skills/bump-version-dev/SKILL.md
+++ b/.agents/skills/bump-version-dev/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: bump-version-dev
+description: Build a release-shaped sim-use binary and install it locally for testing. Use when the user runs `/bump-version-dev` or asks to "build a dev release", "test the release build locally", "install a release build for testing", or "prepare a release candidate without publishing". Builds APK + CLI, stages, ad-hoc signs, and repoints the PATH binary. Does NOT commit, tag, push, create releases, or update homebrew. After local validation, run `/release` to ship for real.
+---
+
+This skill builds and locally installs a release-shaped sim-use binary so the user can validate it before publishing. It delegates the heavy lifting to `scripts/dev-install.sh` and handles version determination + user confirmation.
+
+Run from the sim-use repo root (`git rev-parse --show-toplevel`).
+
+## Restore flow
+
+If the user passes `restore` as an argument (e.g. `/bump-version-dev restore`), skip everything and run:
+
+```bash
+scripts/dev-install.sh --restore
+```
+
+Report success or failure and stop.
+
+## Step 1: Pre-flight
+
+Run these checks. Abort with a clear error if any fails.
+
+1. Current directory is the sim-use repo root.
+2. `build_products/Frameworks/` exists. If missing, tell the user to run `scripts/build.sh dev` (~30 min). Do NOT run it automatically.
+3. Android bridge toolchain: `scripts/build-bridge.sh --check` succeeds. If not, surface the missing tool.
+
+Unlike `/release`, this skill does NOT require:
+- Clean working tree (local modifications are fine — this is a dev build)
+- GitHub auth
+- Homebrew tap clone
+- Codesign identity or notary profile
+
+## Step 2: Determine the next version
+
+1. Find the latest sim-use tag: `git tag --list 'v*' --sort=-v:refname | head -1`.
+2. If a prior tag exists, read commits since it: `git log <last-tag>..HEAD --pretty=format:'%h %s'`.
+3. Pick bump type from conventional commit prefixes:
+   - `feat!:` / `BREAKING CHANGE` → **major**
+   - `feat:` → **minor**
+   - Only `fix:` / `chore:` / `docs:` / `refactor:` / `test:` → **patch**
+4. Compute the next version.
+
+If the user specified a version (e.g. `/bump-version-dev 0.9.1`), use that verbatim instead of auto-bumping.
+
+## Step 3: Confirm with the user
+
+Show:
+- The current tag and the target version.
+- The commit list since the last tag (one line each).
+- What will happen: "Build APK + CLI as vX.Y.Z, stage, ad-hoc sign, and replace the PATH binary."
+
+Ask: **"Build and install vX.Y.Z locally?"** Wait for explicit yes/no/version override.
+
+## Step 4: Run the dev-install script
+
+```bash
+scripts/dev-install.sh --version X.Y.Z
+```
+
+This script handles:
+1. Rebuilding the Android bridge APK (`scripts/build-bridge.sh`)
+2. Building the universal CLI with `SIM_USE_VERSION=X.Y.Z` (`scripts/build.sh executable`)
+3. Staging the payload (`scripts/release-artifacts.sh stage-build-output` + `verify-stage`)
+4. Ad-hoc codesigning the staged payload
+5. Backing up the current PATH binary target
+6. Symlinking the PATH binary to the staged build
+7. Verifying `sim-use --version`
+
+The script typically takes 2-5 minutes. Stream the output so the user sees progress. If the script fails, diagnose:
+
+- Bridge build failed → JDK/SDK issue, see CLAUDE.md Android pitfalls
+- `verify-stage` failed → missing resource bundle, re-check build output
+- Codesign failed → unlikely for ad-hoc; check macOS version
+- Symlink failed → permission issue on the install path
+
+## Step 5: Report
+
+After the script succeeds, report:
+- The installed version (`sim-use --version`)
+- The symlink target
+- Reminder: test the build, then run `/release` to ship for real
+- Reminder: run `scripts/dev-install.sh --restore` (or `/bump-version-dev restore`) to go back
+
+## Things to NOT do
+
+- Don't modify `CHANGELOG.md`, `bridge/app/build.gradle.kts`, or any tracked file.
+- Don't commit, tag, or push anything.
+- Don't run `--build-frameworks` — that's a slow path requiring explicit user opt-in.
+- Don't codesign with Developer ID — ad-hoc is sufficient for local testing.
+- Don't create tarballs, formulas, or releases.
+- Don't attempt notarization.

--- a/skills/sim-use/SKILL.md
+++ b/skills/sim-use/SKILL.md
@@ -66,6 +66,8 @@ sim-use screenshot --device <UDID> --output after.png
 | Android back | `sim-use button back --device <UDID>` |
 | Wait for animation | `sleep 0.4` between commands, or `--pre-delay 0.5` |
 | Toggle/switch | `sim-use tap @N --duration 0.05 --device <UDID>` (UISwitch needs a brief hold) |
+| Pinch zoom in | `sim-use gesture pinch-out --device <UDID>` (two-finger spread) |
+| Rotate | `sim-use gesture rotate-cw --angle 90 --device <UDID>` |
 
 ## 2. Pitfalls
 

--- a/skills/sim-use/references/batch-reference.md
+++ b/skills/sim-use/references/batch-reference.md
@@ -1,0 +1,95 @@
+# sim-use Batch Reference
+
+Use this reference when generating or reviewing `sim-use ios batch` commands.
+
+## Supported step commands
+- `tap`
+- `swipe`
+- `gesture`
+- `touch`
+- `type`
+- `button`
+- `key`
+- `key-sequence`
+- `key-combo`
+- `sleep <seconds>` (batch pseudo-step)
+
+## Batch flags
+- `--device <UDID>`: required simulator target.
+- `--step "..."`: repeatable inline step source.
+- `--file <path>`: read one step per line from file.
+- `--stdin`: read one step per line from stdin.
+- `--continue-on-error`: keep running after a failed step; report failures at end.
+- `--ax-cache perBatch|perStep|none`: selector tap AX snapshot reuse policy.
+- `--type-submission chunked|composite`: submission mode for `type` steps.
+- `--type-chunk-size <n>`: chunk size when using chunked submission.
+- `--wait-timeout <seconds>`: maximum seconds to poll for selector-based elements before failing (0 = no waiting, default).
+- `--poll-interval <seconds>`: seconds between accessibility tree polls when `--wait-timeout` is active (default 0.25).
+- `--verbose`: enable detailed stderr logs for troubleshooting (default quiet output).
+
+## Input rules
+- Use exactly one source: `--step` OR `--file` OR `--stdin`.
+- Empty lines are ignored.
+- `#` comment lines are ignored in file/stdin input.
+- Do not pass `--device` inside step lines; keep it at batch command level.
+
+## Example: inline steps
+```bash
+sim-use ios batch --device SIMULATOR_UDID \
+  --step "tap --id EmailField" \
+  --step "type 'cam@example.com'" \
+  --step "key 43" \
+  --step "type 'super-secret'" \
+  --step "key 40"
+```
+
+## Example: stdin steps
+```bash
+cat <<'EOF' | sim-use ios batch --device SIMULATOR_UDID --stdin
+tap --id EmailField
+type 'cam@example.com'
+key 43
+type 'super-secret'
+key 40
+EOF
+```
+
+## Example: file steps
+`login.steps`
+```text
+# login flow
+tap --id EmailField
+type 'cam@example.com'
+key 43
+type 'super-secret'
+key 40
+```
+
+Run:
+```bash
+sim-use ios batch --device SIMULATOR_UDID --file login.steps
+```
+
+## Example: explicit timing and policy
+```bash
+sim-use ios batch --device SIMULATOR_UDID \
+  --ax-cache perStep \
+  --type-submission chunked \
+  --type-chunk-size 150 \
+  --continue-on-error \
+  --step "tap --label Settings" \
+  --step "sleep 0.5" \
+  --step "tap --id SaveButton"
+```
+
+## Example: multi-screen flow with element waiting
+```bash
+sim-use ios batch --device SIMULATOR_UDID \
+  --wait-timeout 5 \
+  --step "tap --id LoginButton" \
+  --step "tap --id WelcomeMessage"
+```
+
+The second step polls for up to 5 seconds for `WelcomeMessage` to appear after the login tap triggers navigation.
+
+If label selectors are ambiguous and sim-use reports no `AXUniqueId` values for matches, switch that step to coordinates (`tap -x/-y`).

--- a/skills/sim-use/references/cheatsheet.md
+++ b/skills/sim-use/references/cheatsheet.md
@@ -62,11 +62,60 @@ sim-use gesture scroll-up           # scroll-up = content moves up = page down
 sim-use gesture scroll-down         # page up
 sim-use swipe --start-x 50 --start-y 500 --end-x 350 --end-y 500
 sim-use long-press @5               # default 0.8s hold
+sim-use long-press --label "Photos" # selector targeting
+sim-use long-press @5 --duration 1.2  # custom hold time
 sim-use tap @5 --duration 0.05      # brief hold for toggles/switches
 sim-use tap @5 --pre-delay 0.3      # wait before tapping
 ```
 
+`long-press` is sugar over `tap --duration 0.8`. Same targeting surface as `tap`. Use for action menus, launcher popups, drag-handle activation.
+
+Note: some Android apps render long-press menus in a `PopupWindow` overlay that the bridge's `describe-ui` cannot walk — verify with a screenshot when this matters.
+
 **Naming gotcha:** `scroll-up` scrolls the *content* up (like swiping up), which shows content *below* — it's "page down" in reading order.
+
+## Pinch and rotate (two-finger gestures)
+
+```bash
+sim-use gesture pinch-out                             # zoom in (default scale 2.0)
+sim-use gesture pinch-in                              # zoom out (default scale 0.5)
+sim-use gesture pinch-out --scale 3.0 --radius 60     # wider zoom, smaller start circle
+sim-use gesture rotate-cw                             # clockwise 90° (default)
+sim-use gesture rotate-ccw --angle 45                 # counter-clockwise 45°
+sim-use gesture pinch-out --center-x 200 --center-y 400  # off-center pivot
+```
+
+| Parameter | Default | Description |
+|---|---|---|
+| `--scale` | 2.0 (out) / 0.5 (in) | End radius / start radius ratio |
+| `--angle` | 90 | Rotation sweep in degrees |
+| `--center-x/y` | screen center | Pivot point (pixels) |
+| `--radius` | 80 | Start radius (pixels) |
+| `--steps` | 10 | Interpolated HID Move events (iOS only) |
+| `--step-ms` | derived from duration/steps | Sleep between Move events (iOS only) |
+
+## Multi-touch (low-level)
+
+For gestures the presets don't cover, use `multi-touch` directly with two contact points:
+
+```bash
+# Pinch-zoom in by moving two fingers apart vertically
+sim-use multi-touch \
+  --x1 195 --y1 472 --x1-end 195 --y1-end 322 \
+  --x2 195 --y2 472 --x2-end 195 --y2-end 622 \
+  --steps 10 --step-ms 30
+```
+
+Also available: `tap --fingers 2` and `long-press --fingers 2` for two-finger tap/hold.
+
+## Touch (low-level, single finger)
+
+```bash
+sim-use touch -x 150 -y 250 --down                # touch down only
+sim-use touch -x 150 -y 250 --up                  # touch up only
+sim-use touch -x 150 -y 250 --down --up            # tap
+sim-use touch -x 150 -y 250 --down --up --delay 1.0  # long press
+```
 
 ## Screenshots and video
 
@@ -74,6 +123,18 @@ sim-use tap @5 --pre-delay 0.3      # wait before tapping
 sim-use screenshot --output shot.png
 sim-use record-video --output recording.mp4 --fps 15   # Ctrl+C to stop
 sim-use ios stream-video --fps 10 --format mjpeg        # iOS only
+```
+
+### Stopping a backgrounded recording
+
+Send `SIGTERM` and `wait` — do **not** `SIGKILL`, which skips the MP4 trailer and produces an unplayable file.
+
+```bash
+sim-use record-video --output recording.mp4 &
+PID=$!
+# ... drive the simulator ...
+kill -TERM "$PID"
+wait "$PID"               # blocks ~50–150 ms while the trailer is written
 ```
 
 ## Batch (iOS only)
@@ -90,6 +151,7 @@ sim-use ios batch --device <UDID> \
 - `--wait-timeout` makes selector taps poll for the element.
 - `--ax-cache perStep` refreshes the AX snapshot between steps.
 - Do not put `--device` inside step lines.
+- See `references/batch-reference.md` for full semantics, flags, and examples.
 
 ## Daemon
 
@@ -101,6 +163,50 @@ SIM_USE_NO_DAEMON=1 sim-use ui     # bypass daemon for one call
 ```
 
 Daemon is iOS-only (auto-spawned, 600s idle TTL). Android commands go through adb directly.
+
+## iOS keyboard (HID keycodes)
+
+```bash
+sim-use ios key 40                                    # Enter
+sim-use ios key 42 --duration 1.0                     # Hold Backspace
+sim-use ios key-sequence --keycodes 11,8,15,15,18     # "hello"
+sim-use ios key-combo --modifiers 227 --key 4         # Cmd+A
+sim-use ios key-combo --modifiers 227 --key 6         # Cmd+C
+sim-use ios key-combo --modifiers 227 --key 25        # Cmd+V
+sim-use ios key-combo --modifiers 227,225 --key 4     # Cmd+Shift+A
+```
+
+### Common keycodes
+
+| Key | Code | Key | Code | Key | Code |
+|---|---|---|---|---|---|
+| Enter | 40 | Escape | 41 | Backspace | 42 |
+| Tab | 43 | Space | 44 | a | 4 |
+| LeftGUI (Cmd) | 227 | LeftShift | 225 | LeftCtrl | 224 |
+| LeftAlt | 226 | F1 | 58 | F12 | 69 |
+
+## Timing parameters
+
+| Parameter | Range | Description | Available on |
+|---|---|---|---|
+| `--pre-delay` | 0–10s | Delay before action | tap, swipe, gesture |
+| `--post-delay` | 0–10s | Delay after action | tap, swipe, gesture |
+| `--duration` | 0–10s | Action duration | swipe, gesture, button, key, tap (opt-in for toggles) |
+| `--delay` | 0–5s | Between-item delay | key-sequence, touch |
+
+## UDID auto-resolution
+
+`--device` is optional. Resolution order:
+
+1. Explicit `--device <UDID>` flag
+2. `$SIM_USE_DEVICE` environment variable
+3. The only live sim-use daemon under `/tmp/sim-use-<uid>/` (<1 ms)
+4. The only simulator with `state == "Booted"` via `xcrun simctl list` (~150 ms)
+
+Edge cases:
+- **Stale daemon**: if you shut down a simulator outside sim-use but its daemon is still alive, the next command fails loudly — run `sim-use daemon stop --all` then retry.
+- **Multiple daemons + multiple booted**: falls through to step 4 and errors with a disambiguation message listing all booted devices.
+- For CI fan-out (many simulators in parallel), keep `--device` explicit.
 
 ## --json envelope
 


### PR DESCRIPTION
## Summary

- Port `batch-reference.md` from the private repo as a dedicated batch command reference (flags, rules, examples)
- Expand `cheatsheet.md` with missing content:
  - Pinch/rotate two-finger gesture presets with parameter table
  - `multi-touch` low-level two-finger command (flag names verified on live simulator)
  - `touch` single-finger low-level command
  - iOS HID keycode table and `key`/`key-combo`/`key-sequence` examples
  - Timing parameters consolidated table
  - UDID auto-resolution behavior and edge cases
  - `record-video` SIGTERM+wait safe-stop pattern
  - `long-press` details and Android caveat
- Add pinch and rotate entries to SKILL.md common moves table
- Add `bump-version-dev` skill for local release-shaped builds without commit/tag/push
- Fix `multi-touch` flag names: `--x1-end` (not `--end-x1`), caught by live testing on Maps

## Test plan

- [x] `pinch-out` / `pinch-in` verified on iOS Simulator Maps (zoom in/out)
- [x] `rotate-cw` / `rotate-ccw` verified on Maps (compass needle rotated)
- [x] `multi-touch` low-level verified with correct flag names
- [x] `bump-version-dev` skill references existing `scripts/dev-install.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)