### PR TITLE
Fix Viewer API false success on non-zero subprocess exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Daemon no longer shuts itself down in the middle of a request that runs longer than the idle timeout (e.g. `tap --wait-timeout` beyond the timeout, or a long `batch`). The idle timer now defers shutdown while a request is in flight.
 - Daemon client no longer respawns and resends a command when the daemon drops the connection *after* receiving the request (a possible mid-execution crash). Such ambiguous outcomes now surface a dedicated error with a hint to re-observe the screen before retrying, so a side-effecting verb (tap/type/swipe) is never silently applied twice. Pre-delivery failures (connect/write) still respawn as before.
 - `keyboard-state` now routes through the per-UDID daemon like every other verb (amortised init) and surfaces crash advisories and error `Hint:` lines; a vestigial `run()` override had silently opted it out. The `soft`/`hidden`/failure exit codes are unchanged.
+- Viewer API no longer reports success when the underlying sim-use invocation exits non-zero without a parseable JSON envelope; the subprocess's stderr is now surfaced in the error response instead of a generic JSON-parse failure.
 
 ## [0.9.0] - 2026-06-29
 

--- a/Sources/SimUse/Viewer/ViewerAPIHandlers.swift
+++ b/Sources/SimUse/Viewer/ViewerAPIHandlers.swift
@@ -29,12 +29,13 @@ struct ViewerAPIHandlers {
 
     func devices(_ request: HTTPRequest) async -> HTTPResponse {
         do {
-            let (stdout, _) = try await run(arguments: ["devices", "--json"])
-            guard let envelope = try JSONSerialization.jsonObject(with: stdout) as? [String: Any] else {
-                return .json(502, ["ok": false, "error": "sim-use devices: bad JSON"])
+            let result = try await run(arguments: ["devices", "--json"])
+            let envelope = parseEnvelope(result.stdout)
+            if let failure = failureResponse(envelope: envelope, result: result) {
+                return failure
             }
-            if let ok = envelope["ok"] as? Bool, ok == false {
-                return forwardFailure(envelope)
+            guard let envelope else {
+                return .json(502, ["ok": false, "error": "sim-use devices: bad JSON"])
             }
             let data = (envelope["data"] as? [String: Any]) ?? [:]
             let rawDevices = (data["devices"] as? [[String: Any]]) ?? []
@@ -70,12 +71,13 @@ struct ViewerAPIHandlers {
             return .json(400, ["ok": false, "error": "deviceId (or udid) query param is required"])
         }
         do {
-            let (stdout, _) = try await run(arguments: ["describe-ui", "--device", deviceId, "--json"], timeout: 30)
-            guard let envelope = try JSONSerialization.jsonObject(with: stdout) as? [String: Any] else {
-                return .json(502, ["ok": false, "error": "sim-use describe-ui: bad JSON"])
+            let result = try await run(arguments: ["describe-ui", "--device", deviceId, "--json"], timeout: 30)
+            let envelope = parseEnvelope(result.stdout)
+            if let failure = failureResponse(envelope: envelope, result: result) {
+                return failure
             }
-            if let ok = envelope["ok"] as? Bool, ok == false {
-                return forwardFailure(envelope)
+            guard let envelope else {
+                return .json(502, ["ok": false, "error": "sim-use describe-ui: bad JSON"])
             }
             let data = (envelope["data"] as? [String: Any]) ?? [:]
             let outline = data["outline"] as? String
@@ -121,11 +123,9 @@ struct ViewerAPIHandlers {
             return .json(400, ["ok": false, "error": "at must be a positive integer alias"])
         }
         do {
-            let (stdout, _) = try await run(arguments: ["tap", "@\(at)", "--device", deviceId, "--json"])
-            if let envelope = try JSONSerialization.jsonObject(with: stdout) as? [String: Any],
-               let ok = envelope["ok"] as? Bool, ok == false
-            {
-                return forwardFailure(envelope)
+            let result = try await run(arguments: ["tap", "@\(at)", "--device", deviceId, "--json"])
+            if let failure = failureResponse(envelope: parseEnvelope(result.stdout), result: result) {
+                return failure
             }
             return .json(200, ["ok": true, "at": at])
         } catch {
@@ -135,7 +135,10 @@ struct ViewerAPIHandlers {
 
     // MARK: - Subprocess plumbing
 
-    private func run(arguments: [String], timeout: TimeInterval = 15) async throws -> (Data, Data) {
+    private func run(
+        arguments: [String],
+        timeout: TimeInterval = 15
+    ) async throws -> (stdout: Data, stderr: Data, status: Int32) {
         let process = Process()
         process.executableURL = executable
         process.arguments = arguments
@@ -165,7 +168,7 @@ struct ViewerAPIHandlers {
         try process.run()
 
         return try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<(Data, Data), Error>) in
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<(stdout: Data, stderr: Data, status: Int32), Error>) in
                 let timeoutTask = DispatchWorkItem {
                     if process.isRunning {
                         process.terminate()
@@ -179,16 +182,13 @@ struct ViewerAPIHandlers {
                     // is not our verb's output anyway.
                     let out = collectedOut.finish()
                     let err = collectedErr.finish()
-                    // The CLI uses non-zero exits for domain errors,
-                    // but the JSON envelope carries those as
-                    // `{ok:false, error, hint}` which the caller
-                    // already forwards. Treat a normal exit as
-                    // success regardless of code; only surface a
-                    // subprocess failure when the kernel reports the
-                    // child was killed by a signal (timeout fired,
-                    // peer disconnect, etc.).
+                    // A normal exit — even non-zero — is the caller's
+                    // to interpret via `failureResponse`, so hand back
+                    // the exit status alongside the output. Only throw
+                    // when the kernel reports the child was killed by
+                    // a signal (timeout fired, peer disconnect, etc.).
                     if proc.terminationReason == .exit {
-                        continuation.resume(returning: (out, err))
+                        continuation.resume(returning: (out, err, proc.terminationStatus))
                     } else {
                         let stderrText = String(data: err, encoding: .utf8) ?? ""
                         let stdoutText = String(data: out, encoding: .utf8) ?? ""
@@ -205,6 +205,45 @@ struct ViewerAPIHandlers {
                 process.terminate()
             }
         }
+    }
+
+    private func parseEnvelope(_ stdout: Data) -> [String: Any]? {
+        (try? JSONSerialization.jsonObject(with: stdout)) as? [String: Any]
+    }
+
+    /// Shared failure policy for a completed subprocess. Returns the
+    /// response to send when the invocation must be treated as failed,
+    /// or nil when the caller may proceed with its success path.
+    ///
+    /// - An envelope carrying `ok == false` is forwarded verbatim,
+    ///   regardless of exit code — CLI domain errors legitimately exit
+    ///   non-zero WITH an envelope.
+    /// - Without a usable `ok` field (unparseable stdout, non-object
+    ///   JSON, or a missing/mistyped `ok`), a non-zero exit means the
+    ///   CLI died before producing its envelope: surface its stderr
+    ///   (falling back to stdout, then to the bare exit status)
+    ///   instead of pretending the verb succeeded.
+    private func failureResponse(
+        envelope: [String: Any]?,
+        result: (stdout: Data, stderr: Data, status: Int32)
+    ) -> HTTPResponse? {
+        if let envelope, let ok = envelope["ok"] as? Bool {
+            return ok ? nil : forwardFailure(envelope)
+        }
+        guard result.status != 0 else { return nil }
+        let stderrText = (String(data: result.stderr, encoding: .utf8) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let stdoutText = (String(data: result.stdout, encoding: .utf8) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let message: String
+        if !stderrText.isEmpty {
+            message = stderrText
+        } else if !stdoutText.isEmpty {
+            message = stdoutText
+        } else {
+            message = "sim-use exited with status \(result.status)"
+        }
+        return .json(502, ["ok": false, "error": message])
     }
 
     private func forwardFailure(_ envelope: [String: Any]) -> HTTPResponse {

--- a/Tests/ViewerAPIHandlersTests.swift
+++ b/Tests/ViewerAPIHandlersTests.swift
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+@testable import SimUse
+import Foundation
+import Testing
+
+// Coverage for ViewerAPIHandlers' subprocess-envelope policy. The
+// handlers shell out to the sim-use binary; these tests point
+// `executable` at a small shell script that emits scripted
+// stdout/stderr and exits with a chosen status, so the full policy
+// matrix is exercised without a real CLI or simulator:
+//
+// - `{ok:false}` envelope → forwarded 502 regardless of exit code
+//   (CLI domain errors legitimately exit non-zero WITH an envelope);
+// - no usable envelope + non-zero exit → 502 carrying stderr (falling
+//   back to stdout, then to a generic status message) — previously
+//   this either produced a false 200 or a useless NSCocoaErrorDomain
+//   string;
+// - zero exit → existing success paths, unchanged.
+@Suite("ViewerAPIHandlers subprocess policy")
+struct ViewerAPIHandlersTests {
+
+    // MARK: - Fixtures
+
+    /// Writes an executable `/bin/sh` script that prints the given
+    /// stdout/stderr and exits with `exitCode`, then returns handlers
+    /// pointed at it. The script lives in a per-test temp directory
+    /// cleaned up by the returned closure.
+    private func makeHandlers(
+        stdout: String,
+        stderr: String = "",
+        exitCode: Int32
+    ) throws -> (handlers: ViewerAPIHandlers, cleanup: () -> Void) {
+        let suffix = String(UUID().uuidString.prefix(6))
+        let dir = URL(fileURLWithPath: "/tmp/sim-use-viewer-\(suffix)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let script = dir.appendingPathComponent("fake-sim-use")
+        var lines = ["#!/bin/sh"]
+        // Heredocs keep the JSON fixtures verbatim — no shell quoting
+        // pitfalls around the double quotes inside the envelopes.
+        if !stdout.isEmpty {
+            lines.append("cat <<'STDOUT_EOF'")
+            lines.append(stdout)
+            lines.append("STDOUT_EOF")
+        }
+        if !stderr.isEmpty {
+            lines.append("cat <<'STDERR_EOF' >&2")
+            lines.append(stderr)
+            lines.append("STDERR_EOF")
+        }
+        lines.append("exit \(exitCode)")
+        try Data((lines.joined(separator: "\n") + "\n").utf8).write(to: script)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: script.path
+        )
+        return (
+            ViewerAPIHandlers(executable: script),
+            { try? FileManager.default.removeItem(at: dir) }
+        )
+    }
+
+    private func getRequest(query: [String: String] = [:]) -> HTTPRequest {
+        HTTPRequest(method: "GET", path: "/api", query: query, headers: [:], body: Data())
+    }
+
+    private func tapRequest(deviceId: String = "TEST-UDID", at: Int = 1) throws -> HTTPRequest {
+        let body = try JSONSerialization.data(withJSONObject: ["deviceId": deviceId, "at": at])
+        return HTTPRequest(method: "POST", path: "/api/tap", query: [:], headers: [:], body: body)
+    }
+
+    private func jsonBody(_ response: HTTPResponse) throws -> [String: Any] {
+        try #require(JSONSerialization.jsonObject(with: response.body) as? [String: Any])
+    }
+
+    // MARK: - Non-zero exit without an envelope surfaces stderr
+
+    @Test("tap: non-zero exit with empty stdout returns stderr, not 200")
+    func tapNonZeroExitEmptyStdout() async throws {
+        let (handlers, cleanup) = try makeHandlers(stdout: "", stderr: "boom", exitCode: 3)
+        defer { cleanup() }
+        let response = await handlers.tap(try tapRequest())
+        #expect(response.status != 200)
+        let body = try jsonBody(response)
+        #expect(body["ok"] as? Bool == false)
+        let error = try #require(body["error"] as? String)
+        #expect(error.contains("boom"))
+    }
+
+    @Test("devices: non-zero exit with empty stdout returns stderr, not 200")
+    func devicesNonZeroExitEmptyStdout() async throws {
+        let (handlers, cleanup) = try makeHandlers(stdout: "", stderr: "boom", exitCode: 3)
+        defer { cleanup() }
+        let response = await handlers.devices(getRequest())
+        #expect(response.status != 200)
+        let body = try jsonBody(response)
+        #expect(body["ok"] as? Bool == false)
+        let error = try #require(body["error"] as? String)
+        #expect(error.contains("boom"))
+    }
+
+    @Test("snapshot: non-zero exit with empty stdout returns stderr, not 200")
+    func snapshotNonZeroExitEmptyStdout() async throws {
+        let (handlers, cleanup) = try makeHandlers(stdout: "", stderr: "boom", exitCode: 3)
+        defer { cleanup() }
+        let response = await handlers.snapshot(getRequest(query: ["deviceId": "TEST-UDID"]))
+        #expect(response.status != 200)
+        let body = try jsonBody(response)
+        #expect(body["ok"] as? Bool == false)
+        let error = try #require(body["error"] as? String)
+        #expect(error.contains("boom"))
+    }
+
+    @Test("tap: non-zero exit with non-JSON stdout falls back to stdout text")
+    func tapNonZeroExitFallsBackToStdout() async throws {
+        let (handlers, cleanup) = try makeHandlers(stdout: "garbage output", exitCode: 2)
+        defer { cleanup() }
+        let response = await handlers.tap(try tapRequest())
+        #expect(response.status != 200)
+        let body = try jsonBody(response)
+        #expect(body["ok"] as? Bool == false)
+        let error = try #require(body["error"] as? String)
+        #expect(error.contains("garbage output"))
+    }
+
+    @Test("tap: non-zero exit with no output falls back to a status message")
+    func tapNonZeroExitNoOutput() async throws {
+        let (handlers, cleanup) = try makeHandlers(stdout: "", exitCode: 4)
+        defer { cleanup() }
+        let response = await handlers.tap(try tapRequest())
+        #expect(response.status != 200)
+        let body = try jsonBody(response)
+        #expect(body["ok"] as? Bool == false)
+        let error = try #require(body["error"] as? String)
+        #expect(error.contains("4"))
+    }
+
+    // MARK: - False-success regression: JSON object without `ok`
+
+    @Test("tap: non-zero exit with an ok-less JSON object is not a success")
+    func tapNonZeroExitUnexpectedShape() async throws {
+        let (handlers, cleanup) = try makeHandlers(stdout: #"{"unexpected":"shape"}"#, exitCode: 2)
+        defer { cleanup() }
+        let response = await handlers.tap(try tapRequest())
+        #expect(response.status != 200)
+        let body = try jsonBody(response)
+        #expect(body["ok"] as? Bool == false)
+    }
+
+    // MARK: - `{ok:false}` envelope forwarded regardless of exit code
+
+    @Test("tap: ok:false envelope with non-zero exit forwards error and hint")
+    func tapForwardsFailureEnvelope() async throws {
+        let (handlers, cleanup) = try makeHandlers(
+            stdout: #"{"ok":false,"error":"E","hint":"H"}"#,
+            exitCode: 1
+        )
+        defer { cleanup() }
+        let response = await handlers.tap(try tapRequest())
+        #expect(response.status == 502)
+        let body = try jsonBody(response)
+        #expect(body["ok"] as? Bool == false)
+        #expect(body["error"] as? String == "E")
+        #expect(body["hint"] as? String == "H")
+    }
+
+    // MARK: - Zero exit with a good envelope keeps succeeding
+
+    @Test("tap: zero exit with ok:true envelope returns 200")
+    func tapSuccess() async throws {
+        let (handlers, cleanup) = try makeHandlers(
+            stdout: #"{"ok":true,"data":{}}"#,
+            exitCode: 0
+        )
+        defer { cleanup() }
+        let response = await handlers.tap(try tapRequest(at: 7))
+        #expect(response.status == 200)
+        let body = try jsonBody(response)
+        #expect(body["ok"] as? Bool == true)
+        #expect(body["at"] as? Int == 7)
+    }
+
+    @Test("devices: zero exit with ok:true envelope returns 200 with devices")
+    func devicesSuccess() async throws {
+        let envelope = #"{"ok":true,"data":{"devices":[{"deviceId":"ABC","name":"iPhone","platform":"ios","runtime":"iOS 18.0"}]}}"#
+        let (handlers, cleanup) = try makeHandlers(stdout: envelope, exitCode: 0)
+        defer { cleanup() }
+        let response = await handlers.devices(getRequest())
+        #expect(response.status == 200)
+        let body = try jsonBody(response)
+        #expect(body["ok"] as? Bool == true)
+        let devices = try #require(body["devices"] as? [[String: Any]])
+        #expect(devices.count == 1)
+        #expect(devices.first?["deviceId"] as? String == "ABC")
+    }
+}


### PR DESCRIPTION
## Summary

Fixes deferred review item D15: the Viewer's API handlers (`ViewerAPIHandlers.swift`) shelled out to the sim-use binary and trusted only the `{ok:false}` JSON envelope for failure detection — the child's exit status was discarded for any normal exit. Two failure modes resulted:

1. Non-zero exit + stdout parsing as a JSON object without an `ok` field → the handler fell through to its success path and returned `200 {ok:true}` — false success.
2. Non-zero exit + empty/non-JSON stdout → the caller saw a useless `NSCocoaErrorDomain 3840` parse-error string while the real error text on stderr was dropped.

## Changes

- `run()` now returns `(stdout: Data, stderr: Data, status: Int32)` instead of swallowing the exit status on `.exit` terminations (signal kills still throw as before).
- A shared `failureResponse(envelope:result:)` helper applies one policy across `devices`, `snapshot`, and `tap`:
  - envelope with `ok == false` → forwarded verbatim as 502, regardless of exit code (CLI domain errors legitimately exit non-zero WITH an envelope);
  - no usable `ok` field AND non-zero exit → 502 `{ok:false, error: <trimmed stderr, falling back to stdout, falling back to "sim-use exited with status N">}`;
  - zero exit → existing behavior, including the "bad JSON" 502 guards in `devices`/`snapshot`.

## Testing

- New `Tests/ViewerAPIHandlersTests.swift` (9 tests, TDD-first — 6 failed against the old code): points `ViewerAPIHandlers(executable:)` at per-test `/bin/sh` scripts with scripted stdout/stderr/exit codes to cover the policy matrix, including the false-success regression (`exit 2` + `{"unexpected":"shape"}`) and the stderr surfacing (`exit 3` + `boom` on stderr) for tap/devices/snapshot.
- `make build` + full `make test`: 588 tests in 116 suites passed (baseline 579/115).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
