### PR TITLE
Remove dead .hidSwipePerformed notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Daemon client no longer respawns and resends a command when the daemon drops the connection *after* receiving the request (a possible mid-execution crash). Such ambiguous outcomes now surface a dedicated error with a hint to re-observe the screen before retrying, so a side-effecting verb (tap/type/swipe) is never silently applied twice. Pre-delivery failures (connect/write) still respawn as before.
 - `keyboard-state` now routes through the per-UDID daemon like every other verb (amortised init) and surfaces crash advisories and error `Hint:` lines; a vestigial `run()` override had silently opted it out. The `soft`/`hidden`/failure exit codes are unchanged.
 
+### Removed
+
+- Dead `.hidSwipePerformed` notification posted by `ios swipe` — nothing ever observed it since its introduction.
+
 ## [0.9.0] - 2026-06-29
 
 Initial public release.

--- a/Sources/iOSSimBackend/Verbs/IOSSimSwipeCommand.swift
+++ b/Sources/iOSSimBackend/Verbs/IOSSimSwipeCommand.swift
@@ -135,19 +135,6 @@ public struct IOSSimSwipeCommand: SimUseExecutableCommand {
         logger.info().log("Performing swipe from (\(startX), \(startY)) to (\(endX), \(endY))")
         logger.info().log("Duration: \(swipeDuration)s, Delta: \(swipeDelta)px")
 
-        NotificationCenter.default.post(
-            name: .hidSwipePerformed,
-            object: nil,
-            userInfo: [
-                "startX": startX,
-                "startY": startY,
-                "endX": endX,
-                "endY": endY,
-                "duration": swipeDuration,
-                "delta": swipeDelta
-            ]
-        )
-
         var events: [FBSimulatorHIDEvent] = []
 
         if let preDelay, preDelay > 0 {
@@ -181,8 +168,4 @@ public struct IOSSimSwipeCommand: SimUseExecutableCommand {
         logger.info().log("Swipe gesture completed successfully")
         return ExecutionResult()
     }
-}
-
-extension Notification.Name {
-    public static let hidSwipePerformed = Notification.Name("hidSwipePerformed")
 }


### PR DESCRIPTION
## Summary

Deferred review item **D11**: `IOSSimSwipeCommand.execute()` posted a `.hidSwipePerformed` notification with full gesture metadata on every swipe, and declared the `Notification.Name` — but **no observer exists anywhere** in Sources or Tests (verified via repo-wide grep; these were the only two references). This removes both the post and the name declaration.

## Changes

- `Sources/iOSSimBackend/Verbs/IOSSimSwipeCommand.swift` — drop the `NotificationCenter.default.post` call and the `Notification.Name.hidSwipePerformed` extension.
- `CHANGELOG.md` — `[Unreleased] / Removed` bullet.

## Testing

- `make build` OK.
- `make test` — 579 tests / 115 suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
