### PR TITLE
fix: surface ambiguous daemon outcomes instead of resending the command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bridge `/a11y_tree_full` no longer reads the active root's `windowId` after the node was recycled, which silently dropped popup/dialog secondary windows on Android 11–12.
 - Bridge `/keyboard/input` no longer leaks the borrowed root `AccessibilityNodeInfo` on every call.
 - `record-video` no longer hot-spins without frame pacing when screenshot frames persistently fail to decode.
+- Daemon client no longer respawns and resends a command when the daemon drops the connection *after* receiving the request (a possible mid-execution crash). Such ambiguous outcomes now surface a dedicated error with a hint to re-observe the screen before retrying, so a side-effecting verb (tap/type/swipe) is never silently applied twice. Pre-delivery failures (connect/write) still respawn as before.
 
 ## [0.9.0] - 2026-06-29
 

--- a/Sources/SimUseCore/Daemon/DaemonClient.swift
+++ b/Sources/SimUseCore/Daemon/DaemonClient.swift
@@ -63,27 +63,24 @@ public enum DaemonClient {
                     transientRetryDelay: transientRetryDelay
                 )
             } catch {
-                // Cooperative cancellation is the caller's signal, not
-                // a stale daemon — the retry delay below is a
-                // suspension point, so it can surface here. Rethrow
-                // before any cleanup/respawn.
-                if error is CancellationError {
-                    throw error
+                switch classifyFastPathFailure(error) {
+                case .surface(let surfaced):
+                    // Cancellation, a `remote` ok=false answer, or a
+                    // post-write ambiguity — surface as-is. Crucially we
+                    // do NOT respawn+resend on ambiguity: the daemon may
+                    // have executed the command before dropping the
+                    // response, so a blind resend could run a
+                    // side-effecting verb twice. Leave the files for the
+                    // next call's liveness probe to reconcile.
+                    throw surfaced
+                case .respawn:
+                    // The command provably never reached the daemon
+                    // (connect/write failed) — this is the stale-daemon
+                    // case. Clean up and fall through to respawn+resend.
+                    trace("fast-path pre-delivery failure: \(error). Removing stale files.")
+                    paths.removeSocket()
+                    paths.removePidfile()
                 }
-                // A `remote` error means the daemon is alive and
-                // answered `ok=false` — that IS the command's outcome.
-                // Tearing the daemon down here would orphan a healthy
-                // server and re-executing the request would double any
-                // side effects it already performed. Only transport-
-                // level failures (connect/write/read, empty or garbage
-                // response) indicate a stale daemon worth respawning.
-                if let clientError = error as? DaemonClientError,
-                   case .remote = clientError {
-                    throw clientError
-                }
-                trace("fast-path transport failure: \(error). Removing stale files.")
-                paths.removeSocket()
-                paths.removePidfile()
             }
         }
 
@@ -93,12 +90,91 @@ public enum DaemonClient {
         try await waitForSocket(paths: paths, timeout: 5.0)
         trace("socket ready after spawn")
 
-        return try await sendClassifiedRequest(
-            command: command,
-            args: args,
-            paths: paths,
-            transientRetryDelay: transientRetryDelay
-        )
+        do {
+            return try await sendClassifiedRequest(
+                command: command,
+                args: args,
+                paths: paths,
+                transientRetryDelay: transientRetryDelay
+            )
+        } catch {
+            // The fresh daemon can also drop the connection after
+            // receiving the request. Re-tag that post-write ambiguity so
+            // the agent hears "unknown outcome" rather than a bare
+            // transport error; there is no second respawn to attempt.
+            throw surfacedError(error)
+        }
+    }
+
+    /// What the fast-path catch should do with a `sendClassifiedRequest`
+    /// failure.
+    enum FastPathFailureDecision {
+        /// Surface this error to the caller unchanged — no respawn.
+        case surface(Error)
+        /// The request provably never reached the daemon; clean up the
+        /// stale files and respawn a fresh one.
+        case respawn
+    }
+
+    /// Decide the fast-path response to a failure. Extracted for unit
+    /// testing — the daemon-vs-inline resend policy is the load-bearing
+    /// at-most-once guarantee and must not silently regress.
+    static func classifyFastPathFailure(_ error: Error) -> FastPathFailureDecision {
+        // Cancellation and `remote` answers are always surfaced as-is.
+        if error is CancellationError {
+            return .surface(error)
+        }
+        if let clientError = error as? DaemonClientError, case .remote = clientError {
+            return .surface(clientError)
+        }
+        // Post-write ambiguity: the bytes reached the daemon, so the
+        // command may have executed. Surface a typed ambiguity error
+        // instead of respawning.
+        if requestReachedDaemon(error) {
+            return .surface(DaemonClientError.ambiguousExecution(underlying: error))
+        }
+        // Everything else is a pre-delivery transport failure (connect or
+        // write) — the command never ran, so respawning is safe.
+        return .respawn
+    }
+
+    /// Map a spawn-path failure for surfacing: same rules as the fast
+    /// path minus the respawn option (there is no second daemon to spawn).
+    static func surfacedError(_ error: Error) -> Error {
+        switch classifyFastPathFailure(error) {
+        case .surface(let surfaced):
+            return surfaced
+        case .respawn:
+            // A connect/write failure against the daemon we just spawned
+            // is a genuine transport problem, not an ambiguity — surface
+            // it verbatim.
+            return error
+        }
+    }
+
+    /// True when the failure happened AFTER the request bytes were handed
+    /// to the daemon — i.e. the command may already have executed.
+    /// `connect` failures (`DaemonSocketError`) and `write` failures mean
+    /// the request never landed, so the command provably did not run.
+    /// Empty / malformed / post-write read failures are ambiguous.
+    static func requestReachedDaemon(_ error: Error) -> Bool {
+        switch error {
+        case is DaemonSocketError:
+            return false
+        case let clientError as DaemonClientError:
+            switch clientError {
+            case .transportFailure(let op, _, _):
+                // `write` fails before delivery; `read`/`read-wait` fail
+                // after the request is already on the wire.
+                return op != "write"
+            case .emptyResponse, .malformedResponse:
+                return true
+            default:
+                return false
+            }
+        default:
+            return false
+        }
     }
 
     /// Send + classify one business request, retrying exactly once when
@@ -390,6 +466,11 @@ public enum DaemonClientError: Error, CustomStringConvertible, HintProviding {
     case emptyResponse
     case malformedResponse(underlying: Error)
     case remote(message: String, kind: DaemonErrorKind, hint: String?)
+    /// The request was delivered to the daemon, but no valid response
+    /// came back (the connection dropped or the reply was unparseable).
+    /// The command may or may not have executed, so the client did not
+    /// resend it — the caller decides.
+    case ambiguousExecution(underlying: Error)
 
     public var description: String {
         switch self {
@@ -407,6 +488,10 @@ public enum DaemonClientError: Error, CustomStringConvertible, HintProviding {
             return "Daemon response could not be parsed: \(err.localizedDescription)"
         case .remote(let message, _, _):
             return message
+        case .ambiguousExecution(let err):
+            return "The command reached the sim-use daemon but no valid response came back "
+                + "(\(err.localizedDescription)). It may or may not have executed; "
+                + "sim-use did not resend it to avoid running a side-effecting command twice."
         }
     }
 
@@ -416,8 +501,16 @@ public enum DaemonClientError: Error, CustomStringConvertible, HintProviding {
     }
 
     public var hint: String? {
-        if case .remote(_, _, let hint) = self { return hint }
-        return nil
+        switch self {
+        case .remote(_, _, let hint):
+            return hint
+        case .ambiguousExecution:
+            return "Re-observe the screen with `sim-use ui` to check whether the command took "
+                + "effect, then retry only if it did not. sim-use avoids automatic retries here "
+                + "so a tap/type/swipe is never applied twice."
+        default:
+            return nil
+        }
     }
 }
 

--- a/Tests/DaemonClientAmbiguousExecutionTests.swift
+++ b/Tests/DaemonClientAmbiguousExecutionTests.swift
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+@testable import SimUseCore
+import Darwin
+import Foundation
+import Testing
+
+// D2: a daemon request that fails AFTER the bytes are on the wire (the
+// daemon received it, possibly executed a side-effecting verb, then
+// dropped the connection) must NOT be blindly respawned + resent — that
+// would risk running tap/type/swipe twice. sim-use's callers are agents,
+// so the right move is to surface a typed "ambiguous outcome" error with
+// a hint and let the agent re-observe and decide. Pre-delivery failures
+// (connect/write) still respawn, since the command provably never ran.
+
+// MARK: - Pure classifier
+
+@Suite("DaemonClient fast-path failure classification")
+struct DaemonClientFastPathClassificationTests {
+
+    @Test("connect failure (DaemonSocketError) is pre-delivery → respawn")
+    func connectFailureRespawns() {
+        let err = DaemonSocketError(op: "connect", errno: ECONNREFUSED)
+        #expect(DaemonClient.requestReachedDaemon(err) == false)
+        guard case .respawn = DaemonClient.classifyFastPathFailure(err) else {
+            Issue.record("expected .respawn")
+            return
+        }
+    }
+
+    @Test("write failure is pre-delivery → respawn")
+    func writeFailureRespawns() {
+        let err = DaemonClientError.transportFailure(op: "write", errno: EPIPE, message: "broken pipe")
+        #expect(DaemonClient.requestReachedDaemon(err) == false)
+        guard case .respawn = DaemonClient.classifyFastPathFailure(err) else {
+            Issue.record("expected .respawn")
+            return
+        }
+    }
+
+    @Test("empty response is post-delivery → surface ambiguousExecution")
+    func emptyResponseIsAmbiguous() {
+        #expect(DaemonClient.requestReachedDaemon(DaemonClientError.emptyResponse) == true)
+        guard case .surface(let surfaced) = DaemonClient.classifyFastPathFailure(DaemonClientError.emptyResponse),
+              let clientError = surfaced as? DaemonClientError,
+              case .ambiguousExecution = clientError else {
+            Issue.record("expected .surface(ambiguousExecution)")
+            return
+        }
+        #expect(clientError.hint != nil)
+    }
+
+    @Test("malformed response is post-delivery → surface ambiguousExecution")
+    func malformedResponseIsAmbiguous() {
+        let err = DaemonClientError.malformedResponse(underlying: CocoaSentinel.boom)
+        #expect(DaemonClient.requestReachedDaemon(err) == true)
+        guard case .surface(let surfaced) = DaemonClient.classifyFastPathFailure(err),
+              let clientError = surfaced as? DaemonClientError,
+              case .ambiguousExecution = clientError else {
+            Issue.record("expected .surface(ambiguousExecution)")
+            return
+        }
+    }
+
+    @Test("read-wait timeout is post-delivery → ambiguous")
+    func readWaitTimeoutIsAmbiguous() {
+        let err = DaemonClientError.transportFailure(op: "read-wait", errno: ETIMEDOUT, message: "timed out")
+        #expect(DaemonClient.requestReachedDaemon(err) == true)
+    }
+
+    @Test("remote ok=false is surfaced verbatim, never ambiguous")
+    func remoteSurfacedVerbatim() {
+        let err = DaemonClientError.remote(message: "element not found", kind: .other, hint: "try --id")
+        guard case .surface(let surfaced) = DaemonClient.classifyFastPathFailure(err),
+              let clientError = surfaced as? DaemonClientError,
+              case .remote = clientError else {
+            Issue.record("expected .surface(remote)")
+            return
+        }
+        #expect(clientError.hint == "try --id")
+    }
+
+    @Test("cancellation is surfaced verbatim")
+    func cancellationSurfaced() {
+        guard case .surface(let surfaced) = DaemonClient.classifyFastPathFailure(CancellationError()) else {
+            Issue.record("expected .surface")
+            return
+        }
+        #expect(surfaced is CancellationError)
+    }
+
+    private enum CocoaSentinel: Error { case boom }
+}
+
+// MARK: - Integration: a daemon that drops after receiving the request
+
+@Suite("DaemonClient.invoke — ambiguous outcome without resend", .serialized)
+struct DaemonClientAmbiguousIntegrationTests {
+
+    private func makeTempDirectory() throws -> URL {
+        let suffix = String(UUID().uuidString.prefix(6))
+        let dir = URL(fileURLWithPath: "/tmp/sim-use-amb-\(suffix)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    /// Bind the daemon's socket path and accept connections in a loop,
+    /// reading each request line then closing WITHOUT a response —
+    /// exactly what a daemon that crashed after receiving (and maybe
+    /// executing) the command looks like on the wire. Returns the
+    /// listening fd so the caller can close it to end the loop.
+    private func startDroppingServer(at path: String) -> Int32 {
+        let listenFd = try! DaemonSocket.listen(path: path)
+        // DaemonSocket.listen sets O_NONBLOCK; restore blocking accept
+        // for a simple loop.
+        let flags = fcntl(listenFd, F_GETFL, 0)
+        _ = fcntl(listenFd, F_SETFL, flags & ~O_NONBLOCK)
+        Thread.detachNewThread {
+            while true {
+                let conn = Darwin.accept(listenFd, nil, nil)
+                if conn < 0 { break }
+                _ = DaemonSocket.readLine(fd: conn)
+                Darwin.close(conn) // no response — drop the connection
+            }
+        }
+        return listenFd
+    }
+
+    @Test("a mid-flight drop surfaces ambiguousExecution and does not respawn")
+    func ambiguousDropNoResend() async throws {
+        let tmp = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let udid = "TEST-AMBIG-\(UUID().uuidString.prefix(8))"
+        let paths = DaemonPaths(udid: udid, baseDirectory: tmp)
+        try paths.ensureBaseDirectory()
+
+        // Look alive: a bound socket + a pidfile naming a live process
+        // (ourselves) makes filesystemLiveness report `probablyAlive`.
+        let listenFd = startDroppingServer(at: paths.socketURL.path)
+        defer { Darwin.close(listenFd) }
+        try paths.writePidfile(getpid())
+
+        do {
+            _ = try await DaemonClient.invoke(
+                command: "tap",
+                args: [],
+                udid: udid,
+                baseDirectory: tmp
+            )
+            Issue.record("expected invoke to throw")
+        } catch let error as DaemonClientError {
+            guard case .ambiguousExecution = error else {
+                Issue.record("expected .ambiguousExecution, got \(error)")
+                return
+            }
+            #expect(error.hint != nil)
+        }
+
+        // No respawn: the pidfile still names our process. A fallthrough
+        // to the spawn path would have removed it and started a real
+        // daemon that overwrote it with a different pid.
+        #expect(paths.readPidfile() == getpid())
+    }
+}


### PR DESCRIPTION
## Summary (D2 from the post-review discussion)

The daemon client's fast-path catch respawned + resent the request on **any** transport failure. That is correct only when the failure proves the command never ran. When the daemon receives the request, executes it (a real `tap`/`type`/`swipe`), and then crashes before replying, the client saw an empty/unparseable response, treated it as a stale daemon, respawned, and **resent — running the side-effecting verb a second time.**

sim-use's callers are agents, so per the discussion the right move is to hand the decision back to them rather than guess. This splits the fast-path failure by whether the request was delivered:

- **Pre-delivery** (`connect` / `write` failed) — the command provably never reached the daemon. Clean up the stale files and respawn + resend, exactly as before. This is the common stale-daemon case.
- **Post-delivery** (empty / malformed / post-write read failure) — the request landed and may have executed. Surface a new typed `DaemonClientError.ambiguousExecution` whose hint tells the agent to re-observe (`sim-use ui`) and retry only if the command did not take effect. **No respawn, no resend.**

The classification is a pure function so the at-most-once policy is unit-tested directly, and the spawn path applies the same mapping (a fresh daemon that drops mid-request reports the ambiguity too, instead of a bare transport error).

## Error surface (what the agent sees)

```
Error: The command reached the sim-use daemon but no valid response came back (…). It may or may
not have executed; sim-use did not resend it to avoid running a side-effecting command twice.
Hint: Re-observe the screen with `sim-use ui` to check whether the command took effect, then retry
only if it did not. sim-use avoids automatic retries here so a tap/type/swipe is never applied twice.
```

Flows through both the text (`Error:`/`Hint:`) and `--json` (`{ok:false, error, hint}`) surfaces via the existing `LocalizedError` + `HintProviding` plumbing.

## Tests (TDD)

New `Tests/DaemonClientAmbiguousExecutionTests.swift`:
- **Pure classifier** (`classifyFastPathFailure` / `requestReachedDaemon`): connect → respawn, write → respawn, empty/malformed/read-wait → ambiguous, remote ok=false → surface verbatim, cancellation → surface verbatim.
- **Integration**: a hand-rolled server binds the daemon socket, reads the request line, then closes without responding (a daemon that dropped mid-request). `invoke` throws `ambiguousExecution` with a hint and does **not** respawn (the pidfile still names the original process). Completes in ~4 ms — the pre-fix path would have removed the pidfile and paid a 5 s spawn timeout.

Full suite: 577 tests / 113 suites pass.

> Branches off current `main`; the single CHANGELOG `[Unreleased]` bullet may need a trivial union with other in-flight PRs (#11) on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
