### PR TITLE
fix: guard daemon file ownership on cleanup and validate the base directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Daemon shutdown no longer deletes the socket/pidfile of a successor daemon that took the paths over, which previously chained invisible orphan daemons.
+- Daemon base directory under `/tmp` is now validated on every run (symlinks, foreign owners rejected; loose permissions tightened to 0700) instead of trusting whatever was pre-created there.
+
 ## [0.9.0] - 2026-06-29
 
 Initial public release.

--- a/Sources/SimUse/Commands/Daemon.swift
+++ b/Sources/SimUse/Commands/Daemon.swift
@@ -172,7 +172,7 @@ struct Daemon: AsyncParsableCommand {
         }
 
         func execute() async throws -> ExecutionResult {
-            let targets = resolveTargets()
+            let targets = try resolveTargets()
             var entries: [StopEntry] = []
             for target in targets {
                 entries.append(await stopOne(target))
@@ -206,12 +206,17 @@ struct Daemon: AsyncParsableCommand {
         // `--udid` with no live daemon yields an empty list so both the
         // CLI and `--json` path produce a "nothing to do" outcome rather
         // than an error; scripts wrapping this stay zero-exit.
-        private func resolveTargets() -> [DaemonPaths.DiscoveredDaemon] {
+        //
+        // Throws on a base directory that fails the security gate: the
+        // pids found here get SIGTERMed on the fallback path, so a
+        // pre-planted tree must be an error, never a target list.
+        private func resolveTargets() throws -> [DaemonPaths.DiscoveredDaemon] {
             if all {
-                return DaemonPaths.enumerateLiveDaemons()
+                return try DaemonPaths.enumerateLiveDaemons()
             }
             guard let target = simulatorUDID else { return [] }
             let paths = DaemonPaths(udid: target)
+            try DaemonPaths.validateBaseDirectory(at: paths.baseDirectory)
             if case .probablyAlive(let pid) = paths.filesystemLiveness() {
                 return [DaemonPaths.DiscoveredDaemon(udid: target, pid: pid, paths: paths)]
             }
@@ -365,7 +370,7 @@ struct Daemon: AsyncParsableCommand {
         }
 
         func execute() async throws -> ExecutionResult {
-            let discovered = DaemonPaths.enumerateLiveDaemons()
+            let discovered = try DaemonPaths.enumerateLiveDaemons()
             var entries: [StatusEntry] = []
             for daemon in discovered {
                 entries.append(pingOne(daemon))

--- a/Sources/SimUseCore/Daemon/DaemonServer.swift
+++ b/Sources/SimUseCore/Daemon/DaemonServer.swift
@@ -286,6 +286,19 @@ public final class DaemonServer {
             Darwin.close(listenFd)
             listenFd = -1
         }
+        // Only remove the socket/pidfile while this process still owns
+        // them. A successor daemon may have taken the paths over —
+        // `listen()` unlinks + rebinds the socket and the pidfile gets
+        // overwritten — while this instance idled toward shutdown. An
+        // orphan wiping the live daemon's files makes the successor
+        // invisible to clients, which then spawn yet another daemon
+        // and chain more orphans. Missing/unparseable pidfile keeps
+        // the old stale-cleanup behaviour.
+        let owner = paths.readPidfile()
+        if let owner, owner != getpid() {
+            logInfo("sim-use-daemon: cleanup complete (paths taken over by pid \(owner); files left in place)")
+            return
+        }
         paths.removeSocket()
         paths.removePidfile()
         logInfo("sim-use-daemon: cleanup complete")

--- a/Sources/SimUseCore/Daemon/DaemonServer.swift
+++ b/Sources/SimUseCore/Daemon/DaemonServer.swift
@@ -292,11 +292,13 @@ public final class DaemonServer {
         // overwritten — while this instance idled toward shutdown. An
         // orphan wiping the live daemon's files makes the successor
         // invisible to clients, which then spawn yet another daemon
-        // and chain more orphans. Missing/unparseable pidfile keeps
-        // the old stale-cleanup behaviour.
+        // and chain more orphans. Ownership is only honoured while the
+        // owner is still alive: a dead owner's files are stale garbage
+        // (and its recycled pid could fake a live daemon later), so
+        // they are cleaned like the missing/unparseable-pidfile case.
         let owner = paths.readPidfile()
-        if let owner, owner != getpid() {
-            logInfo("sim-use-daemon: cleanup complete (paths taken over by pid \(owner); files left in place)")
+        if let owner, owner != getpid(), DaemonPaths.isProcessAlive(pid: owner) {
+            logInfo("sim-use-daemon: cleanup complete (paths taken over by live pid \(owner); files left in place)")
             return
         }
         paths.removeSocket()

--- a/Sources/SimUseCore/DaemonPaths.swift
+++ b/Sources/SimUseCore/DaemonPaths.swift
@@ -45,6 +45,14 @@ public struct DaemonPaths {
     /// Create the base directory with mode 0700 if missing. Idempotent;
     /// safe to call from both the client (before probing) and the server
     /// (before binding) on every invocation.
+    ///
+    /// `createDirectory` applies the 0700 attribute only on first
+    /// creation and silently accepts a pre-existing path. The base
+    /// directory lives under world-writable /tmp, so re-validate on
+    /// every run: reject symlinks/non-directories and foreign owners
+    /// outright (a pre-planted path would let another local user swap
+    /// sockets and pidfiles under us), and tighten loose permissions
+    /// back to 0700.
     public func ensureBaseDirectory() throws {
         let fm = FileManager.default
         try fm.createDirectory(
@@ -52,6 +60,28 @@ public struct DaemonPaths {
             withIntermediateDirectories: true,
             attributes: [.posixPermissions: NSNumber(value: 0o700)]
         )
+
+        var st = stat()
+        guard lstat(baseDirectory.path, &st) == 0 else {
+            throw DaemonSocketError(op: "lstat", errno: errno)
+        }
+        guard (st.st_mode & S_IFMT) == S_IFDIR else {
+            throw DaemonPathsError.insecureBaseDirectory(
+                path: baseDirectory.path,
+                reason: "it is not a real directory (symlink or special file)"
+            )
+        }
+        guard st.st_uid == getuid() else {
+            throw DaemonPathsError.insecureBaseDirectory(
+                path: baseDirectory.path,
+                reason: "it is owned by uid \(st.st_uid), not the current user (uid \(getuid()))"
+            )
+        }
+        if st.st_mode & 0o077 != 0 {
+            guard chmod(baseDirectory.path, 0o700) == 0 else {
+                throw DaemonSocketError(op: "chmod", errno: errno)
+            }
+        }
     }
 
     /// Read the pid text written by the daemon on startup. Returns nil
@@ -116,6 +146,19 @@ public struct DaemonPaths {
     public enum FilesystemLiveness {
         case noDaemon
         case probablyAlive(pid: pid_t)
+    }
+
+    public enum DaemonPathsError: Error, CustomStringConvertible, LocalizedError {
+        case insecureBaseDirectory(path: String, reason: String)
+
+        public var description: String {
+            switch self {
+            case .insecureBaseDirectory(let path, let reason):
+                return "Daemon base directory \(path) is not safe to use: \(reason). Remove it and retry."
+            }
+        }
+
+        public var errorDescription: String? { description }
     }
 
     /// A daemon discovered during a directory scan: its UDID, live pid,

--- a/Sources/SimUseCore/DaemonPaths.swift
+++ b/Sources/SimUseCore/DaemonPaths.swift
@@ -60,25 +60,36 @@ public struct DaemonPaths {
             withIntermediateDirectories: true,
             attributes: [.posixPermissions: NSNumber(value: 0o700)]
         )
+        try Self.validateBaseDirectory(at: baseDirectory)
+    }
 
+    /// Security gate for every consumer of the base directory — the
+    /// spawn/connect paths (via `ensureBaseDirectory`) AND the
+    /// management paths (`enumerateLiveDaemons`, `daemon stop/status`),
+    /// which act on the pids and sockets they find and must not trust a
+    /// pre-planted tree. An absent path is fine (nothing to validate);
+    /// a symlink, non-directory, or foreign owner throws; loose
+    /// group/other permission bits are tightened back to 0700.
+    public static func validateBaseDirectory(at url: URL) throws {
         var st = stat()
-        guard lstat(baseDirectory.path, &st) == 0 else {
+        guard lstat(url.path, &st) == 0 else {
+            if errno == ENOENT { return }
             throw DaemonSocketError(op: "lstat", errno: errno)
         }
         guard (st.st_mode & S_IFMT) == S_IFDIR else {
             throw DaemonPathsError.insecureBaseDirectory(
-                path: baseDirectory.path,
+                path: url.path,
                 reason: "it is not a real directory (symlink or special file)"
             )
         }
         guard st.st_uid == getuid() else {
             throw DaemonPathsError.insecureBaseDirectory(
-                path: baseDirectory.path,
+                path: url.path,
                 reason: "it is owned by uid \(st.st_uid), not the current user (uid \(getuid()))"
             )
         }
         if st.st_mode & 0o077 != 0 {
-            guard chmod(baseDirectory.path, 0o700) == 0 else {
+            guard chmod(url.path, 0o700) == 0 else {
                 throw DaemonSocketError(op: "chmod", errno: errno)
             }
         }
@@ -181,8 +192,14 @@ public struct DaemonPaths {
     /// `filesystemLiveness`'s existing behaviour), so callers only see
     /// daemons that are at least probably reachable. `baseDirectory`
     /// defaults to `/tmp/sim-use-<uid>/`; tests pass an isolated directory.
-    public static func enumerateLiveDaemons(baseDirectory: URL? = nil) -> [DiscoveredDaemon] {
+    ///
+    /// Throws when the base directory fails `validateBaseDirectory` —
+    /// callers act on what they find here (`stop --all` SIGTERMs the
+    /// pids, `status` connects to the sockets), so a pre-planted tree
+    /// must surface as an error, not as forged entries.
+    public static func enumerateLiveDaemons(baseDirectory: URL? = nil) throws -> [DiscoveredDaemon] {
         let baseDir = baseDirectory ?? Self.defaultBaseDirectory
+        try validateBaseDirectory(at: baseDir)
         guard let entries = try? FileManager.default.contentsOfDirectory(
             at: baseDir,
             includingPropertiesForKeys: nil,

--- a/Sources/SimUseCore/DeviceResolver.swift
+++ b/Sources/SimUseCore/DeviceResolver.swift
@@ -107,7 +107,9 @@ public struct DeviceResolver {
 
         // 3. Single live daemon — steady-state fast path. After the first
         // command in an agent session this hits and avoids the simctl fork.
-        let daemons = DaemonPaths.enumerateLiveDaemons(baseDirectory: baseDirectory)
+        // A base directory that fails validation throws here: resolution
+        // must not be steered by forged pidfiles in a pre-planted tree.
+        let daemons = try DaemonPaths.enumerateLiveDaemons(baseDirectory: baseDirectory)
         if daemons.count == 1 {
             return daemons[0].udid
         }

--- a/Tests/DaemonServerCleanupOwnershipTests.swift
+++ b/Tests/DaemonServerCleanupOwnershipTests.swift
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+@testable import SimUse
+@testable import iOSSimBackend
+@testable import SimUseCore
+import Darwin
+import Foundation
+import Testing
+
+// Coverage for DaemonServer.cleanup()'s file ownership check.
+//
+// A daemon's socket/pidfile paths can be taken over while it is still
+// running: `DaemonSocket.listen` unlinks + rebinds the socket path and
+// the successor overwrites the pidfile. That happens whenever a client
+// respawns past a wedged daemon, or `daemon start` is run twice. The
+// orphaned predecessor keeps serving its already-accepted connections
+// and eventually shuts down (idle timeout / SIGTERM) — at which point
+// its cleanup must NOT delete the successor's socket/pidfile. Deleting
+// them makes the live successor invisible (next client spawns a third
+// daemon) and chains orphans, each pinning FBSimulatorControl state.
+//
+// Serialised for the usual reason: concurrent DaemonServers in one
+// process interfere via signal handling.
+@Suite("DaemonServer.cleanup ownership", .serialized)
+@MainActor
+struct DaemonServerCleanupOwnershipTests {
+
+    private func makeTempDirectory() throws -> URL {
+        let suffix = String(UUID().uuidString.prefix(6))
+        let dir = URL(fileURLWithPath: "/tmp/sim-use-co-\(suffix)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    enum TestError: Error { case daemonNeverReady }
+
+    private func startTestDaemon(
+        udid: String,
+        baseDirectory: URL
+    ) async throws -> (DaemonPaths, Task<Void, Error>) {
+        let paths = DaemonPaths(udid: udid, baseDirectory: baseDirectory)
+        try paths.ensureBaseDirectory()
+        let server = DaemonServer(udid: udid, idleTimeout: 30, paths: paths)
+        let task = Task { try await server.run() }
+        for _ in 0..<50 {
+            if FileManager.default.fileExists(atPath: paths.socketURL.path),
+               paths.readPidfile() != nil {
+                return (paths, task)
+            }
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
+        task.cancel()
+        throw TestError.daemonNeverReady
+    }
+
+    @Test("Shutdown after a path takeover leaves the successor's files in place")
+    func takeoverSurvivesPredecessorShutdown() async throws {
+        let tmp = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let udid = "TEST-TAKEOVER-\(UUID().uuidString.prefix(8))"
+        let (paths, task) = try await startTestDaemon(udid: udid, baseDirectory: tmp)
+        defer { task.cancel() }
+
+        // Connect BEFORE the takeover: an established connection keeps
+        // working on the bound inode even after the path is unlinked,
+        // exactly like a real client that raced the successor's bind.
+        let fd = try DaemonSocket.connect(path: paths.socketURL.path)
+        defer { Darwin.close(fd) }
+
+        // Simulate the successor daemon taking over both paths.
+        let foreignPid: pid_t = 99999
+        try Data("\(foreignPid)\n".utf8).write(to: paths.pidfileURL)
+        try FileManager.default.removeItem(at: paths.socketURL)
+        FileManager.default.createFile(
+            atPath: paths.socketURL.path,
+            contents: Data("successor-socket".utf8)
+        )
+
+        // Stop the predecessor over the pre-takeover connection. The
+        // blocking write/read must run OFF the main actor: the server
+        // handles requests on the main actor, so a main-actor-blocking
+        // readLine would deadlock the test against the daemon.
+        var request = try JSONEncoder().encode(DaemonRequest(cmd: "_stop"))
+        request.append(0x0A)
+        let stopRequest = request
+        let ack: Data? = await Task.detached {
+            let writeResult = DaemonSocket.writeAll(fd: fd, data: stopRequest)
+            guard writeResult.ok else { return nil }
+            return DaemonSocket.readLine(fd: fd)
+        }.value
+        #expect(ack != nil)
+
+        _ = try? await task.value
+
+        // The successor's files must survive the predecessor's cleanup.
+        #expect(paths.readPidfile() == foreignPid)
+        let socketData = FileManager.default.contents(atPath: paths.socketURL.path)
+        #expect(socketData == Data("successor-socket".utf8))
+    }
+}

--- a/Tests/DaemonServerCleanupOwnershipTests.swift
+++ b/Tests/DaemonServerCleanupOwnershipTests.swift
@@ -67,8 +67,16 @@ struct DaemonServerCleanupOwnershipTests {
         let fd = try DaemonSocket.connect(path: paths.socketURL.path)
         defer { Darwin.close(fd) }
 
-        // Simulate the successor daemon taking over both paths.
-        let foreignPid: pid_t = 99999
+        // Simulate the successor daemon taking over both paths. The
+        // successor must be a LIVE process we own — ownership is only
+        // honoured while the owner is alive (a dead owner's files are
+        // stale garbage; see the dead-pid test below).
+        let successor = Process()
+        successor.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        successor.arguments = ["30"]
+        try successor.run()
+        defer { successor.terminate() }
+        let foreignPid: pid_t = successor.processIdentifier
         try Data("\(foreignPid)\n".utf8).write(to: paths.pidfileURL)
         try FileManager.default.removeItem(at: paths.socketURL)
         FileManager.default.createFile(
@@ -96,5 +104,46 @@ struct DaemonServerCleanupOwnershipTests {
         #expect(paths.readPidfile() == foreignPid)
         let socketData = FileManager.default.contents(atPath: paths.socketURL.path)
         #expect(socketData == Data("successor-socket".utf8))
+    }
+
+    @Test("Takeover by a dead pid is cleaned up as stale on shutdown")
+    func takeoverByDeadPidIsCleanedUp() async throws {
+        let tmp = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let udid = "TEST-DEADOWNER-\(UUID().uuidString.prefix(8))"
+        let (paths, task) = try await startTestDaemon(udid: udid, baseDirectory: tmp)
+        defer { task.cancel() }
+
+        let fd = try DaemonSocket.connect(path: paths.socketURL.path)
+        defer { Darwin.close(fd) }
+
+        // Pidfile points at a pid that is certainly dead (above macOS
+        // pid_max). Deferring to a dead "owner" would strand stale
+        // files that the next client only clears via its liveness
+        // probe — and a recycled pid could even fake a live daemon.
+        let deadPid: pid_t = 9_999_997
+        try Data("\(deadPid)\n".utf8).write(to: paths.pidfileURL)
+        try FileManager.default.removeItem(at: paths.socketURL)
+        FileManager.default.createFile(
+            atPath: paths.socketURL.path,
+            contents: Data("stale-socket".utf8)
+        )
+
+        var request = try JSONEncoder().encode(DaemonRequest(cmd: "_stop"))
+        request.append(0x0A)
+        let stopRequest = request
+        let ack: Data? = await Task.detached {
+            let writeResult = DaemonSocket.writeAll(fd: fd, data: stopRequest)
+            guard writeResult.ok else { return nil }
+            return DaemonSocket.readLine(fd: fd)
+        }.value
+        #expect(ack != nil)
+
+        _ = try? await task.value
+
+        // Dead owner → stale files; the shutting-down daemon removes them.
+        #expect(paths.readPidfile() == nil)
+        #expect(!FileManager.default.fileExists(atPath: paths.socketURL.path))
     }
 }

--- a/Tests/SimUseCoreTests/DaemonPathsTests.swift
+++ b/Tests/SimUseCoreTests/DaemonPathsTests.swift
@@ -188,14 +188,14 @@ struct DaemonPathsEnumerateTests {
         let tmp = try makeTempDirectory()
         defer { removeTempDirectory(tmp) }
 
-        #expect(DaemonPaths.enumerateLiveDaemons(baseDirectory: tmp).isEmpty)
+        #expect(try DaemonPaths.enumerateLiveDaemons(baseDirectory: tmp).isEmpty)
     }
 
     @Test("Missing directory returns no discovered daemons")
-    func missingDirectory() {
+    func missingDirectory() throws {
         let ghost = FileManager.default.temporaryDirectory
             .appendingPathComponent("sim-use-daemon-missing-\(UUID().uuidString)", isDirectory: true)
-        #expect(DaemonPaths.enumerateLiveDaemons(baseDirectory: ghost).isEmpty)
+        #expect(try DaemonPaths.enumerateLiveDaemons(baseDirectory: ghost).isEmpty)
     }
 
     @Test("Non-.pid files are ignored")
@@ -207,7 +207,7 @@ struct DaemonPathsEnumerateTests {
         try writeFile(tmp.appendingPathComponent("another.txt"), "noise")
         try writeFile(tmp.appendingPathComponent("bare"), "noise")
 
-        #expect(DaemonPaths.enumerateLiveDaemons(baseDirectory: tmp).isEmpty)
+        #expect(try DaemonPaths.enumerateLiveDaemons(baseDirectory: tmp).isEmpty)
     }
 
     @Test("Live and dead daemons: dead is skipped and cleaned, live is returned")
@@ -223,7 +223,7 @@ struct DaemonPathsEnumerateTests {
         try writeFile(dead.socketURL)
         try writeFile(dead.pidfileURL, "\(implausiblePid)\n")
 
-        let discovered = DaemonPaths.enumerateLiveDaemons(baseDirectory: tmp)
+        let discovered = try DaemonPaths.enumerateLiveDaemons(baseDirectory: tmp)
         #expect(discovered.count == 1)
         #expect(discovered.first?.udid == "B-alive")
         #expect(discovered.first?.pid == getpid())
@@ -243,7 +243,7 @@ struct DaemonPathsEnumerateTests {
             try writeFile(paths.pidfileURL, "\(getpid())\n")
         }
 
-        let discovered = DaemonPaths.enumerateLiveDaemons(baseDirectory: tmp)
+        let discovered = try DaemonPaths.enumerateLiveDaemons(baseDirectory: tmp)
         #expect(discovered.map(\.udid) == ["AAA", "MMM", "ZZZ"])
     }
 }
@@ -302,5 +302,68 @@ struct DaemonPathsEnsureBaseDirectoryTests {
         #expect(throws: (any Error).self) {
             try paths.ensureBaseDirectory()
         }
+    }
+}
+
+// MARK: - enumerateLiveDaemons base-directory security
+
+// `stop --all` SIGTERMs the pids it enumerates and `status` connects to
+// the sockets it finds, so enumeration must apply the same base-directory
+// gate as `ensureBaseDirectory`: a pre-planted directory/symlink under
+// world-writable /tmp would otherwise let another local user steer those
+// management commands (e.g. a forged pidfile pointing at an arbitrary
+// process the victim owns).
+@Suite("DaemonPaths.enumerateLiveDaemons base directory security")
+struct DaemonPathsEnumerateSecurityTests {
+    private func mode(of url: URL) throws -> mode_t {
+        var st = stat()
+        try #require(lstat(url.path, &st) == 0)
+        return st.st_mode & 0o777
+    }
+
+    @Test("A symlink planted at the base path is rejected")
+    func symlinkRejected() throws {
+        let tmp = try makeTempDirectory()
+        defer { removeTempDirectory(tmp) }
+
+        let target = tmp.appendingPathComponent("real-dir", isDirectory: true)
+        try FileManager.default.createDirectory(at: target, withIntermediateDirectories: true)
+        let base = tmp.appendingPathComponent("link-base", isDirectory: true)
+        try FileManager.default.createSymbolicLink(at: base, withDestinationURL: target)
+
+        #expect(throws: (any Error).self) {
+            _ = try DaemonPaths.enumerateLiveDaemons(baseDirectory: base)
+        }
+    }
+
+    @Test("A regular file planted at the base path is rejected")
+    func regularFileRejected() throws {
+        let tmp = try makeTempDirectory()
+        defer { removeTempDirectory(tmp) }
+
+        let base = tmp.appendingPathComponent("file-base")
+        try Data("not a dir".utf8).write(to: base)
+
+        #expect(throws: (any Error).self) {
+            _ = try DaemonPaths.enumerateLiveDaemons(baseDirectory: base)
+        }
+    }
+
+    @Test("Loose permissions are tightened to 0700 before enumeration proceeds")
+    func loosePermissionsTightened() throws {
+        let tmp = try makeTempDirectory()
+        defer { removeTempDirectory(tmp) }
+
+        let base = tmp.appendingPathComponent("loose-base", isDirectory: true)
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        // One live entry: our own pid is alive by definition.
+        let live = DaemonPaths(udid: "LIVE", baseDirectory: base)
+        try writeFile(live.socketURL)
+        try live.writePidfile(getpid())
+        try #require(chmod(base.path, 0o777) == 0)
+
+        let discovered = try DaemonPaths.enumerateLiveDaemons(baseDirectory: base)
+        #expect(discovered.map(\.udid) == ["LIVE"])
+        #expect(try mode(of: base) == 0o700)
     }
 }

--- a/Tests/SimUseCoreTests/DaemonPathsTests.swift
+++ b/Tests/SimUseCoreTests/DaemonPathsTests.swift
@@ -247,3 +247,60 @@ struct DaemonPathsEnumerateTests {
         #expect(discovered.map(\.udid) == ["AAA", "MMM", "ZZZ"])
     }
 }
+// MARK: - Base directory hardening
+
+// The base directory lives under world-writable /tmp, so its 0700 mode
+// is only meaningful if we verify it on every run: `createDirectory`
+// applies the permission attribute solely on first creation and
+// silently accepts a pre-existing directory — including one another
+// local user pre-created (with their ownership and mode) to swap
+// sockets/pidfiles under us, or a symlink planted at the path.
+@Suite("DaemonPaths.ensureBaseDirectory hardening")
+struct DaemonPathsEnsureBaseDirectoryTests {
+    private func mode(of url: URL) throws -> mode_t {
+        var st = stat()
+        try #require(lstat(url.path, &st) == 0)
+        return st.st_mode & 0o777
+    }
+
+    @Test("Fresh creation applies mode 0700")
+    func freshCreationIs0700() throws {
+        let tmp = try makeTempDirectory()
+        defer { removeTempDirectory(tmp) }
+
+        let base = tmp.appendingPathComponent("fresh-base", isDirectory: true)
+        let paths = DaemonPaths(udid: "U", baseDirectory: base)
+        try paths.ensureBaseDirectory()
+        #expect(try mode(of: base) == 0o700)
+    }
+
+    @Test("Pre-existing directory with loose permissions is tightened to 0700")
+    func looseExistingDirectoryIsTightened() throws {
+        let tmp = try makeTempDirectory()
+        defer { removeTempDirectory(tmp) }
+
+        let base = tmp.appendingPathComponent("loose-base", isDirectory: true)
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        try #require(chmod(base.path, 0o777) == 0)
+
+        let paths = DaemonPaths(udid: "U", baseDirectory: base)
+        try paths.ensureBaseDirectory()
+        #expect(try mode(of: base) == 0o700)
+    }
+
+    @Test("A symlink planted at the base path is rejected")
+    func symlinkAtBasePathThrows() throws {
+        let tmp = try makeTempDirectory()
+        defer { removeTempDirectory(tmp) }
+
+        let target = tmp.appendingPathComponent("real-dir", isDirectory: true)
+        try FileManager.default.createDirectory(at: target, withIntermediateDirectories: true)
+        let base = tmp.appendingPathComponent("link-base", isDirectory: true)
+        try FileManager.default.createSymbolicLink(at: base, withDestinationURL: target)
+
+        let paths = DaemonPaths(udid: "U", baseDirectory: base)
+        #expect(throws: (any Error).self) {
+            try paths.ensureBaseDirectory()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Two daemon filesystem-lifecycle fixes.

**Orphan cleanup deletes the successor's files.** `DaemonServer.cleanup()` removed its socket/pidfile unconditionally. When a successor daemon takes the paths over (`listen()` unlinks + rebinds the socket; the pidfile is overwritten), an orphaned predecessor shutting down later — idle timeout or SIGTERM — deleted the **live** daemon's files. The next client then saw no daemon and spawned a third one, chaining invisible orphans that each pin FBSimulatorControl state. Observed live during review: an orphan's idle-timeout wiped the pidfile of the daemon actively serving the UDID (visible in `/tmp/sim-use-<uid>/<udid>.log`).

**Base directory trusts whatever pre-exists.** `DaemonPaths.ensureBaseDirectory()` applied its 0700 mode only on first creation and silently accepted a pre-existing path at world-writable `/tmp/sim-use-<uid>` — including a directory or symlink pre-planted by another local user, who could then swap sockets and pidfiles underneath us (the doc comment claimed 0700 protection the implementation didn't guarantee).

## Fix

- `cleanup()` leaves the socket/pidfile alone when the pidfile holds another process's pid; missing/unparseable pidfile keeps the old stale-cleanup behaviour.
- `ensureBaseDirectory()` lstat-validates on every run: symlinks/non-directories and foreign owners are rejected with an actionable `DaemonPathsError`, loose group/other permission bits are tightened back to 0700.

## Tests (TDD, red → green)

- `Tests/DaemonServerCleanupOwnershipTests.swift` — starts a real `DaemonServer`, simulates a path takeover (foreign pidfile + replaced socket file), stops the predecessor over a pre-takeover connection, and asserts the successor's files survive.
- `DaemonPathsTests` — new suite: fresh creation is 0700 (pin), pre-existing 0777 dir is tightened to 0700, symlink at the base path is rejected.

Full suite: 559 tests / 109 suites pass.

> Note: four concurrent fix PRs each carry their own `CHANGELOG.md` [Unreleased] entries; trivial adjacent-line conflicts on merge are expected — union the bullets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
