### PR TITLE
Fail record-video loudly when the asset writer stalls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bridge `/a11y_tree_full` no longer reads the active root's `windowId` after the node was recycled, which silently dropped popup/dialog secondary windows on Android 11–12.
 - Bridge `/keyboard/input` no longer leaks the borrowed root `AccessibilityNodeInfo` on every call.
 - `record-video` no longer hot-spins without frame pacing when screenshot frames persistently fail to decode.
+- `record-video` no longer hangs forever when AVAssetWriter stops accepting frames; a stalled writer now fails the recording with an explicit error after 10 s.
 - Daemon no longer shuts itself down in the middle of a request that runs longer than the idle timeout (e.g. `tap --wait-timeout` beyond the timeout, or a long `batch`). The idle timer now defers shutdown while a request is in flight.
 - Daemon client no longer respawns and resends a command when the daemon drops the connection *after* receiving the request (a possible mid-execution crash). Such ambiguous outcomes now surface a dedicated error with a hint to re-observe the screen before retrying, so a side-effecting verb (tap/type/swipe) is never silently applied twice. Pre-delivery failures (connect/write) still respawn as before.
 - `keyboard-state` now routes through the per-UDID daemon like every other verb (amortised init) and surfaces crash advisories and error `Hint:` lines; a vestigial `run()` override had silently opted it out. The `soft`/`hidden`/failure exit codes are unchanged.

--- a/Sources/SimUse/Commands/RecordVideo.swift
+++ b/Sources/SimUse/Commands/RecordVideo.swift
@@ -218,6 +218,10 @@ struct RecordVideo: SimUseExecutableCommand {
                     let actualFPS = Double(frameCount) / max(elapsed, 0.0001)
                     FileHandle.standardError.write(Data(String(format: "Captured %lld frames (%.1f FPS actual)\n", frameCount, actualFPS).utf8))
                 }
+            } catch let error as VideoWriterStallError {
+                // A stalled writer does not recover; abort the recording
+                // instead of re-logging the stall once per timeout forever.
+                throw error
             } catch {
                 FileHandle.standardError.write(Data("Error capturing frame: \(error.localizedDescription)\n".utf8))
             }

--- a/Sources/iOSSimBackend/Util/VideoCommandSupport.swift
+++ b/Sources/iOSSimBackend/Util/VideoCommandSupport.swift
@@ -88,6 +88,22 @@ public enum VideoProcessingError: Error {
     case failedToAllocatePixelBuffer
 }
 
+/// Thrown when the asset writer input refuses new frames for longer
+/// than the stall timeout. A wedged writer (disk pressure, encoder
+/// failure) does not recover, so callers must abort the recording
+/// rather than retry — a distinct type lets frame loops tell this
+/// fatal condition apart from transient per-frame capture errors.
+public struct VideoWriterStallError: Error, LocalizedError, Equatable {
+    public let timeout: TimeInterval
+
+    public var errorDescription: String? {
+        String(
+            format: "Video writer did not accept new frames for %.0f seconds; the writer appears stalled (disk pressure or encoder failure). Aborting recording.",
+            timeout
+        )
+    }
+}
+
 public struct VideoFrameUtilities {
     public static func captureScreenshotData(from simulator: FBSimulator) async throws -> Data {
         let screenshotFuture = simulator.takeScreenshot(.PNG)
@@ -223,12 +239,37 @@ public final class H264StreamRecorder: @unchecked Sendable {
         self.adaptor = adaptor
     }
 
-    public func append(image: CGImage, presentationTime: CMTime) throws {
-        if !input.isReadyForMoreMediaData {
-            while !input.isReadyForMoreMediaData {
-                Thread.sleep(forTimeInterval: 0.005)
+    /// How long `append` waits for the writer input to drain before
+    /// giving up. Generous on purpose: with `expectsMediaDataInRealTime`
+    /// a healthy writer is ready again within milliseconds, so reaching
+    /// this deadline means the writer is wedged, not merely busy.
+    static let readinessTimeout: TimeInterval = 10
+
+    /// Poll `isReady` every `pollInterval` until it returns true,
+    /// throwing `VideoWriterStallError` once `timeout` has elapsed.
+    /// The clock and sleep hooks are injectable so the timeout policy
+    /// is unit-testable without AVFoundation or real sleeping.
+    static func waitUntilReady(
+        isReady: () -> Bool,
+        timeout: TimeInterval,
+        pollInterval: TimeInterval = 0.005,
+        now: () -> ContinuousClock.Instant = { ContinuousClock.now },
+        sleep: (TimeInterval) -> Void = { Thread.sleep(forTimeInterval: $0) }
+    ) throws {
+        let deadline = now().advanced(by: .seconds(timeout))
+        while !isReady() {
+            guard now() < deadline else {
+                throw VideoWriterStallError(timeout: timeout)
             }
+            sleep(pollInterval)
         }
+    }
+
+    public func append(image: CGImage, presentationTime: CMTime) throws {
+        try Self.waitUntilReady(
+            isReady: { input.isReadyForMoreMediaData },
+            timeout: Self.readinessTimeout
+        )
 
         guard let pixelBuffer = Self.makePixelBuffer(width: width, height: height, adaptor: adaptor) else {
             throw VideoProcessingError.failedToAllocatePixelBuffer

--- a/Sources/iOSSimBackend/Verbs/IOSSimRecordVideoCommand.swift
+++ b/Sources/iOSSimBackend/Verbs/IOSSimRecordVideoCommand.swift
@@ -202,6 +202,10 @@ public struct IOSSimRecordVideoCommand: SimUseExecutableCommand {
                 } else {
                     FileHandle.standardError.write(Data("Unable to decode screenshot frame\n".utf8))
                 }
+            } catch let error as VideoWriterStallError {
+                // A stalled writer does not recover; abort the recording
+                // instead of re-logging the stall once per timeout forever.
+                throw error
             } catch {
                 FileHandle.standardError.write(Data("Error capturing frame: \(error.localizedDescription)\n".utf8))
             }

--- a/Tests/VideoWriterStallTimeoutTests.swift
+++ b/Tests/VideoWriterStallTimeoutTests.swift
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+import Testing
+import Foundation
+import AVFoundation
+@testable import iOSSimBackend
+
+@Suite("H264StreamRecorder writer-readiness timeout policy")
+struct VideoWriterStallTimeoutTests {
+    /// Deterministic stand-in for the wall clock: `sleep` advances the
+    /// fake instant instead of blocking, so timeout paths run instantly.
+    private final class FakeClock {
+        private(set) var current = ContinuousClock.now
+        private(set) var sleepCalls: [TimeInterval] = []
+
+        func now() -> ContinuousClock.Instant { current }
+
+        func sleep(_ interval: TimeInterval) {
+            sleepCalls.append(interval)
+            current = current.advanced(by: .seconds(interval))
+        }
+    }
+
+    @Test("Never-ready input throws VideoWriterStallError once the deadline passes")
+    func neverReadyThrowsAfterDeadline() {
+        let clock = FakeClock()
+        // 0.25 is exactly representable in binary, so 4 polls land the
+        // fake clock precisely on the 1 s deadline — no FP drift.
+        #expect(throws: VideoWriterStallError(timeout: 1.0)) {
+            try H264StreamRecorder.waitUntilReady(
+                isReady: { false },
+                timeout: 1.0,
+                pollInterval: 0.25,
+                now: clock.now,
+                sleep: clock.sleep
+            )
+        }
+        #expect(clock.sleepCalls.count == 4)
+    }
+
+    @Test("Ready input returns immediately without sleeping")
+    func readyImmediatelyDoesNotSleep() throws {
+        let clock = FakeClock()
+        try H264StreamRecorder.waitUntilReady(
+            isReady: { true },
+            timeout: 1.0,
+            now: clock.now,
+            sleep: clock.sleep
+        )
+        #expect(clock.sleepCalls.isEmpty)
+    }
+
+    @Test("Input becoming ready after N polls returns after exactly N sleeps")
+    func readyAfterNPolls() throws {
+        let clock = FakeClock()
+        var checks = 0
+        try H264StreamRecorder.waitUntilReady(
+            isReady: {
+                checks += 1
+                return checks > 3
+            },
+            timeout: 1.0,
+            pollInterval: 0.005,
+            now: clock.now,
+            sleep: clock.sleep
+        )
+        #expect(clock.sleepCalls == [0.005, 0.005, 0.005])
+    }
+
+    @Test("Production timeout is generous — a busy but healthy writer never trips it")
+    func productionTimeoutIsGenerous() {
+        #expect(H264StreamRecorder.readinessTimeout == 10)
+    }
+
+    @Test("Stall error message names the timeout and the stalled writer")
+    func stallErrorMessageIsDescriptive() {
+        let message = VideoWriterStallError(timeout: 10).localizedDescription
+        #expect(message.contains("10"))
+        #expect(message.lowercased().contains("stall"))
+    }
+
+    // Integration: an AVAssetWriterInput whose writer never started
+    // reports `isReadyForMoreMediaData == false` forever — the exact
+    // shape of a wedged writer. Uses the real clock with a short
+    // timeout, so this stays fast and headless.
+    @Test("Unstarted AVAssetWriterInput trips the stall timeout")
+    func unstartedInputTimesOut() {
+        let input = AVAssetWriterInput(mediaType: .video, outputSettings: nil)
+        #expect(throws: VideoWriterStallError(timeout: 0.05)) {
+            try H264StreamRecorder.waitUntilReady(
+                isReady: { input.isReadyForMoreMediaData },
+                timeout: 0.05,
+                pollInterval: 0.005
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`H264StreamRecorder.append` busy-waited on `input.isReadyForMoreMediaData` with no timeout. `append` is synchronous and called from the recording loops' async context, so a wedged `AVAssetWriter` (disk pressure, encoder stall) parked a Swift-concurrency cooperative-pool thread and hung the recording task forever with no escape.

## Changes

- Extract the wait into `H264StreamRecorder.waitUntilReady(isReady:timeout:pollInterval:now:sleep:)` with a generous 10 s deadline. With `expectsMediaDataInRealTime = true` a healthy writer drains within milliseconds, so hitting the deadline means the writer is wedged, not merely busy.
- On timeout the helper throws a dedicated `VideoWriterStallError` (`LocalizedError`) with a descriptive message. This is an intentional behavior change on the failure path: a stalled writer now fails the recording loudly instead of hanging.
- Both frame loops (iOS `IOSSimRecordVideoCommand.recordVideo` and the Android branch in `RecordVideo`) rethrow `VideoWriterStallError` past their transient per-frame `catch`, so the command exits non-zero with the message instead of re-logging the stall once per timeout forever. Transient capture errors keep their existing log-and-continue behavior.

## Testing

The timeout policy is a pure function with injectable `now`/`sleep` hooks, so it is unit-tested without AVFoundation or real sleeping (`Tests/VideoWriterStallTimeoutTests.swift`):

- never-ready input throws `VideoWriterStallError` exactly at the deadline (fake clock, instant);
- ready-immediately returns without sleeping;
- ready after N polls returns after exactly N sleep calls;
- production timeout constant is 10 s; stall error message is descriptive.

Plus a short real-clock AVFoundation integration test: an `AVAssetWriterInput` whose writer never started reports `isReadyForMoreMediaData == false` forever, and trips the helper with a 50 ms timeout (runs headless in ~60 ms).

`make build` and `make test` green: 585 Swift Testing tests / 116 suites + 302 XCTest tests, 0 failures. (`AdbRunnerTests.testRunFastChildHasLowLatency` flaked once under concurrent build load on the *unmodified* baseline too; it passes in isolation and in the final clean run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
