### PR TITLE
fix: don't let the daemon idle-timeout shut down a request in flight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bridge `/a11y_tree_full` no longer reads the active root's `windowId` after the node was recycled, which silently dropped popup/dialog secondary windows on Android 11–12.
 - Bridge `/keyboard/input` no longer leaks the borrowed root `AccessibilityNodeInfo` on every call.
 - `record-video` no longer hot-spins without frame pacing when screenshot frames persistently fail to decode.
+- Daemon no longer shuts itself down in the middle of a request that runs longer than the idle timeout (e.g. `tap --wait-timeout` beyond the timeout, or a long `batch`). The idle timer now defers shutdown while a request is in flight.
 
 ## [0.9.0] - 2026-06-29
 

--- a/Sources/SimUseCore/Daemon/DaemonServer.swift
+++ b/Sources/SimUseCore/Daemon/DaemonServer.swift
@@ -256,8 +256,21 @@ public final class DaemonServer {
         timer.schedule(deadline: .now() + idleTimeout, repeating: .never)
         timer.setEventHandler { [weak self] in
             Task { @MainActor in
-                self?.logInfo("sim-use-daemon: idle timeout reached, stopping")
-                self?.triggerShutdown()
+                guard let self else { return }
+                // "Idle" means no request in flight. The timer counts from
+                // the last reset (request start / response end), so a
+                // single request that runs longer than idleTimeout — e.g.
+                // `tap --wait-timeout 700` or a long `batch` — would
+                // otherwise trip it mid-execution and tear the daemon down
+                // while the command is still running. Reschedule instead;
+                // the reset after the response goes out starts the real
+                // idle countdown.
+                guard self.activeRequests == 0 else {
+                    self.resetIdleTimer()
+                    return
+                }
+                self.logInfo("sim-use-daemon: idle timeout reached, stopping")
+                self.triggerShutdown()
             }
         }
         timer.resume()

--- a/Tests/DaemonClientInvokeErrorRoutingTests.swift
+++ b/Tests/DaemonClientInvokeErrorRoutingTests.swift
@@ -109,14 +109,14 @@ struct DaemonClientInvokeErrorRoutingTests {
 
     enum TestError: Error { case daemonNeverReady }
 
+    // Delegates to the shared gate so this suite's parser window can't
+    // overlap another suite's (they all mutate the process-global
+    // `DaemonDispatch.commandParser` across `await`s).
     private func withParser(
         _ parser: ((@MainActor ([String]) throws -> ParsableCommand))?,
         body: () async throws -> Void
-    ) async rethrows {
-        let saved = DaemonDispatch.commandParser
-        DaemonDispatch.commandParser = parser
-        defer { DaemonDispatch.commandParser = saved }
-        try await body()
+    ) async throws {
+        try await withExclusiveCommandParser(parser, body: body)
     }
 
     private struct SuccessEnvelope: Decodable {
@@ -217,10 +217,10 @@ struct DaemonClientInvokeErrorRoutingTests {
             message: "Simulator is unavailable as it is not booted"
         )
 
-        // No `try`: this closure handles every error itself (invoke runs
-        // in an unstructured Task whose result is consumed by do/catch),
-        // so `withParser`'s rethrows resolves to non-throwing here.
-        await withParser({ _ in FakeFlakyCommand() }) {
+        // The closure handles every error itself (invoke runs in an
+        // unstructured Task whose result is consumed by do/catch); the
+        // `try` is for `withParser` acquiring the shared parser gate.
+        try await withParser({ _ in FakeFlakyCommand() }) {
             // Long retry delay so the cancel lands inside the retry
             // sleep — the only suspension point on the fast path.
             let invokeTask = Task {

--- a/Tests/DaemonCommandParserInjectionTests.swift
+++ b/Tests/DaemonCommandParserInjectionTests.swift
@@ -21,16 +21,14 @@ import Testing
 @MainActor
 struct DaemonCommandParserInjectionTests {
     /// Reset / restore around each test so a global-state hop in one
-    /// test can't leak into the next. We avoid stomping a parser that
-    /// some other test may already have set: snapshot, mutate, restore.
+    /// test can't leak into the next, and — via the shared gate — that
+    /// no other suite's parser window overlaps this one (they all mutate
+    /// the process-global `DaemonDispatch.commandParser` across `await`s).
     private func withParser(
         _ parser: ((@MainActor ([String]) throws -> ParsableCommand))?,
         body: () async throws -> Void
-    ) async rethrows {
-        let saved = DaemonDispatch.commandParser
-        DaemonDispatch.commandParser = parser
-        defer { DaemonDispatch.commandParser = saved }
-        try await body()
+    ) async throws {
+        try await withExclusiveCommandParser(parser, body: body)
     }
 
     /// When `commandParser` is unset, dispatch must return a permanent

--- a/Tests/DaemonServerIdleTimerTests.swift
+++ b/Tests/DaemonServerIdleTimerTests.swift
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+@testable import SimUse
+@testable import iOSSimBackend
+@testable import SimUseCore
+import ArgumentParser
+import Darwin
+import Foundation
+import Testing
+
+// D3: the idle timer counts from the last reset (request start / response
+// end), not from actual idleness, and its fire handler never consulted
+// the `activeRequests` counter. A single daemon-routed request that runs
+// longer than idleTimeout (e.g. `tap --wait-timeout 700`, or a long
+// `batch` sent as `--step`s) therefore tripped the timer *mid-execution*:
+// `triggerShutdown` resumed the shutdown continuation during the request's
+// `await`, `cleanup()` tore down the socket/pidfile while the request was
+// still in flight, and in a real process `run()` returning exits it out
+// from under the unfinished command.
+//
+// The fix defers shutdown while a request is executing. This suite drives
+// a deliberately slow command through a real DaemonServer whose idle
+// timeout is far shorter than the command, and asserts the daemon has NOT
+// cleaned up its socket by the time the command finishes.
+
+// Shared knobs for the slow probe command below. MainActor so the daemon
+// dispatch (MainActor) and the test body touch them safely.
+@MainActor
+private enum SlowProbeState {
+    static var socketPath = ""
+    static var sleepNanos: UInt64 = 0
+
+    static func configure(socketPath: String, sleepNanos: UInt64) {
+        self.socketPath = socketPath
+        self.sleepNanos = sleepNanos
+    }
+}
+
+/// A daemon-dispatchable command that sleeps well past the server's idle
+/// timeout, then reports whether the daemon's own socket still exists.
+/// If the idle timer wrongly fired mid-request, `cleanup()` will have
+/// unlinked the socket before this returns.
+private struct SlowProbeCommand: SimUseExecutableCommand {
+    struct Payload: Codable { var socketStillPresent: Bool }
+    typealias ExecutionResult = Payload
+
+    static let configuration = CommandConfiguration(commandName: "slow-probe")
+    var jsonOutput: Bool { false }
+
+    func execute() async throws -> Payload {
+        let (nanos, path) = await MainActor.run {
+            (SlowProbeState.sleepNanos, SlowProbeState.socketPath)
+        }
+        try await Task.sleep(nanoseconds: nanos)
+        return Payload(socketStillPresent: FileManager.default.fileExists(atPath: path))
+    }
+
+    func format(_ result: Payload) -> CommandOutput {
+        .line("\(result.socketStillPresent)")
+    }
+}
+
+@Suite("DaemonServer idle timer respects in-flight requests", .serialized)
+@MainActor
+struct DaemonServerIdleTimerTests {
+
+    private func makeTempDirectory() throws -> URL {
+        let suffix = String(UUID().uuidString.prefix(6))
+        let dir = URL(fileURLWithPath: "/tmp/sim-use-idle-\(suffix)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private struct Envelope: Decodable {
+        let ok: Bool
+        let data: SlowProbeCommand.Payload
+    }
+
+    @Test("a request that outlasts the idle timeout is not shut down mid-flight")
+    func idleTimerDefersWhileRequestInFlight() async throws {
+        let tmp = try makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let udid = "TEST-IDLE-\(UUID().uuidString.prefix(8))"
+        let paths = DaemonPaths(udid: udid, baseDirectory: tmp)
+        try paths.ensureBaseDirectory()
+
+        // Command runs 0.5 s; idle timeout is 0.2 s. A buggy timer fires
+        // (twice) during the command and tears the socket down at 0.2 s.
+        SlowProbeState.configure(socketPath: paths.socketURL.path, sleepNanos: 500_000_000)
+
+        try await withExclusiveCommandParser({ _ in SlowProbeCommand() }) {
+            let server = DaemonServer(udid: udid, idleTimeout: 0.2, paths: paths)
+            let serverTask = Task { try await server.run() }
+
+            // Wait for bind + listen + pidfile.
+            var ready = false
+            for _ in 0..<50 {
+                if FileManager.default.fileExists(atPath: paths.socketURL.path),
+                   paths.readPidfile() != nil {
+                    ready = true
+                    break
+                }
+                try? await Task.sleep(nanoseconds: 20_000_000)
+            }
+            #expect(ready)
+
+            // Send one request off the main actor — the server serves on
+            // the main actor, so a main-actor-blocking readLine here would
+            // deadlock against it.
+            let fd = try DaemonSocket.connect(path: paths.socketURL.path)
+            defer { Darwin.close(fd) }
+            var request = try JSONEncoder().encode(DaemonRequest(cmd: "slow-probe"))
+            request.append(0x0A)
+            let requestData = request
+            let responseLine: Data? = await Task.detached {
+                guard DaemonSocket.writeAll(fd: fd, data: requestData).ok else { return nil }
+                return DaemonSocket.readLine(fd: fd)
+            }.value
+
+            let line = try #require(responseLine, "daemon sent no response")
+            let envelope = try JSONDecoder().decode(Envelope.self, from: line)
+            #expect(envelope.ok)
+            #expect(envelope.data.socketStillPresent,
+                    "idle timer fired mid-request: the daemon cleaned up its socket before the command finished")
+
+            // Once the request is done the daemon should idle out on its
+            // own; give it room to shut down cleanly.
+            _ = try? await serverTask.value
+        }
+    }
+}

--- a/Tests/TestUtilities.swift
+++ b/Tests/TestUtilities.swift
@@ -1,7 +1,65 @@
 // SPDX-License-Identifier: Apache-2.0
+import ArgumentParser
 import Darwin
 import Foundation
 import Testing
+@testable import SimUseCore
+
+// MARK: - Shared daemon command-parser gate
+
+/// `DaemonDispatch.commandParser` is process-global mutable state. Every
+/// suite that installs a fake parser and then `await`s (spinning up a
+/// real `DaemonServer`, driving a slow dispatch, running a full
+/// `invoke`) yields the main actor while holding it, so two such suites
+/// running concurrently clobber each other's parser — one sees the
+/// other's fake, or a `nil` from a sibling's `defer`. This actor
+/// serialises the whole set-use-restore window across suites regardless
+/// of swift-testing's parallelism. `.serialized` only orders tests
+/// within one suite, which is not enough here.
+actor CommandParserGate {
+    static let shared = CommandParserGate()
+    private var locked = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func acquire() async {
+        if !locked {
+            locked = true
+            return
+        }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func release() {
+        if waiters.isEmpty {
+            locked = false
+        } else {
+            waiters.removeFirst().resume()
+        }
+    }
+}
+
+/// Install `parser` as `DaemonDispatch.commandParser` for the duration of
+/// `body`, holding the shared gate so no other suite's parser window
+/// overlaps. Restores the previous parser and releases the gate on the
+/// way out, including when `body` throws.
+@MainActor
+func withExclusiveCommandParser(
+    _ parser: (@MainActor ([String]) throws -> ParsableCommand)?,
+    body: () async throws -> Void
+) async throws {
+    await CommandParserGate.shared.acquire()
+    let saved = DaemonDispatch.commandParser
+    DaemonDispatch.commandParser = parser
+    do {
+        try await body()
+    } catch {
+        DaemonDispatch.commandParser = saved
+        await CommandParserGate.shared.release()
+        throw error
+    }
+    DaemonDispatch.commandParser = saved
+    await CommandParserGate.shared.release()
+}
 
 // MARK: - Command Execution
 


### PR DESCRIPTION
## Summary (D3 from the post-review discussion)

The per-UDID daemon's idle timer is a one-shot timer rescheduled to `now + idleTimeout` at two points only: the **start** of `handleConnection` and **after** the response is written. The actual command executes between them (`await DaemonDispatch.handle(...)`), with no reset in between — so the timer measures *time since the last reset*, not idleness, and its fire handler never consulted the `activeRequests` counter the server already maintains.

A single daemon-routed request that runs longer than `idleTimeout` (default 600 s) therefore trips the timer **mid-execution**. Because the command runs at an `await` on the main actor, the timer's shutdown `Task` gets scheduled during that suspension → `triggerShutdown()` resumes the shutdown continuation → `cleanup()` unlinks the socket/pidfile while the request is still running → `run()` returns and, in a real process, exits it out from under the unfinished command. The client, blocked in `readLine`, then sees EOF.

**Realistic triggers** (all daemon-routed): `tap --label X --wait-timeout 700` (polls the AX tree past the 600 s idle), or a long `batch` sent as `--step`s. `record-video` / `stream-video` are `daemonBypass` and unaffected.

## Fix

The idle fire handler reschedules instead of shutting down when `activeRequests > 0`; the reset after the response goes out starts the real idle countdown. `handleChain` serialises requests, so the counter is 0/1 and precisely means "a request is executing" — exactly what the counter was there for.

## Tests (TDD, red → green)

New `DaemonServerIdleTimerTests` drives a deliberately slow command (0.5 s) through a real `DaemonServer` whose idle timeout is 0.2 s, and asserts — in-band, from inside the command — that the daemon's socket still exists when the command finishes.
- **Red** (before the fix): the timer fired at 0.2 s, `cleanup()` unlinked the socket, and the command reported `socketStillPresent: false`.
- **Green**: the socket survives; the daemon still idles out ~0.2 s *after* the request completes (the whole test finishes in ~0.7 s), proving the timer semantics are preserved for the genuinely-idle case.

**Test-infra hardening (same PR):** three suites mutate the process-global `DaemonDispatch.commandParser` and `await` while holding it, so under swift-testing's cross-suite parallelism they can clobber each other's parser. It was latent (short windows); this fix's slow-dispatch test widened the window enough to make it deterministic. A shared `CommandParserGate` actor now serialises the set-use-restore window across all three suites (`.serialized` only orders tests *within* a suite). Full suite run three times back-to-back: 570 tests / 112 suites, green each time.

> Branches off current `main`; the CHANGELOG `[Unreleased]` bullet may need a trivial union with in-flight PRs (#11, #12) on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
