### PR TITLE
Fix comment drift: ghost doc refs, stale minSdk, gesture endpoint

### DIFF
--- a/Sources/AndroidBackend/Adb/AuthTokenFetcher.swift
+++ b/Sources/AndroidBackend/Adb/AuthTokenFetcher.swift
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import Foundation
 
-/// Fetches the bridge's bearer token via the ContentProvider URI defined
-/// in `ai-doc/ANDROID_WIRE_SPEC.md` §Bootstrap sequence:
+/// Fetches the bridge's bearer token via the ContentProvider URI served
+/// by the bridge's `service/SimuseContentProvider.kt`, as part of the
+/// bootstrap sequence (`AndroidDeviceController.initialize`):
 ///
 /// ```
 /// adb -s <serial> shell content query \
@@ -16,7 +17,7 @@ import Foundation
 /// We extract `<uuid>` defensively — whitespace and exact line wording
 /// vary slightly across Android versions / shell variants.
 public enum AuthTokenFetcher {
-    /// Toggle URIs from the wire spec.
+    /// ContentProvider URIs exposed by `SimuseContentProvider.kt`.
     public static let authUri = "content://com.linecorp.simuse.devicebridge/auth_token"
     public static let toggleUri = "content://com.linecorp.simuse.devicebridge/toggle_socket_server"
 

--- a/Sources/AndroidBackend/Bridge/BridgeClient.swift
+++ b/Sources/AndroidBackend/Bridge/BridgeClient.swift
@@ -2,8 +2,9 @@
 import Foundation
 import SimUseCore
 
-/// HTTP client that speaks the bridge wire protocol described in
-/// `ai-doc/ANDROID_WIRE_SPEC.md`.
+/// HTTP client that speaks the bridge wire protocol served by the
+/// bridge's `server/ActionRouter.kt` ((method, path) dispatch + auth)
+/// and its `handler/` classes.
 ///
 /// Lifecycle: a client is created with a known device serial; it lazily
 /// establishes an `adb forward` and fetches the auth token on first

--- a/Sources/AndroidBackend/Bridge/BridgeEnvelope.swift
+++ b/Sources/AndroidBackend/Bridge/BridgeEnvelope.swift
@@ -2,8 +2,8 @@
 import Foundation
 import SimUseCore
 
-/// Common response envelope emitted by every bridge endpoint, per
-/// `ai-doc/ANDROID_WIRE_SPEC.md`. Inline JSON `result` (NOT csat's
+/// Common response envelope emitted by every bridge endpoint (built in
+/// the bridge's `server/ActionRouter.kt`). Inline JSON `result` (NOT csat's
 /// double-encoded string form). On success: `status="success"`, `result`
 /// is endpoint-specific. On failure: `status="error"`, `error` is a
 /// human message, `code` is a machine-readable token.

--- a/Sources/AndroidBackend/Bridge/BridgeSession.swift
+++ b/Sources/AndroidBackend/Bridge/BridgeSession.swift
@@ -94,7 +94,7 @@ public enum BridgeSessionStore {
         // (Wi-Fi adb: 192.168.1.5:5555), and underscores
         // (occasionally produced by emulator tooling).
         let allowed = CharacterSet(charactersIn:
-            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._:-_"
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._:-"
         )
         return udid.unicodeScalars.allSatisfy(allowed.contains)
     }

--- a/Sources/AndroidBackend/Bridge/ElementNode.swift
+++ b/Sources/AndroidBackend/Bridge/ElementNode.swift
@@ -4,7 +4,8 @@ import SimUseCore
 
 /// Wire schema for an accessibility node as emitted by
 /// `sim-use-device-bridge`'s `/a11y_tree_full` endpoint. Matches the full
-/// P0+P1 field set from `ai-doc/ANDROID_WIRE_SPEC.md` §Schemas. Fields
+/// P0+P1 field set of the bridge's `model/ElementNode.kt` — keep the
+/// two field sets in sync. Fields
 /// that may be absent on older Android versions are modeled as `nil`
 /// rather than forced to defaults so the normalizer can tell "absent"
 /// from "empty".

--- a/Sources/AndroidBackend/Verbs/AndroidDeviceController.swift
+++ b/Sources/AndroidBackend/Verbs/AndroidDeviceController.swift
@@ -138,7 +138,9 @@ public final class AndroidDeviceController {
         public let portForward: Int
     }
 
-    /// Runs the 6-step bootstrap from `ai-doc/ANDROID_WIRE_SPEC.md`.
+    /// Runs the 6-step bridge bootstrap: install APK → register the
+    /// a11y service → enable a11y globally → toggle the HTTP server →
+    /// fetch the auth token → port-forward + ping.
     /// Idempotent: rerunning on an initialized device is a no-op for
     /// every step except APK install (`install -r`).
     public func initialize(serial: String, options: InitOptions = InitOptions()) throws -> InitReport {

--- a/Sources/AndroidBackend/Verbs/AndroidGestureCommand.swift
+++ b/Sources/AndroidBackend/Verbs/AndroidGestureCommand.swift
@@ -4,9 +4,9 @@ import Foundation
 import SimUseCore
 
 /// `sim-use android gesture` — preset gesture pattern dispatched
-/// through the bridge's `/swipe` endpoint (which is itself backed by
-/// `AccessibilityService.dispatchGesture`, the right primitive for
-/// single-finger linear strokes).
+/// through the bridge: single-finger presets via `/swipe`, multi-touch
+/// presets (pinch / rotate) via `/gesture` multi-stroke dispatch. Both
+/// endpoints are backed by `AccessibilityService.dispatchGesture`.
 ///
 /// Mirrors the iOS `gesture` verb on the Android side; the cross-
 /// platform top-level `gesture` forwards here for Android UDIDs.

--- a/Sources/iOSSimBackend/Verbs/IOSSimDescribeUICommand.swift
+++ b/Sources/iOSSimBackend/Verbs/IOSSimDescribeUICommand.swift
@@ -87,7 +87,7 @@ public struct IOSSimDescribeUICommand: SimUseExecutableCommand {
         public let appLabel: String
         /// CFBundleIdentifier of the foreground app. iOS V1 leaves this
         /// empty when the AX tree doesn't expose it; resolution via
-        /// simctl is a separate follow-up (see plan/IMPLEMENTATION_LOG).
+        /// simctl is a separate follow-up.
         public let appPackage: String
         /// Android-only crash-dialog signal carried through the top-level
         /// `describe-ui` envelope (which shares this iOS-shaped struct).

--- a/bridge/app/build.gradle.kts
+++ b/bridge/app/build.gradle.kts
@@ -14,8 +14,9 @@ android {
         versionCode = 16
         versionName = "0.9.0"
 
-        // protocol_version aligns with the wire spec at
-        // ai-doc/ANDROID_WIRE_SPEC.md. Bumped to 2: `/a11y_tree_full`
+        // Must match `BridgeClient.expectedProtocolVersion` on the
+        // Swift side — bump both together on breaking wire changes
+        // only (see CLAUDE.md). Bumped to 2: `/a11y_tree_full`
         // may now return a synthetic root with `className =
         // "__simuse:multi_window__"` when the app has secondary
         // windows (PopupWindow / dialog / dropdown). Old clients would

--- a/bridge/app/src/main/java/com/linecorp/simuse/devicebridge/handler/CaptureHandler.kt
+++ b/bridge/app/src/main/java/com/linecorp/simuse/devicebridge/handler/CaptureHandler.kt
@@ -16,10 +16,10 @@ import java.util.concurrent.atomic.AtomicReference
  * wire envelope.
  *
  * Replicates csat's `CaptureHandler`. Pre-API-30 fallback (manual
- * `screencap` via shell) is intentionally absent — `minSdk=26` in our
- * Gradle config but `AccessibilityService.takeScreenshot` is API 30+,
- * so devices below 30 will get a `screenshot_failed` error. Decision
- * tracked in [`plan/IMPLEMENTATION_LOG.md`].
+ * `screencap` via shell) is intentionally absent — `minSdk=30` in our
+ * Gradle config already matches the API 30+ requirement of
+ * `AccessibilityService.takeScreenshot`, so no installable device
+ * needs the fallback.
  *
  * Memory profile: `hwBitmap.copy(ARGB_8888, false)` allocates
  * `width × height × 4` bytes (≈10 MB on 1080×2400, 40+ MB on tablets

--- a/bridge/app/src/main/java/com/linecorp/simuse/devicebridge/model/ElementNode.kt
+++ b/bridge/app/src/main/java/com/linecorp/simuse/devicebridge/model/ElementNode.kt
@@ -6,10 +6,11 @@ import org.json.JSONArray
 import org.json.JSONObject
 
 /**
- * Wire schema for an accessibility tree node. Conforms to
- * `ai-doc/ANDROID_WIRE_SPEC.md` §`ElementNode` — full **P0+P1** field
- * set (csat ships only 10 fields; we ship 22 so V2/V3 verbs don't have
- * to bump `protocol_version` to read additional fields).
+ * Wire schema for an accessibility tree node. Mirrors the Swift
+ * decoder `Sources/AndroidBackend/Bridge/ElementNode.swift` — keep the
+ * two field sets in sync. Full **P0+P1** field set (csat ships only 10
+ * fields; we ship 22 so V2/V3 verbs don't have to bump
+ * `protocol_version` to read additional fields).
  *
  * Fields that may be absent on older Android versions (`uniqueId` on
  * pre-API-33, `hintText` on pre-API-26, `stateDescription` on pre-API-30)


### PR DESCRIPTION
## Summary

Deferred review items **D6** (doc drift) and **D20** (cosmetic), bundled as one zero-behavior cleanup PR.

### D6 — ghost document references (9 sites)

`ai-doc/ANDROID_WIRE_SPEC.md` (7 cites) and `plan/IMPLEMENTATION_LOG.md` (2 cites) **never existed in this repo's git history** (verified with `git log --all --diff-filter=A`). Every citation is repointed at the real in-repo source of truth:

| Site | Now points at |
|---|---|
| `ElementNode.swift` / `ElementNode.kt` | each other, as the sync pair |
| `BridgeClient.swift`, `BridgeEnvelope.swift` | `server/ActionRouter.kt` (envelope + dispatch) |
| `AuthTokenFetcher.swift` | `service/SimuseContentProvider.kt` + `AndroidDeviceController.initialize` |
| `AndroidDeviceController.initialize` | names the 6 bootstrap steps inline |
| `bridge/app/build.gradle.kts` `PROTOCOL_VERSION` | Swift twin `BridgeClient.expectedProtocolVersion` (CLAUDE.md pairing rule) |
| `IOSSimDescribeUICommand` | dangling follow-up pointer dropped |

### D6 — factual drift

- `CaptureHandler.kt` claimed `minSdk=26`; actual is **30**, which is exactly why the pre-API-30 `screencap` fallback is absent. Reworded.
- `AndroidGestureCommand` header said presets dispatch through `/swipe`; multi-touch presets (pinch / rotate) actually go through `/gesture` (see `execute()`, `client.gesture(strokes:)`).

### D20 — cosmetic

- `BridgeSession.isValidUDID` allowed-charset literal contained a duplicated `_`. No behavior change (charset membership is a set).

## Notes

- Kotlin changes are comment-only — no APK content change, so no `versionCode` bump.
- No CHANGELOG entry: nothing user-visible changes.

## Testing

- `make build` OK.
- `make test` — 579 tests / 115 suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
