### PR TITLE
fix: bridge node lifecycle and swipe duration clamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bridge `/swipe` now accepts durations up to 10 s (previously silently clamped to 5 s), covering the full `--duration` range the CLI validates for long-press holds. Bridge `versionCode` bumped to 16.
+
+### Fixed
+
+- Bridge `/a11y_tree_full` no longer reads the active root's `windowId` after the node was recycled, which silently dropped popup/dialog secondary windows on Android 11–12.
+- Bridge `/keyboard/input` no longer leaks the borrowed root `AccessibilityNodeInfo` on every call.
+
 ## [0.9.0] - 2026-06-29
 
 Initial public release.

--- a/bridge/app/build.gradle.kts
+++ b/bridge/app/build.gradle.kts
@@ -11,7 +11,7 @@ android {
         applicationId = "com.linecorp.simuse.devicebridge"
         minSdk = 30
         targetSdk = 35
-        versionCode = 15
+        versionCode = 16
         versionName = "0.9.0"
 
         // protocol_version aligns with the wire spec at

--- a/bridge/app/src/main/java/com/linecorp/simuse/devicebridge/handler/GestureHandler.kt
+++ b/bridge/app/src/main/java/com/linecorp/simuse/devicebridge/handler/GestureHandler.kt
@@ -36,7 +36,7 @@ class GestureHandler {
         endY: Float,
         duration: Long,
     ): Boolean {
-        val clamped = duration.coerceIn(MIN_SWIPE_DURATION, MAX_SWIPE_DURATION)
+        val clamped = clampSwipeDuration(duration)
         val path = Path().apply {
             moveTo(startX, startY)
             lineTo(endX, endY)
@@ -104,7 +104,16 @@ class GestureHandler {
     companion object {
         private const val TAG = "SimuseGesture"
         private const val TAP_DURATION = 50L
-        private const val MIN_SWIPE_DURATION = 10L
-        private const val MAX_SWIPE_DURATION = 5_000L
+        // The sim-use client validates `--duration` up to 10 s and
+        // delivers long-press holds as /swipe with start == end, so the
+        // ceiling must cover the full client range — a silently
+        // shortened hold breaks e.g. 10 s long-press flows. The bound
+        // exists only against runaway requests; GestureDescription
+        // itself accepts far longer strokes.
+        internal const val MIN_SWIPE_DURATION = 10L
+        internal const val MAX_SWIPE_DURATION = 10_000L
+
+        internal fun clampSwipeDuration(duration: Long): Long =
+            duration.coerceIn(MIN_SWIPE_DURATION, MAX_SWIPE_DURATION)
     }
 }

--- a/bridge/app/src/main/java/com/linecorp/simuse/devicebridge/server/ActionRouter.kt
+++ b/bridge/app/src/main/java/com/linecorp/simuse/devicebridge/server/ActionRouter.kt
@@ -124,6 +124,12 @@ class ActionRouter(
     private fun handleTree(params: Map<String, String>): HttpResponse {
         val service = requireService() ?: return serviceUnavailable()
         val activeRoot = getRootWithTimeout(service) ?: return rootWindowTimeout()
+        // buildTree recycles activeRoot in its finally — read everything
+        // we still need from the node BEFORE handing it over. On API
+        // 30-32 recycle() clears the fields, so a post-recycle windowId
+        // read comes back UNDEFINED and every popup/dialog window would
+        // silently vanish from the merged tree.
+        val activeWindowId = activeRoot.windowId
         val filter = params["filter"]?.lowercase() == "true"
         val activeTree = treeHandler.buildTree(activeRoot, filter)
             ?: return HttpResponse(500, errorJson("tree_build_failed"))
@@ -137,7 +143,7 @@ class ActionRouter(
         // filter rationale.
         val display = computeDisplay(service)
         val displayBounds = Rect(0, 0, display.optInt("width"), display.optInt("height"))
-        val secondaries = collectSecondaryAppWindowTrees(service, activeRoot, filter)
+        val secondaries = collectSecondaryAppWindowTrees(service, activeWindowId, filter)
 
         val resultTree = if (secondaries.isEmpty()) {
             activeTree
@@ -186,12 +192,11 @@ class ActionRouter(
      */
     private fun collectSecondaryAppWindowTrees(
         service: AccessibilityService,
-        activeRoot: AccessibilityNodeInfo,
+        activeWindowId: Int,
         filter: Boolean,
     ): List<ElementNode> {
         val windows = service.windows ?: return emptyList()
         try {
-            val activeWindowId = activeRoot.windowId
             // Sort by layer ascending so the bottom-most popup (closest
             // to active) appears first in the outline. Agent-side this
             // matches the visual stacking when there's more than one
@@ -343,8 +348,16 @@ class ActionRouter(
             return badRequest("invalid_base64")
         }
         val root = getRootWithTimeout(service) ?: return rootWindowTimeout()
-        val ok = inputHandler.inputText(root, text, clear)
-        return if (ok) HttpResponse(200, successJson()) else badRequest("no_focused_input")
+        // The InputHandler only recycles the *focused* child it finds —
+        // the root we just borrowed is on us to recycle, same
+        // Binder-reference leak class handlePaste was fixed for.
+        return try {
+            val ok = inputHandler.inputText(root, text, clear)
+            if (ok) HttpResponse(200, successJson()) else badRequest("no_focused_input")
+        } finally {
+            @Suppress("DEPRECATION")
+            try { root.recycle() } catch (_: Exception) {}
+        }
     }
 
     private fun handleKey(params: Map<String, String>): HttpResponse {

--- a/bridge/app/src/test/java/com/linecorp/simuse/devicebridge/ActionRouterNodeLifecycleTest.kt
+++ b/bridge/app/src/test/java/com/linecorp/simuse/devicebridge/ActionRouterNodeLifecycleTest.kt
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.linecorp.simuse.devicebridge
+
+import android.accessibilityservice.AccessibilityService
+import android.util.Base64
+import android.view.WindowManager
+import android.view.accessibility.AccessibilityNodeInfo
+import com.linecorp.simuse.devicebridge.config.AuthManager
+import com.linecorp.simuse.devicebridge.server.ActionRouter
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * AccessibilityNodeInfo lifecycle contracts on the router paths that
+ * borrow the active-window root:
+ *
+ *  - `/a11y_tree_full` must read everything it needs from the root
+ *    (notably `windowId` for the secondary-window merge) BEFORE
+ *    `TreeHandler.buildTree` recycles it. On API 30-32 a recycled
+ *    node's fields are cleared, so a post-recycle `windowId` read
+ *    silently drops every popup/dialog window from the tree.
+ *  - `/keyboard/input` owns the root it borrows and must recycle it
+ *    exactly like `/paste` does; `InputHandler` only recycles the
+ *    focused child it finds.
+ *
+ * The recycled-root mock throws on post-recycle field access, which is
+ * stricter than API 30-32 (cleared fields) — either behaviour is a bug
+ * we want to fail loudly here.
+ */
+class ActionRouterNodeLifecycleTest {
+
+    private val token = "test-token-1234"
+    private lateinit var authManager: AuthManager
+    private lateinit var service: AccessibilityService
+
+    @Before
+    fun setUp() {
+        authManager = mockk()
+        every { authManager.getOrCreateToken() } returns token
+        service = mockk(relaxed = true)
+        every { service.windows } returns emptyList()
+        // Relaxed getSystemService returns a plain Object; computeDisplay
+        // casts it to WindowManager, so stub a typed mock explicitly.
+        every { service.getSystemService(any()) } returns mockk<WindowManager>(relaxed = true)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(Base64::class)
+    }
+
+    private fun authed(): Map<String, String> = mapOf("authorization" to "Bearer $token")
+
+    private fun makeLifecycleTrackedRoot(windowId: Int): Pair<AccessibilityNodeInfo, () -> Boolean> {
+        var recycled = false
+        val root = mockk<AccessibilityNodeInfo>(relaxed = true)
+        every { root.recycle() } answers { recycled = true }
+        every { root.childCount } returns 0
+        every { root.windowId } answers {
+            check(!recycled) { "windowId read after recycle()" }
+            windowId
+        }
+        return root to { recycled }
+    }
+
+    @Test
+    fun treeHandlerReadsWindowIdBeforeRootIsRecycled() {
+        val (root, _) = makeLifecycleTrackedRoot(windowId = 42)
+        every { service.rootInActiveWindow } returns root
+        val router = ActionRouter(serviceProvider = { service }, authManager = authManager)
+
+        val resp = router.route("GET", "/a11y_tree_full", emptyMap(), authed())
+
+        assertEquals(
+            "windowId must be captured before buildTree recycles the root; body=${resp.body}",
+            200,
+            resp.statusCode,
+        )
+        assertEquals("success", JSONObject(resp.body).getString("status"))
+    }
+
+    @Test
+    fun inputHandlerRouteRecyclesBorrowedRoot() {
+        // android.util.Base64 is an SDK stub on the JVM (returns null),
+        // so bridge it to java.util.Base64 for a real decode.
+        mockkStatic(Base64::class)
+        every { Base64.decode(any<String>(), any()) } answers {
+            java.util.Base64.getDecoder().decode(firstArg<String>())
+        }
+
+        val (root, wasRecycled) = makeLifecycleTrackedRoot(windowId = 42)
+        every { service.rootInActiveWindow } returns root
+        val router = ActionRouter(serviceProvider = { service }, authManager = authManager)
+
+        val b64 = java.util.Base64.getEncoder().encodeToString("hello".toByteArray())
+        router.route("POST", "/keyboard/input", mapOf("base64_text" to b64), authed())
+
+        verify(exactly = 1) { root.recycle() }
+        assertEquals(true, wasRecycled())
+    }
+}

--- a/bridge/app/src/test/java/com/linecorp/simuse/devicebridge/GestureHandlerClampTest.kt
+++ b/bridge/app/src/test/java/com/linecorp/simuse/devicebridge/GestureHandlerClampTest.kt
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.linecorp.simuse.devicebridge
+
+import com.linecorp.simuse.devicebridge.handler.GestureHandler
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * `/swipe` duration clamp contract. The Swift client validates
+ * `--duration` up to 10 s (long-press taps and holds are delivered as
+ * `/swipe` with start == end), so the bridge must accept the full
+ * client range instead of silently shortening a 10 s hold to 5 s.
+ * Android's GestureDescription supports strokes well beyond 10 s, so
+ * the ceiling exists only to bound runaway requests.
+ */
+class GestureHandlerClampTest {
+
+    @Test
+    fun clampKeepsClientRangeIntact() {
+        // Client contract allows up to 10s — must pass through unchanged.
+        assertEquals(7_000L, GestureHandler.clampSwipeDuration(7_000L))
+        assertEquals(10_000L, GestureHandler.clampSwipeDuration(10_000L))
+    }
+
+    @Test
+    fun clampBoundsRunawayValues() {
+        assertEquals(10_000L, GestureHandler.clampSwipeDuration(60_000L))
+        assertEquals(10L, GestureHandler.clampSwipeDuration(0L))
+        assertEquals(10L, GestureHandler.clampSwipeDuration(-5L))
+    }
+}


### PR DESCRIPTION
## Summary

Three device-bridge fixes. `versionCode` 15 → 16 (`versionName` stays 0.9.0 — the release flow aligns it with the CLI version at tag time). The bundled APK is rebuilt locally by `scripts/build-bridge.sh` as usual (not checked in).

**`/a11y_tree_full` use-after-recycle drops popup windows (API 30–32).** `handleTree` read `activeRoot.windowId` *after* `TreeHandler.buildTree` had recycled the root in its `finally`. On API 30–32 `recycle()` clears the node's fields, so the id read back UNDEFINED, `isDescendantOf` never matched, and every same-task popup/dialog/dropdown window silently vanished from the merged tree — exactly the windows the multi-window merge (protocol v2) exists to expose. The window id is now captured before the tree walk, and `collectSecondaryAppWindowTrees` takes the id instead of the node.

**`/keyboard/input` leaks the borrowed root.** `handleInput` never recycled the root from `getRootWithTimeout` (`InputHandler` only recycles the focused child it finds) — one `AccessibilityNodeInfo` Binder reference into system_server leaked per call on API 30–32. Same leak class `handlePaste` already guards with try/finally; `handleInput` now mirrors it.

**`/swipe` silently clamps 10 s holds to 5 s.** The CLI validates `--duration` up to 10 s and delivers long-press holds as `/swipe` with start == end, but `GestureHandler` clamped durations to 5 s. The clamp now covers the full client range (10 ms – 10 s, extracted into a unit-testable `clampSwipeDuration`); it exists only to bound runaway requests — `GestureDescription` itself accepts far longer strokes.

## Tests (TDD, red → green)

- `ActionRouterNodeLifecycleTest.kt` — stateful mockk root that throws on post-recycle `windowId` access: tree route must return 200 (previously 500 `internal_error: windowId read after recycle()`); input route must `recycle()` the borrowed root exactly once (previously never).
- `GestureHandlerClampTest.kt` — client range passes through unchanged; runaway values bounded.

Bridge JVM suite: 46 tests / 7 classes pass (`:app:testDebugUnitTest`).

> Note: four concurrent fix PRs each carry their own `CHANGELOG.md` [Unreleased] entries; trivial adjacent-line conflicts on merge are expected — union the bullets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
