### PR TITLE
Document frame units in SKILL.md; correct keep-alive comment

### DIFF
--- a/Sources/AndroidBackend/Bridge/BridgeClient.swift
+++ b/Sources/AndroidBackend/Bridge/BridgeClient.swift
@@ -69,9 +69,11 @@ public final class BridgeClient: @unchecked Sendable {
         let config = URLSessionConfiguration.ephemeral
         config.timeoutIntervalForRequest = readTimeout
         config.timeoutIntervalForResource = readTimeout
-        // Reuse a single TCP connection across requests — `adb forward`
-        // is a stream-multiplexer and benefits massively from keep-alive
-        // (saves the connect handshake on every call).
+        // No connection reuse in practice: the bridge answers every
+        // request with `Connection: close` (HttpServer.kt), so each
+        // call pays a fresh loopback connect — cheap through
+        // `adb forward`. The cap only bounds concurrent sockets should
+        // the server ever gain keep-alive.
         config.httpMaximumConnectionsPerHost = 4
         self.urlSession = urlSession ?? URLSession(configuration: config)
         self.connectionTimeout = connectionTimeout

--- a/skills/sim-use/SKILL.md
+++ b/skills/sim-use/SKILL.md
@@ -31,6 +31,8 @@ sim-use ui --device <UDID>
 
 Read the outline. Each element has an `@N` alias and optionally a `#<id>` identifier. List cells carry `#N` (dominant list) or `#N@M` (scoped).
 
+Frames in the JSON output (`--json`: `entries[].frame`, `screen`) are in platform-native units — iOS **points**, Android **pixels**. Key off the envelope's `platform` field before doing math on coordinates across platforms.
+
 ### Act
 
 Pick a selector, in order of preference:


### PR DESCRIPTION
## Summary

Deferred review items **D7** and **D5**, both resolved as "document reality, no behavior change" per owner decision.

### D7 — frame units

`Outline.Frame` values are platform-native (iOS **points**, Android **pixels**). Verification showed the describe-ui JSON envelope already exposes a machine-readable `platform` field, so consumers can disambiguate without any wire change. Added one line to `skills/sim-use/SKILL.md` §Observe telling agents to key off `platform` before doing cross-platform coordinate math.

### D5 — keep-alive comment

`BridgeClient.swift` claimed the URLSession reuses a TCP connection across requests, but the bridge's `HttpServer.kt` sends `Connection: close` on every response — reuse never happens. The comment now describes reality (fresh loopback connect per call, cheap through `adb forward`; server-side keep-alive intentionally not implemented).

## Testing

- `make build` OK.
- `make test` — 579 tests / 115 suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
