### PR TITLE
fix: drop keyboard-state's vestigial run() override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bridge `/a11y_tree_full` no longer reads the active root's `windowId` after the node was recycled, which silently dropped popup/dialog secondary windows on Android 11–12.
 - Bridge `/keyboard/input` no longer leaks the borrowed root `AccessibilityNodeInfo` on every call.
 - `record-video` no longer hot-spins without frame pacing when screenshot frames persistently fail to decode.
+- `keyboard-state` now routes through the per-UDID daemon like every other verb (amortised init) and surfaces crash advisories and error `Hint:` lines; a vestigial `run()` override had silently opted it out. The `soft`/`hidden`/failure exit codes are unchanged.
 
 ## [0.9.0] - 2026-06-29
 

--- a/Sources/SimUse/Commands/KeyboardState.swift
+++ b/Sources/SimUse/Commands/KeyboardState.swift
@@ -11,10 +11,10 @@ import iOSSimBackend
 /// Simulator UDIDs, `AndroidKeyboardStateCommand.performKeyboardState`
 /// for adb serials).
 ///
-/// Overrides `run()` so the JSON envelope shape (`{ok, data}` /
-/// `{ok, error}`) and the soft-vs-hidden exit-code semantics stay
-/// stable across the migration — both `soft` and `hidden` exit 0;
-/// non-zero is reserved for genuine probe failure.
+/// Uses the protocol-default `run()`: the soft-vs-hidden exit-code
+/// semantics (both exit 0; non-zero reserved for genuine probe failure)
+/// come from `execute()` returning a result rather than throwing, so no
+/// custom `run()` is needed. See the note above `format(_:)`.
 struct KeyboardState: SimUseExecutableCommand {
     typealias ExecutionResult = IOSSimKeyboardStateCommand.ExecutionResult
 
@@ -90,37 +90,18 @@ struct KeyboardState: SimUseExecutableCommand {
         .line(result.visible ? "soft" : "hidden")
     }
 
-    // `hidden` is a valid probe result, not a failure: until 0.5.x this
-    // path threw `ExitCode(1)` on hidden so shell pipelines could branch
-    // with `if sim-use keyboard-state --udid X; then ...`. That shape
-    // conflated "keyboard is hidden" (an expected steady state on
-    // Android, and on iOS whenever no field is focused) with genuine
-    // failure (device unreachable, AX fetch error), making non-zero
-    // unusable as a real error signal — every wrapper script had to
-    // distinguish the two by parsing stderr. Both `soft` and `hidden`
-    // now exit 0; callers branch on stdout (`[[ $(sim-use keyboard-state
-    // --udid X) == soft ]]`) or on `data.visible` in the JSON envelope.
+    // No custom `run()`: the exit-code contract this command needs —
+    // both `soft` and `hidden` exit 0, non-zero reserved for genuine
+    // failure (device unreachable, AX fetch error) — falls out of the
+    // protocol default. `execute()` returns a result for both keyboard
+    // states rather than throwing, so the default `run()` renders it and
+    // exits 0; only a thrown error exits non-zero. Callers branch on
+    // stdout (`[[ $(sim-use keyboard-state --udid X) == soft ]]`) or on
+    // `data.visible` in the JSON envelope.
     //
-    // The override still skips the protocol-default `run()` (which is
-    // what wires `resolveDeferredArguments()` for every other command),
-    // so we call the resolver explicitly. Without this the
-    // `simulatorUDID` stays empty and every dispatch fails with
-    // `"Simulator with UDID  not found in set."`.
-    mutating func run() async throws {
-        if jsonOutput {
-            do {
-                try resolveDeferredArguments()
-                let result = try await execute()
-                try JSONEnvelopeWriter.writeSuccess(result)
-            } catch {
-                JSONEnvelopeWriter.writeError(error)
-                throw ExitCode(1)
-            }
-            return
-        }
-
-        try resolveDeferredArguments()
-        let result = try await execute()
-        format(result).emit()
-    }
+    // A pre-0.5.x override threw `ExitCode(1)` on `hidden`; when that was
+    // dropped the override lingered and quietly opted the verb out of
+    // daemon routing, the crash-advisory banner, and `Hint:` formatting.
+    // Using the default `run()` restores all three and keeps the exit
+    // codes identical.
 }

--- a/Tests/KeyboardStateTests.swift
+++ b/Tests/KeyboardStateTests.swift
@@ -119,6 +119,18 @@ struct KeyboardStateDaemonRoutingTests {
             allowFailure: true
         )
 
+        // Assert the precondition explicitly. Without it a stale or
+        // pre-existing daemon for this UDID (stop failed, or the box
+        // already had one) would make the post-call `status` contain the
+        // UDID even under the inline-execution regression — a false pass.
+        // The post-call check is only meaningful if we start from empty.
+        let preStatus = try await CommandRunner.run(
+            "\"\(simUsePath)\" daemon status --json",
+            allowFailure: true
+        )
+        #expect(!preStatus.output.contains(udid),
+                "precondition: no daemon for \(udid) should exist before the call (stop may have failed); status: \(preStatus.output)")
+
         // On a freshly booted simulator the frontmost app is SpringBoard,
         // which has no software keyboard: expect a clean `hidden`, exit 0.
         let result = try await CommandRunner.run("\"\(simUsePath)\" keyboard-state --udid \(udid)")

--- a/Tests/KeyboardStateTests.swift
+++ b/Tests/KeyboardStateTests.swift
@@ -6,13 +6,13 @@ import Foundation
 import Testing
 @testable import SimUseCore
 
-// Regression coverage for LINEIOS-216939: KeyboardState overrides `run()`
-// (so the text path can return exit 1 when the keyboard is hidden), but
-// the override has to call `resolveDeferredArguments()` itself — the
-// protocol-default `run()` is what wires that for every other command.
-// Without the explicit call, `udid.resolved` stays "" and every dispatch
-// fails with `"Simulator with UDID  not found in set."` (note the double
-// space — the empty UDID).
+// Regression coverage for LINEIOS-216939: `resolveDeferredArguments()`
+// must copy the explicit `--device`/`--udid` into `device.resolved`
+// before dispatch. The protocol-default `run()` wires that for every
+// command (KeyboardState no longer overrides it). If resolution is
+// skipped, `device.resolved` stays "" and every dispatch fails with
+// `"Simulator with UDID  not found in set."` (note the double space —
+// the empty UDID).
 
 @Suite("KeyboardState — resolveDeferredArguments wiring")
 struct KeyboardStateResolveTests {
@@ -48,19 +48,14 @@ struct KeyboardStateResolveTests {
     }
 }
 
-// End-to-end coverage that catches the actual run()-bypasses-resolve
-// regression. Doesn't require a booted simulator — the test just asserts
-// that the explicit UDID echoes back inside the "not found in set"
-// error. Pre-fix the message contained an empty UDID (`UDID  not
-// found`); post-fix it contains BOGUS-UDID-* (or whatever was passed).
-//
-// Only the text path can carry the UDID assertion: the `--json` error
-// envelope currently goes through `error.localizedDescription`, which
-// for our `CLIError` reports the NSError-bridged generic message
-// instead of the typed `errorDescription` payload. That's a separate
-// concern; this suite stays narrow to the resolveDeferredArguments
-// regression.
-@Suite("KeyboardState — run() wires resolveDeferredArguments end-to-end", .serialized, .enabled(if: isE2EEnabled))
+// End-to-end coverage that the resolved UDID reaches dispatch: the
+// explicit value must echo back inside the failure surface. Pre-fix (a
+// custom `run()` that skipped resolution) the message carried an empty
+// UDID (`UDID  not found`); with the protocol-default `run()` it carries
+// the value that was passed. Runs against a host with no matching
+// simulator, so the call fails — the assertion is on which UDID the
+// failure names, not on success.
+@Suite("KeyboardState — resolved UDID reaches dispatch end-to-end", .serialized, .enabled(if: isE2EEnabled))
 struct KeyboardStateRunRegressionTests {
     @Test("text path: explicit --udid reaches FBSimulatorSet (no empty-UDID surface)")
     func textPathRoutesUDID() async throws {
@@ -99,5 +94,45 @@ struct KeyboardStateRunRegressionTests {
                 "expected structured JSON envelope; got: \(result.output)")
         #expect(!result.output.contains("ArgumentParser.ValidationError"),
                 "regression: ArgumentParser usage error leaked into --json envelope. Output: \(result.output)")
+    }
+}
+
+// keyboard-state is a read-only AX probe with the same daemon-eligibility
+// surface as describe-ui (non-nil `simulatorUDIDForDaemon`, no
+// `daemonBypass`), so it must amortise init through the per-UDID daemon
+// like every other verb. A vestigial `run()` override used to bypass the
+// protocol default and run inline, silently opting the verb out of daemon
+// routing (and the crash-advisory banner + hint formatting). This suite
+// pins the restored routing: after a successful keyboard-state call a
+// daemon exists for the target UDID. Requires a booted simulator
+// (`SIMULATOR_UDID`).
+@Suite("KeyboardState — routes through the per-UDID daemon", .serialized, .enabled(if: isE2EEnabled))
+struct KeyboardStateDaemonRoutingTests {
+    @Test("a successful keyboard-state call spawns/uses the per-UDID daemon")
+    func routesThroughDaemon() async throws {
+        let udid = try #require(defaultSimulatorUDID, "SIMULATOR_UDID must be set for this e2e test")
+        let simUsePath = try TestHelpers.getSimUsePath()
+
+        // Clean slate: no daemon for this UDID before the call.
+        _ = try await CommandRunner.run(
+            "\"\(simUsePath)\" daemon stop --udid \(udid)",
+            allowFailure: true
+        )
+
+        // On a freshly booted simulator the frontmost app is SpringBoard,
+        // which has no software keyboard: expect a clean `hidden`, exit 0.
+        let result = try await CommandRunner.run("\"\(simUsePath)\" keyboard-state --udid \(udid)")
+        #expect(result.exitCode == 0)
+        #expect(result.output.contains("hidden") || result.output.contains("soft"))
+
+        // Daemon routing restored → the call spawned a daemon that is now
+        // discoverable. Inline execution (the old override) would leave
+        // `daemon status` empty for this UDID.
+        let status = try await CommandRunner.run(
+            "\"\(simUsePath)\" daemon status --json",
+            allowFailure: true
+        )
+        #expect(status.output.contains(udid),
+                "keyboard-state should have routed through a daemon for \(udid); status: \(status.output)")
     }
 }


### PR DESCRIPTION
## Summary (D1 from the post-review discussion)

`KeyboardState` carried a hand-rolled `run()` override from a **pre-0.5.x** design where `hidden` exited 1. That contract was later changed — both `soft` and `hidden` now exit 0, which falls out of `execute()` returning a result (`visible: true/false`) instead of throwing — but the override was left behind. Its own comment had gone self-contradictory ("overrides run() … Both `soft` and `hidden` now exit 0"), and the test file still documented the removed exit-1 behaviour.

With its original purpose gone, the override only diverged from the protocol default in ways nobody intended:

- **No daemon routing** — every `keyboard-state` call paid full framework + `FBSimulatorControl` init instead of amortising through the per-UDID daemon the way `describe-ui` does. The two entry points to the same verb even disagreed: `sim-use ios keyboard-state` (no override) routed through the daemon; top-level `sim-use keyboard-state` did not.
- **No crash-advisory banner** — the process-liveness banner other verbs print was silently suppressed.
- **No `Hint:` line** — hint-bearing errors lost their actionable suggestion on the text path.

None of these was a feature. Removing the override adopts the default `run()` and restores all three, while keeping the exit-code contract byte-for-byte: `execute()` returns a result for both keyboard states (exit 0) and only throws on genuine failure (exit 1).

## Tests

TDD, red → green. New e2e suite `KeyboardState — routes through the per-UDID daemon` pins the restored routing (after a successful call, `daemon status` lists a daemon for the UDID). It **fails** with the override in place (`daemons:[]`, inline execution) and **passes** after removal. The existing resolve-wiring and UDID-echo suites still pass under the default `run()`; their stale "overrides run()" comments are corrected.

- `make test` (unit): 570 tests / 112 suites pass.
- E2E with a booted simulator (`SIM_USE_E2E=1 SIMULATOR_UDID=…`): all four KeyboardState suites pass.
- Live spot-checks: `hidden` → exit 0, `--json` → exit 0, bogus UDID → exit 1 with a `Hint:` line now present, `daemon status` shows the spawned daemon after a call (empty before).

> Branches off current `main`; no CHANGELOG conflict expected with anything outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
