### PR TITLE
chore: add prepare-commit-msg hook for automatic DCO sign-off

### DIFF
--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,19 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+#
+# Automatically append a Signed-off-by line (DCO) if one is not already
+# present. Equivalent to `git commit -s` without having to remember the flag.
+
+# Only act on regular commits (not merges, squashes, or template messages).
+case "$2" in
+  merge|squash) exit 0 ;;
+esac
+
+SOB="Signed-off-by: $(git config user.name) <$(git config user.email)>"
+
+# Do nothing if the sign-off is already there.
+grep -qF "$SOB" "$1" && exit 0
+
+# Append a blank line + sign-off at the end of the message.
+echo "" >> "$1"
+echo "$SOB" >> "$1"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,13 @@ Git can add this automatically with the `-s` flag:
 git commit -s -m "Fix tap selector disambiguation"
 ```
 
+Alternatively, enable the bundled git hook so every commit is signed off
+automatically — no need to remember `-s`:
+
+```bash
+git config core.hooksPath .githooks
+```
+
 Pull requests are checked by a DCO bot; commits missing a valid sign-off will
 be flagged and must be amended (`git commit --amend -s`, or `git rebase
 --signoff` for a series) before they can be merged.


### PR DESCRIPTION
## Summary

- Add `.githooks/prepare-commit-msg` that auto-appends `Signed-off-by` to commit messages (skips merges/squashes, no-ops if already present)
- Document the opt-in step (`git config core.hooksPath .githooks`) in the DCO section of `CONTRIBUTING.md`

Contributors must explicitly opt in — no behavior change for anyone who doesn't run the config command.

## Test plan

- [x] Verified hook appends sign-off on a fresh commit
- [x] Verified hook skips when sign-off already present (`git commit -s`)
- [x] Verified merge commits are not modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)