### PR TITLE
chore: wire up make e2e with xcodegen-based playground project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
-.PHONY: help build test clean viewer
+.PHONY: help build test e2e clean viewer
 
 help:
 	@echo "Common sim-use commands"
 	@echo "  make build   Build sim-use"
 	@echo "  make viewer  Rebuild the Viewer SPA into Sources/SimUse/Resources/viewer/"
-	@echo "  make test    Run default tests"
+	@echo "  make test    Run unit tests (no simulator needed)"
+	@echo "  make e2e     Run end-to-end tests on a booted simulator"
 	@echo "  make clean   Clean Swift build artifacts"
 
 build:
@@ -20,6 +21,9 @@ viewer:
 
 test:
 	swift test
+
+e2e:
+	./scripts/test-runner.sh
 
 clean:
 	swift package clean

--- a/SimUsePlaygroundApp/SimUsePlayground/Info.plist
+++ b/SimUsePlaygroundApp/SimUsePlayground/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>SimUsePlayground</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>UILaunchScreen</key>
+	<dict/>
+</dict>
+</plist>

--- a/SimUsePlaygroundApp/project.yml
+++ b/SimUsePlaygroundApp/project.yml
@@ -1,0 +1,25 @@
+name: SimUsePlayground
+options:
+  bundleIdPrefix: com.cameroncooke
+  deploymentTarget:
+    iOS: "18.0"
+
+targets:
+  SimUsePlayground:
+    type: application
+    platform: iOS
+    sources:
+      - SimUsePlayground
+    info:
+      path: SimUsePlayground/Info.plist
+      properties:
+        CFBundleDisplayName: SimUsePlayground
+        UILaunchScreen: {}
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.cameroncooke.SimUsePlayground
+        MARKETING_VERSION: "1.0"
+        CURRENT_PROJECT_VERSION: "1"
+        CODE_SIGN_IDENTITY: "-"
+        CODE_SIGNING_ALLOWED: "NO"
+        GENERATE_INFOPLIST_FILE: "YES"

--- a/scripts/test-runner.sh
+++ b/scripts/test-runner.sh
@@ -141,6 +141,12 @@ check_prerequisites() {
         exit 1
     fi
 
+    # Check if xcodegen is available (needed to generate the playground project)
+    if ! command -v xcodegen &> /dev/null; then
+        print_error "xcodegen not found. Install with: brew install xcodegen"
+        exit 1
+    fi
+
     print_success "All prerequisites satisfied"
 }
 
@@ -209,6 +215,20 @@ build_sim_use() {
         print_error "Failed to build sim-use executable"
         exit 1
     fi
+}
+
+# Function to generate the Xcode project for the playground app
+generate_playground_project() {
+    print_header "Generating Playground Xcode Project"
+
+    if [[ ! -f "SimUsePlaygroundApp/project.yml" ]]; then
+        print_error "SimUsePlaygroundApp/project.yml not found."
+        exit 1
+    fi
+
+    print_info "Running xcodegen..."
+    (cd SimUsePlaygroundApp && xcodegen generate)
+    print_success "Xcode project generated"
 }
 
 # Function to build and install playground app
@@ -384,6 +404,7 @@ main() {
     if [[ "$TESTS_ONLY" != true ]]; then
         clean_build
         build_sim_use
+        generate_playground_project
         build_playground_app
     fi
 


### PR DESCRIPTION
## Summary

- Add `project.yml` as xcodegen spec for the SimUsePlayground app (source of truth; `*.xcodeproj` stays gitignored)
- Update `test-runner.sh` to auto-generate the Xcode project via `xcodegen` before building
- Add `make e2e` target that wraps `./scripts/test-runner.sh`

New prerequisite for running e2e tests: `brew install xcodegen`

Closes #1 (the `make e2e` target is now functional).

## Test plan

- [x] `xcodegen generate` produces a valid xcodeproj from `project.yml`
- [x] `xcodebuild build` succeeds against a booted simulator
- [x] `make -n e2e` resolves to `./scripts/test-runner.sh`
- [x] `make help` lists the new `e2e` target

🤖 Generated with [Claude Code](https://claude.com/claude-code)