### PR TITLE
fix: record-video stop watchdog no longer exits 0 on finalization overrun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Daemon no longer shuts itself down in the middle of a request that runs longer than the idle timeout (e.g. `tap --wait-timeout` beyond the timeout, or a long `batch`). The idle timer now defers shutdown while a request is in flight.
 - Daemon client no longer respawns and resends a command when the daemon drops the connection *after* receiving the request (a possible mid-execution crash). Such ambiguous outcomes now surface a dedicated error with a hint to re-observe the screen before retrying, so a side-effecting verb (tap/type/swipe) is never silently applied twice. Pre-delivery failures (connect/write) still respawn as before.
 - `keyboard-state` now routes through the per-UDID daemon like every other verb (amortised init) and surfaces crash advisories and error `Hint:` lines; a vestigial `run()` override had silently opted it out. The `soft`/`hidden`/failure exit codes are unchanged.
+- `record-video`'s stop watchdog no longer exits 0 when video finalization overruns its grace window, which could report success for a truncated/unplayable MP4. It now warns on stderr and exits 70 (`EX_SOFTWARE`), and the grace window is 3 s (was 1.5 s).
 
 ## [0.9.0] - 2026-06-29
 

--- a/Sources/SimUse/Commands/RecordVideo.swift
+++ b/Sources/SimUse/Commands/RecordVideo.swift
@@ -112,11 +112,7 @@ struct RecordVideo: SimUseExecutableCommand {
         let recordingFinished = CancellationFlag()
         let signalObserver = SignalObserver(signals: [SIGINT, SIGTERM]) {
             cancellationFlag.cancel()
-            DispatchQueue.global().asyncAfter(deadline: .now() + 1.5) {
-                if !recordingFinished.isCancelled() {
-                    _exit(0)
-                }
-            }
+            RecordingFinishWatchdog.arm(recordingFinished: recordingFinished)
         }
         defer { signalObserver.invalidate() }
 

--- a/Sources/iOSSimBackend/Util/VideoCommandSupport.swift
+++ b/Sources/iOSSimBackend/Util/VideoCommandSupport.swift
@@ -54,6 +54,39 @@ public func cancellableSleep(seconds: TimeInterval, flag: CancellationFlag) asyn
     }
 }
 
+/// Stop-path watchdog for the `record-video` command.
+///
+/// After a stop signal arrives, the frame loop breaks and
+/// `H264StreamRecorder.finish()` (`AVAssetWriter.finishWriting`) writes the
+/// mp4 trailer (moov atom). If finalization hangs past `gracePeriod`, the
+/// process must not exit 0 — the file is likely truncated and unplayable —
+/// so the watchdog warns on stderr and exits `EX_SOFTWARE` instead of
+/// leaving a supervisor to SIGKILL us or, worse, reporting success.
+public enum RecordingFinishWatchdog {
+    /// Grace window granted to `finish()` after the stop signal. Wide
+    /// enough for a normal trailer flush (typically well under 1 s) while
+    /// still bounding a hung `finishWriting`.
+    public static let gracePeriod: TimeInterval = 3.0
+
+    /// `EX_SOFTWARE` (sysexits.h). Distinct from the exit codes the CLI
+    /// already produces: 0 (success), 1 (runtime error), 64 (usage error).
+    public static let exitCode: Int32 = 70
+
+    public static let warningMessage =
+        "warning: video finalization did not complete within \(Int(gracePeriod))s — output file may be truncated or unplayable\n"
+
+    /// Arm the watchdog from the signal handler. `recordingFinished` must
+    /// be cancelled once `finish()` has returned (success or failure).
+    public static func arm(recordingFinished: CancellationFlag) {
+        DispatchQueue.global().asyncAfter(deadline: .now() + gracePeriod) {
+            if !recordingFinished.isCancelled() {
+                FileHandle.standardError.write(Data(warningMessage.utf8))
+                _exit(exitCode)
+            }
+        }
+    }
+}
+
 public final class SignalObserver {
     private var sources: [DispatchSourceSignal] = []
     private let signals: [Int32]

--- a/Sources/iOSSimBackend/Verbs/IOSSimRecordVideoCommand.swift
+++ b/Sources/iOSSimBackend/Verbs/IOSSimRecordVideoCommand.swift
@@ -104,16 +104,9 @@ public struct IOSSimRecordVideoCommand: SimUseExecutableCommand {
 
         let cancellationFlag = CancellationFlag()
         let recordingFinished = CancellationFlag()
-        // Watchdog: if `recorder.finish()` has not returned 1.5 s after the
-        // signal arrives, exit cleanly so the supervisor sees status 0
-        // instead of being forced to SIGKILL us mid-flush.
         let signalObserver = SignalObserver(signals: [SIGINT, SIGTERM]) {
             cancellationFlag.cancel()
-            DispatchQueue.global().asyncAfter(deadline: .now() + 1.5) {
-                if !recordingFinished.isCancelled() {
-                    _exit(0)
-                }
-            }
+            RecordingFinishWatchdog.arm(recordingFinished: recordingFinished)
         }
         defer { signalObserver.invalidate() }
 

--- a/Tests/RecordingFinishWatchdogTests.swift
+++ b/Tests/RecordingFinishWatchdogTests.swift
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+@testable import iOSSimBackend
+import Foundation
+import Testing
+
+/// Pins the record-video stop watchdog policy. The `arm()` side effect
+/// (`_exit` from a detached dispatch closure) is not unit-testable, so
+/// these tests lock the observable contract instead: a finalization
+/// overrun must never masquerade as success (exit 0) and must be
+/// explained on stderr.
+@Suite("Recording Finish Watchdog Policy")
+struct RecordingFinishWatchdogTests {
+    @Test("Overrun exits EX_SOFTWARE, not success")
+    func exitCodeIsSoftwareError() {
+        #expect(RecordingFinishWatchdog.exitCode == 70)
+        #expect(RecordingFinishWatchdog.exitCode != 0)
+    }
+
+    @Test("Grace window is 3 seconds")
+    func gracePeriod() {
+        #expect(RecordingFinishWatchdog.gracePeriod == 3.0)
+    }
+
+    @Test("Warning names the grace window and the truncation risk")
+    func warningMessage() {
+        let message = RecordingFinishWatchdog.warningMessage
+        #expect(message.hasPrefix("warning:"))
+        #expect(message.contains("3s"))
+        #expect(message.contains("truncated"))
+        #expect(message.hasSuffix("\n"))
+    }
+}


### PR DESCRIPTION
## Problem (deferred review item D13)

The `record-video` SIGINT/SIGTERM handler armed a watchdog:

```swift
DispatchQueue.global().asyncAfter(deadline: .now() + 1.5) {
    if !recordingFinished.isCancelled() { _exit(0) }
}
```

The stop path breaks the frame loop, then awaits `recorder.finish()` (`AVAssetWriter.finishWriting`), and `recordingFinished.cancel()` is only set after `recordVideo` returns. If `finishWriting` takes longer than 1.5 s (large file, slow disk), `_exit(0)` fires mid-finalization: the MP4's moov atom is never written — a truncated, possibly unplayable file with **exit status 0**.

The identical pattern existed at both watchdog sites: `IOSSimRecordVideoCommand.execute()` (iOS) and `RecordVideo.executeAndroid()` (Android branch of the top-level forwarder).

## Fix

Keep the watchdog — it still bounds a genuinely hung `finishWriting` — but make it honest:

- Grace window widened 1.5 s → 3 s.
- On overrun it now writes `warning: video finalization did not complete within 3s — output file may be truncated or unplayable` to stderr and exits **70** (`EX_SOFTWARE`) instead of 0.

The policy (grace period, exit code, message) plus the arm routine are extracted into `RecordingFinishWatchdog` in `VideoCommandSupport.swift`, shared by both call sites so they can't drift again.

Exit code 70 does not collide with existing exit paths: the CLI otherwise produces 0 (success), 1 (runtime error via `CLIError`), and 64 (ArgumentParser usage errors). `record-video` is `daemonBypass = true`, so stderr at the watchdog site is the invoking terminal/pipe, not a daemon log.

## Testing

- `make build` green; `make test` green — 582 tests / 116 suites (baseline 579 / 115 + the 3 new tests below).
- New `Tests/RecordingFinishWatchdogTests.swift` pins the watchdog contract: exit code 70 (and explicitly `!= 0`), 3 s grace window, warning message shape. The `_exit` side effect itself fires from a detached dispatch closure and is not unit-testable in-process.
- Manual verification is a code-path walkthrough (no booted simulator available): signal → `cancellationFlag.cancel()` + `RecordingFinishWatchdog.arm(...)` → frame loop breaks → `recorder.finish()` → on return (success or error) `recordingFinished.cancel()` disarms the watchdog before it can fire; only an overrunning/hung `finish()` reaches the warning + `_exit(70)` branch. The fast path (finalization under 3 s) is behaviorally unchanged. The existing E2E regression test for issue #35 (`RecordVideoTests.recordVideoShortGraceSIGTERM`) still covers the signal → valid-mp4 path when run with a simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
