### PR TITLE
fix: surface daemon command errors without respawning the daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Daemon client now retries a command once against the same daemon when the simulator reports the post-boot `transient_booting` readiness gap, matching the long-documented behaviour.
+
+### Fixed
+
+- Daemon client no longer tears down a healthy daemon and re-executes the command when the daemon answers with a command-level error (element not found, etc.). Failed commands now surface immediately instead of paying a full daemon respawn, and side-effecting commands are no longer executed twice.
+
 ## [0.9.0] - 2026-06-29
 
 Initial public release.

--- a/Sources/SimUseCore/Daemon/DaemonClient.swift
+++ b/Sources/SimUseCore/Daemon/DaemonClient.swift
@@ -63,6 +63,13 @@ public enum DaemonClient {
                     transientRetryDelay: transientRetryDelay
                 )
             } catch {
+                // Cooperative cancellation is the caller's signal, not
+                // a stale daemon — the retry delay below is a
+                // suspension point, so it can surface here. Rethrow
+                // before any cleanup/respawn.
+                if error is CancellationError {
+                    throw error
+                }
                 // A `remote` error means the daemon is alive and
                 // answered `ok=false` — that IS the command's outcome.
                 // Tearing the daemon down here would orphan a healthy
@@ -113,7 +120,15 @@ public enum DaemonClient {
         } catch let error as DaemonClientError {
             guard case .remote(_, .transientBooting, _) = error else { throw error }
             trace("transient_booting; retrying once after \(transientRetryDelay)s")
-            try await Task.sleep(nanoseconds: UInt64(max(0, transientRetryDelay) * 1_000_000_000))
+            // `transientRetryDelay` is public API: guard the nanosecond
+            // conversion against non-finite/overflowing values (skip the
+            // pause, retry immediately) instead of trapping. The cap only
+            // bounds the conversion; sane callers stay well below it.
+            if transientRetryDelay.isFinite, transientRetryDelay > 0 {
+                let cappedSeconds = min(transientRetryDelay, 60)
+                try await Task.sleep(nanoseconds: UInt64(cappedSeconds * 1_000_000_000))
+            }
+            try Task.checkCancellation()
             let response = try sendRequest(command: command, args: args, to: paths.socketURL.path)
             trace("retry sendRequest OK \(response.count) bytes, classifying")
             return try classify(response: response)

--- a/Sources/SimUseCore/Daemon/DaemonClient.swift
+++ b/Sources/SimUseCore/Daemon/DaemonClient.swift
@@ -15,10 +15,17 @@ import Foundation
 public enum DaemonClient {
     /// Top-level entry: send a command to the right daemon and return
     /// the response line (without trailing newline).
+    ///
+    /// `baseDirectory` overrides the default `/tmp/sim-use-<uid>/` tree;
+    /// production callers leave it nil, tests pass an isolated directory.
+    /// `transientRetryDelay` is the pause before the single
+    /// `transient_booting` re-send (see `sendClassifiedRequest`).
     public static func invoke(
         command: String,
         args: [String],
-        udid: String
+        udid: String,
+        baseDirectory: URL? = nil,
+        transientRetryDelay: TimeInterval = 1.0
     ) async throws -> Data {
         // Ignore SIGPIPE for the remainder of the process. Without it,
         // any write() on a socket whose peer has closed its read side
@@ -26,7 +33,7 @@ public enum DaemonClient {
         // code in writeAll gets to run. Cheap and idempotent.
         signal(SIGPIPE, SIG_IGN)
 
-        let paths = DaemonPaths(udid: udid)
+        let paths = DaemonPaths(udid: udid, baseDirectory: baseDirectory)
         try paths.ensureBaseDirectory()
 
         var liveness = paths.filesystemLiveness()
@@ -49,11 +56,25 @@ public enum DaemonClient {
         // Fast path: a daemon already appears to be live.
         if case .probablyAlive = liveness {
             do {
-                let response = try sendRequest(command: command, args: args, to: paths.socketURL.path)
-                trace("sendRequest OK \(response.count) bytes, classifying")
-                return try classify(response: response)
+                return try await sendClassifiedRequest(
+                    command: command,
+                    args: args,
+                    paths: paths,
+                    transientRetryDelay: transientRetryDelay
+                )
             } catch {
-                trace("fast-path sendRequest/classify failed: \(error). Removing stale files.")
+                // A `remote` error means the daemon is alive and
+                // answered `ok=false` — that IS the command's outcome.
+                // Tearing the daemon down here would orphan a healthy
+                // server and re-executing the request would double any
+                // side effects it already performed. Only transport-
+                // level failures (connect/write/read, empty or garbage
+                // response) indicate a stale daemon worth respawning.
+                if let clientError = error as? DaemonClientError,
+                   case .remote = clientError {
+                    throw clientError
+                }
+                trace("fast-path transport failure: \(error). Removing stale files.")
                 paths.removeSocket()
                 paths.removePidfile()
             }
@@ -65,9 +86,38 @@ public enum DaemonClient {
         try await waitForSocket(paths: paths, timeout: 5.0)
         trace("socket ready after spawn")
 
-        let response = try sendRequest(command: command, args: args, to: paths.socketURL.path)
-        trace("post-spawn sendRequest OK \(response.count) bytes, classifying")
-        return try classify(response: response)
+        return try await sendClassifiedRequest(
+            command: command,
+            args: args,
+            paths: paths,
+            transientRetryDelay: transientRetryDelay
+        )
+    }
+
+    /// Send + classify one business request, retrying exactly once when
+    /// the daemon reports `transient_booting` (the post-`simctl boot`
+    /// accessibility-readiness gap). The retry targets the SAME daemon:
+    /// booting is the simulator's condition, not the server's, so a
+    /// respawn would only add latency. Any other failure — including a
+    /// second `transient_booting` — propagates to the caller.
+    private static func sendClassifiedRequest(
+        command: String,
+        args: [String],
+        paths: DaemonPaths,
+        transientRetryDelay: TimeInterval
+    ) async throws -> Data {
+        do {
+            let response = try sendRequest(command: command, args: args, to: paths.socketURL.path)
+            trace("sendRequest OK \(response.count) bytes, classifying")
+            return try classify(response: response)
+        } catch let error as DaemonClientError {
+            guard case .remote(_, .transientBooting, _) = error else { throw error }
+            trace("transient_booting; retrying once after \(transientRetryDelay)s")
+            try await Task.sleep(nanoseconds: UInt64(max(0, transientRetryDelay) * 1_000_000_000))
+            let response = try sendRequest(command: command, args: args, to: paths.socketURL.path)
+            trace("retry sendRequest OK \(response.count) bytes, classifying")
+            return try classify(response: response)
+        }
     }
 
     /// Probe a live daemon with `_ping`, compare its `simUseVersion`

--- a/Tests/DaemonClientInvokeErrorRoutingTests.swift
+++ b/Tests/DaemonClientInvokeErrorRoutingTests.swift
@@ -202,6 +202,91 @@ struct DaemonClientInvokeErrorRoutingTests {
         _ = try? await task.value
     }
 
+    @Test("Cancellation during the retry delay propagates without killing the daemon")
+    func cancellationDuringRetryDelayPropagates() async throws {
+        let tmp = try makeTempDirectory()
+        defer { removeTempDirectory(tmp) }
+
+        let udid = "TEST-CANCEL-\(UUID().uuidString.prefix(8))"
+        let (paths, task) = try await startTestDaemon(udid: udid, baseDirectory: tmp)
+        defer { task.cancel() }
+        let pidBefore = paths.readPidfile()
+
+        FakeCommandState.reset(
+            failures: .max,
+            message: "Simulator is unavailable as it is not booted"
+        )
+
+        try await withParser({ _ in FakeFlakyCommand() }) {
+            // Long retry delay so the cancel lands inside the retry
+            // sleep — the only suspension point on the fast path.
+            let invokeTask = Task {
+                try await DaemonClient.invoke(
+                    command: "fake-flaky",
+                    args: [],
+                    udid: udid,
+                    baseDirectory: tmp,
+                    transientRetryDelay: 30
+                )
+            }
+            try? await Task.sleep(nanoseconds: 500_000_000)
+            invokeTask.cancel()
+
+            do {
+                _ = try await invokeTask.value
+                Issue.record("invoke should have thrown CancellationError")
+            } catch is CancellationError {
+                // Expected: cancellation is the caller's signal, not a
+                // stale daemon.
+            } catch {
+                Issue.record("expected CancellationError, got \(error)")
+            }
+        }
+
+        // A cancelled call must not be misread as a stale daemon: no
+        // file cleanup, no respawn, no re-execution.
+        #expect(FileManager.default.fileExists(atPath: paths.socketURL.path))
+        #expect(paths.readPidfile() == pidBefore)
+        #expect(FakeCommandState.executeCount == 1)
+
+        await DaemonClient.stopDaemon(paths: paths, timeout: 2.0)
+        _ = try? await task.value
+    }
+
+    @Test("Non-finite retry delay is tolerated instead of trapping")
+    func nonFiniteRetryDelayIsTolerated() async throws {
+        let tmp = try makeTempDirectory()
+        defer { removeTempDirectory(tmp) }
+
+        let udid = "TEST-INF-\(UUID().uuidString.prefix(8))"
+        let (paths, task) = try await startTestDaemon(udid: udid, baseDirectory: tmp)
+        defer { task.cancel() }
+
+        FakeCommandState.reset(
+            failures: 1,
+            message: "Simulator is unavailable as it is not booted"
+        )
+
+        // `transientRetryDelay` is public API: a non-finite value must
+        // not trap in the nanosecond conversion. Semantics: skip the
+        // pause and retry immediately.
+        try await withParser({ _ in FakeFlakyCommand() }) {
+            let responseData = try await DaemonClient.invoke(
+                command: "fake-flaky",
+                args: [],
+                udid: udid,
+                baseDirectory: tmp,
+                transientRetryDelay: .infinity
+            )
+            let envelope = try JSONDecoder().decode(SuccessEnvelope.self, from: responseData)
+            #expect(envelope.ok == true)
+        }
+        #expect(FakeCommandState.executeCount == 2)
+
+        await DaemonClient.stopDaemon(paths: paths, timeout: 2.0)
+        _ = try? await task.value
+    }
+
     @Test("transient_booting persisting past one retry propagates without further attempts")
     func transientBootingRetryIsBounded() async throws {
         let tmp = try makeTempDirectory()

--- a/Tests/DaemonClientInvokeErrorRoutingTests.swift
+++ b/Tests/DaemonClientInvokeErrorRoutingTests.swift
@@ -217,7 +217,10 @@ struct DaemonClientInvokeErrorRoutingTests {
             message: "Simulator is unavailable as it is not booted"
         )
 
-        try await withParser({ _ in FakeFlakyCommand() }) {
+        // No `try`: this closure handles every error itself (invoke runs
+        // in an unstructured Task whose result is consumed by do/catch),
+        // so `withParser`'s rethrows resolves to non-throwing here.
+        await withParser({ _ in FakeFlakyCommand() }) {
             // Long retry delay so the cancel lands inside the retry
             // sleep — the only suspension point on the fast path.
             let invokeTask = Task {

--- a/Tests/DaemonClientInvokeErrorRoutingTests.swift
+++ b/Tests/DaemonClientInvokeErrorRoutingTests.swift
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: Apache-2.0
+@testable import SimUse
+@testable import iOSSimBackend
+@testable import SimUseCore
+import ArgumentParser
+import Darwin
+import Foundation
+import Testing
+
+// Coverage for `DaemonClient.invoke`'s error routing on the fast path
+// (a daemon is already live):
+//
+//   1. A `remote` error (the daemon answered `ok=false`) is the
+//      command's outcome. It must surface verbatim — the client must
+//      NOT treat it as a stale daemon, must NOT remove the live
+//      daemon's socket/pidfile, and must NOT respawn + re-execute the
+//      command (double side effects, orphaned daemon).
+//   2. `transient_booting` is the one documented exception: the client
+//      retries the request once against the same daemon (post-`simctl
+//      boot` accessibility-readiness gap), then gives up.
+//
+// Regression context: the fast-path catch used to swallow every
+// classify error, delete the live daemon's files, spawn a fresh
+// daemon, and re-send the request — observed live as a doubled tap
+// search, a ~1.8s failure round trip, and an orphaned daemon process.
+
+// MARK: - Fixtures
+
+private func makeTempDirectory() throws -> URL {
+    let suffix = String(UUID().uuidString.prefix(6))
+    let dir = URL(fileURLWithPath: "/tmp/sim-use-er-\(suffix)", isDirectory: true)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir
+}
+
+private func removeTempDirectory(_ url: URL) {
+    try? FileManager.default.removeItem(at: url)
+}
+
+/// Shared mutable state driving the fake commands below. MainActor so
+/// the daemon dispatch (MainActor) and the test body touch it safely.
+@MainActor
+private enum FakeCommandState {
+    static var executeCount = 0
+    static var failuresRemaining = 0
+    static var failureMessage = ""
+
+    static func reset(failures: Int, message: String) {
+        executeCount = 0
+        failuresRemaining = failures
+        failureMessage = message
+    }
+}
+
+/// Minimal daemon-dispatchable command: fails `failuresRemaining`
+/// times with `failureMessage`, then succeeds.
+private struct FakeFlakyCommand: SimUseExecutableCommand {
+    struct Payload: Codable { var value: String }
+    typealias ExecutionResult = Payload
+
+    static let configuration = CommandConfiguration(commandName: "fake-flaky")
+
+    var jsonOutput: Bool { false }
+
+    func execute() async throws -> Payload {
+        let failure: String? = await MainActor.run {
+            FakeCommandState.executeCount += 1
+            guard FakeCommandState.failuresRemaining > 0 else { return nil }
+            FakeCommandState.failuresRemaining -= 1
+            return FakeCommandState.failureMessage
+        }
+        if let failure {
+            throw CLIError(errorDescription: failure)
+        }
+        return Payload(value: "ok")
+    }
+
+    func format(_ result: Payload) -> CommandOutput { .line(result.value) }
+}
+
+// MARK: - Suite
+
+// Serialised for the same reason as `DaemonClientEnsureCompatibleDaemonTests`:
+// concurrent DaemonServers in one process step on each other's signal
+// handling, and the suite mutates the process-global
+// `DaemonDispatch.commandParser`.
+@Suite("DaemonClient.invoke error routing", .serialized)
+@MainActor
+struct DaemonClientInvokeErrorRoutingTests {
+
+    private func startTestDaemon(
+        udid: String,
+        baseDirectory: URL
+    ) async throws -> (DaemonPaths, Task<Void, Error>) {
+        let paths = DaemonPaths(udid: udid, baseDirectory: baseDirectory)
+        try paths.ensureBaseDirectory()
+        let server = DaemonServer(udid: udid, idleTimeout: 30, paths: paths)
+        let task = Task { try await server.run() }
+        for _ in 0..<50 {
+            if FileManager.default.fileExists(atPath: paths.socketURL.path),
+               paths.readPidfile() != nil {
+                return (paths, task)
+            }
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
+        task.cancel()
+        throw TestError.daemonNeverReady
+    }
+
+    enum TestError: Error { case daemonNeverReady }
+
+    private func withParser(
+        _ parser: ((@MainActor ([String]) throws -> ParsableCommand))?,
+        body: () async throws -> Void
+    ) async rethrows {
+        let saved = DaemonDispatch.commandParser
+        DaemonDispatch.commandParser = parser
+        defer { DaemonDispatch.commandParser = saved }
+        try await body()
+    }
+
+    private struct SuccessEnvelope: Decodable {
+        let ok: Bool
+        let data: FakeFlakyCommand.Payload
+    }
+
+    @Test("Remote error surfaces verbatim without killing or respawning the live daemon")
+    func remoteErrorDoesNotRespawn() async throws {
+        let tmp = try makeTempDirectory()
+        defer { removeTempDirectory(tmp) }
+
+        let udid = "TEST-REMOTE-\(UUID().uuidString.prefix(8))"
+        let (paths, task) = try await startTestDaemon(udid: udid, baseDirectory: tmp)
+        defer { task.cancel() }
+        let pidBefore = paths.readPidfile()
+
+        FakeCommandState.reset(failures: .max, message: "fixture: element not found")
+
+        try await withParser({ _ in FakeFlakyCommand() }) {
+            do {
+                _ = try await DaemonClient.invoke(
+                    command: "fake-flaky",
+                    args: [],
+                    udid: udid,
+                    baseDirectory: tmp
+                )
+                Issue.record("invoke should have thrown the remote error")
+            } catch let error as DaemonClientError {
+                guard case .remote(let message, let kind, _) = error else {
+                    Issue.record("expected .remote, got \(error)")
+                    return
+                }
+                #expect(message.contains("fixture: element not found"))
+                #expect(kind == .other)
+            }
+        }
+
+        // The daemon answered; it is healthy. Its files must survive
+        // and the command must have executed exactly once.
+        #expect(FileManager.default.fileExists(atPath: paths.socketURL.path))
+        #expect(paths.readPidfile() == pidBefore)
+        #expect(FakeCommandState.executeCount == 1)
+
+        await DaemonClient.stopDaemon(paths: paths, timeout: 2.0)
+        _ = try? await task.value
+    }
+
+    @Test("transient_booting is retried once against the same daemon, then succeeds")
+    func transientBootingRetriesOnce() async throws {
+        let tmp = try makeTempDirectory()
+        defer { removeTempDirectory(tmp) }
+
+        let udid = "TEST-TRANSIENT-\(UUID().uuidString.prefix(8))"
+        let (paths, task) = try await startTestDaemon(udid: udid, baseDirectory: tmp)
+        defer { task.cancel() }
+        let pidBefore = paths.readPidfile()
+
+        // Message shape matches DaemonErrorKind.classify's
+        // transient_booting detection.
+        FakeCommandState.reset(
+            failures: 1,
+            message: "Simulator is unavailable as it is not booted"
+        )
+
+        try await withParser({ _ in FakeFlakyCommand() }) {
+            let responseData = try await DaemonClient.invoke(
+                command: "fake-flaky",
+                args: [],
+                udid: udid,
+                baseDirectory: tmp,
+                transientRetryDelay: 0.05
+            )
+            let envelope = try JSONDecoder().decode(SuccessEnvelope.self, from: responseData)
+            #expect(envelope.ok == true)
+            #expect(envelope.data.value == "ok")
+        }
+
+        #expect(FakeCommandState.executeCount == 2)
+        #expect(paths.readPidfile() == pidBefore)
+
+        await DaemonClient.stopDaemon(paths: paths, timeout: 2.0)
+        _ = try? await task.value
+    }
+
+    @Test("transient_booting persisting past one retry propagates without further attempts")
+    func transientBootingRetryIsBounded() async throws {
+        let tmp = try makeTempDirectory()
+        defer { removeTempDirectory(tmp) }
+
+        let udid = "TEST-TRANSIENT2-\(UUID().uuidString.prefix(8))"
+        let (paths, task) = try await startTestDaemon(udid: udid, baseDirectory: tmp)
+        defer { task.cancel() }
+
+        FakeCommandState.reset(
+            failures: .max,
+            message: "Simulator is unavailable as it is not booted"
+        )
+
+        try await withParser({ _ in FakeFlakyCommand() }) {
+            do {
+                _ = try await DaemonClient.invoke(
+                    command: "fake-flaky",
+                    args: [],
+                    udid: udid,
+                    baseDirectory: tmp,
+                    transientRetryDelay: 0.05
+                )
+                Issue.record("invoke should have thrown after the bounded retry")
+            } catch let error as DaemonClientError {
+                guard case .remote(_, let kind, _) = error else {
+                    Issue.record("expected .remote, got \(error)")
+                    return
+                }
+                #expect(kind == .transientBooting)
+            }
+        }
+
+        // Exactly one retry: original attempt + one re-send.
+        #expect(FakeCommandState.executeCount == 2)
+        // The daemon stays up — booting is the simulator's problem,
+        // not the daemon's.
+        #expect(FileManager.default.fileExists(atPath: paths.socketURL.path))
+
+        await DaemonClient.stopDaemon(paths: paths, timeout: 2.0)
+        _ = try? await task.value
+    }
+}


### PR DESCRIPTION
## Summary

The daemon client's fast path treated **every** `classify` failure as a stale-daemon transport failure — including `ok=false` envelopes a perfectly healthy daemon answered with. For any failing command (element not found, bad selector, …) the client would:

1. delete the live daemon's socket + pidfile,
2. spawn a fresh daemon,
3. **re-send the request, executing the command a second time**.

Consequences: side-effecting commands (`type`, `tap --wait-timeout`) could double their effects, a healthy daemon was orphaned until its 600 s idle timeout (still holding FBSimulatorControl/HID connections), and every failed command paid a full respawn before the error reached the user.

## Fix

- `DaemonClientError.remote` is now rethrown on the fast path: the daemon answered, so its response **is** the command's outcome. Only transport-level failures (connect/write/read, empty/malformed response) still trigger stale-file cleanup + respawn.
- The retry-once behaviour for `transient_booting` that `DaemonClient`'s header has always documented is now actually implemented: one bounded re-send against the **same** daemon after a short delay (post-`simctl boot` accessibility-readiness gap). A second `transient_booting` propagates.

New test seams on `invoke`: `baseDirectory` (isolated daemon tree) and `transientRetryDelay`, both defaulted so production call sites are unchanged.

## Tests

`Tests/DaemonClientInvokeErrorRoutingTests.swift` (TDD, red → green), driving a real in-process `DaemonServer` with an injected command parser:

- remote error surfaces verbatim; socket/pidfile survive; command executed exactly once
- `transient_booting` retried once against the same daemon, then succeeds
- persistent `transient_booting` propagates after exactly one retry

Full suite: 558 tests / 108 suites pass.

## Verification (live simulator)

A failing `tap --label` now completes in **0.77 s (was 1.8 s)**, executes once, and leaves the daemon pid unchanged — previously the trace showed `Removing stale files` → `spawning fresh daemon` → duplicated execution, and the orphaned daemon stayed alive.

> Note: four concurrent fix PRs each carry their own `CHANGELOG.md` [Unreleased] entries; trivial adjacent-line conflicts on merge are expected — union the bullets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
