### PR TITLE
Fix `ios batch --ax-cache` being a complete no-op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `ios batch --ax-cache` was a complete no-op: the default `perBatch` never cached and every selector-based step refetched the AX tree. `perBatch` now resolves all steps against one snapshot, `perStep` refetches at each step, `none` never caches, and `--wait-timeout` poll ticks bypass the cache (updating it) so delayed elements are still found.
 - Daemon client no longer tears down a healthy daemon and re-executes the command when the daemon answers with a command-level error (element not found, etc.). Failed commands now surface immediately instead of paying a full daemon respawn, and side-effecting commands are no longer executed twice.
 - Daemon shutdown no longer deletes the socket/pidfile of a successor daemon that took the paths over, which previously chained invisible orphan daemons.
 - Daemon base directory under `/tmp` is now validated on every run (symlinks, foreign owners rejected; loose permissions tightened to 0700) instead of trusting whatever was pre-created there.

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Key semantics:
 - Exactly one step source per run: `--step`, `--file`, or `--stdin`.
 - Fail-fast by default; `--continue-on-error` switches to best-effort.
 - `--wait-timeout <seconds>` makes selector taps poll for the element to appear — primary mechanism for multi-screen flows.
-- `--ax-cache perBatch` (default) reuses one AX snapshot for the whole run; `--ax-cache perStep` refreshes between steps when the UI changes.
+- `--ax-cache perBatch` (default) reuses one AX snapshot for the whole run; `--ax-cache perStep` refreshes between steps when the UI changes; `--ax-cache none` disables snapshot reuse entirely. `--wait-timeout` polling always refetches.
 
 ### Screenshot
 

--- a/Sources/iOSSimBackend/A11y/AccessibilityPoller.swift
+++ b/Sources/iOSSimBackend/A11y/AccessibilityPoller.swift
@@ -3,6 +3,11 @@ import Foundation
 
 @MainActor
 public struct AccessibilityPoller {
+    /// Supplies AX roots for resolution. `forceRefresh: false` may serve
+    /// a cached snapshot; `true` (poll ticks) must fetch a fresh one so
+    /// delayed elements become visible.
+    public typealias RootsProvider = @MainActor (_ forceRefresh: Bool) async throws -> [AccessibilityElement]
+
     public static func resolveWithPolling(
         query: AccessibilityQuery,
         simulatorUDID: String,
@@ -10,9 +15,16 @@ public struct AccessibilityPoller {
         pollInterval: TimeInterval,
         elementType: String? = nil,
         frameFilter: AccessibilityTargetResolver.FrameFilter? = nil,
+        rootsProvider: RootsProvider? = nil,
         logger: SimUseLogger
     ) async throws -> (x: Double, y: Double) {
-        let roots = try await AccessibilityFetcher.fetchAccessibilityElements(for: simulatorUDID, logger: logger)
+        // Non-batch callers pass no provider and keep the historical
+        // fetch-every-time behaviour; batch passes the BatchContext cache.
+        let fetchRoots: RootsProvider = rootsProvider ?? { _ in
+            try await AccessibilityFetcher.fetchAccessibilityElements(for: simulatorUDID, logger: logger)
+        }
+
+        let roots = try await fetchRoots(false)
         do {
             return try AccessibilityTargetResolver.resolveCenterPoint(roots: roots, query: query, elementType: elementType, frameFilter: frameFilter)
         } catch let error as ElementResolutionError where error.isNotFound && waitTimeout > 0 {
@@ -24,7 +36,7 @@ public struct AccessibilityPoller {
                 logger.info().log("Element not found, retrying in \(pollInterval)s…")
                 try await Task.sleep(for: .seconds(pollInterval))
 
-                let freshRoots = try await AccessibilityFetcher.fetchAccessibilityElements(for: simulatorUDID, logger: logger)
+                let freshRoots = try await fetchRoots(true)
                 do {
                     return try AccessibilityTargetResolver.resolveCenterPoint(roots: freshRoots, query: query, elementType: elementType, frameFilter: frameFilter)
                 } catch let retryError as ElementResolutionError where retryError.isNotFound {

--- a/Sources/iOSSimBackend/Batch/BatchContext.swift
+++ b/Sources/iOSSimBackend/Batch/BatchContext.swift
@@ -15,6 +15,10 @@ public enum TypeSubmissionMode: String, CaseIterable, ExpressibleByArgument, Sen
 
 @MainActor
 public final class BatchContext {
+    /// Fetches the AX tree for a UDID. Injectable so the cache policy
+    /// semantics can be unit-tested without a booted simulator.
+    public typealias ElementFetcher = @MainActor (String, SimUseLogger) async throws -> [AccessibilityElement]
+
     public let simulatorUDID: String
     public let axCachePolicy: AXCachePolicy
     public let typeSubmissionMode: TypeSubmissionMode
@@ -22,6 +26,7 @@ public final class BatchContext {
     public let waitTimeout: TimeInterval
     public let pollInterval: TimeInterval
 
+    private let fetchElements: ElementFetcher
     private var cachedRoots: [AccessibilityElement]?
 
     public init(
@@ -30,7 +35,10 @@ public final class BatchContext {
         typeSubmissionMode: TypeSubmissionMode,
         typeChunkSize: Int,
         waitTimeout: TimeInterval = 0,
-        pollInterval: TimeInterval = 0.25
+        pollInterval: TimeInterval = 0.25,
+        fetchElements: @escaping ElementFetcher = { udid, logger in
+            try await AccessibilityFetcher.fetchAccessibilityElements(for: udid, logger: logger)
+        }
     ) {
         self.simulatorUDID = simulatorUDID
         self.axCachePolicy = axCachePolicy
@@ -38,19 +46,31 @@ public final class BatchContext {
         self.typeChunkSize = typeChunkSize
         self.waitTimeout = waitTimeout
         self.pollInterval = pollInterval
+        self.fetchElements = fetchElements
     }
 
+    /// Marks a step boundary. `.perStep` drops its snapshot here so the
+    /// next selector resolution refetches; `.perBatch` keeps the snapshot
+    /// for the whole run and `.none` never caches in the first place.
+    public func beginStep() {
+        if axCachePolicy == .perStep {
+            cachedRoots = nil
+        }
+    }
+
+    /// Returns the AX roots honouring the cache policy. `forceRefresh`
+    /// bypasses the cache and, for caching policies, replaces it — so a
+    /// `--wait-timeout` poll tick propagates the fresh snapshot to later
+    /// resolutions instead of resurrecting the stale one.
     public func accessibilityRoots(logger: SimUseLogger, forceRefresh: Bool = false) async throws -> [AccessibilityElement] {
         switch axCachePolicy {
         case .none:
-            return try await AccessibilityFetcher.fetchAccessibilityElements(for: simulatorUDID, logger: logger)
-        case .perStep:
-            return try await AccessibilityFetcher.fetchAccessibilityElements(for: simulatorUDID, logger: logger)
-        case .perBatch:
+            return try await fetchElements(simulatorUDID, logger)
+        case .perStep, .perBatch:
             if !forceRefresh, let cachedRoots {
                 return cachedRoots
             }
-            let roots = try await AccessibilityFetcher.fetchAccessibilityElements(for: simulatorUDID, logger: logger)
+            let roots = try await fetchElements(simulatorUDID, logger)
             cachedRoots = roots
             return roots
         }

--- a/Sources/iOSSimBackend/Batch/Command+BatchConvertible.swift
+++ b/Sources/iOSSimBackend/Batch/Command+BatchConvertible.swift
@@ -62,6 +62,9 @@ extension IOSSimTapCommand: BatchConvertible {
                 pollInterval: context.pollInterval,
                 elementType: elementType,
                 frameFilter: frameFilter,
+                rootsProvider: { forceRefresh in
+                    try await context.accessibilityRoots(logger: logger, forceRefresh: forceRefresh)
+                },
                 logger: logger
             )
         }

--- a/Sources/iOSSimBackend/Verbs/IOSSimBatchCommand.swift
+++ b/Sources/iOSSimBackend/Verbs/IOSSimBatchCommand.swift
@@ -54,7 +54,7 @@ public struct IOSSimBatchCommand: SimUseExecutableCommand {
     @Flag(name: .customLong("stdin"), help: "Read steps from stdin (one step per line).")
     public var useStdin: Bool = false
 
-    @Option(name: .customLong("ax-cache"), help: "Accessibility snapshot cache policy for selector-based taps.")
+    @Option(name: .customLong("ax-cache"), help: "Accessibility snapshot cache policy for selector-based taps: perBatch reuses one snapshot for the whole run, perStep refetches at each step, none never caches. --wait-timeout polling always refetches.")
     public var axCachePolicy: AXCachePolicy = .perBatch
 
     @Option(name: .customLong("type-submission"), help: "Type step submission mode.")
@@ -196,6 +196,9 @@ public struct IOSSimBatchCommand: SimUseExecutableCommand {
         for (index, line) in stepLines.enumerated() {
             var stepName = "<unparsed>"
             do {
+                // Step boundary: `--ax-cache perStep` invalidates its
+                // snapshot here so selector taps see the current UI.
+                await context.beginStep()
                 let tokens = try ShellTokenizer.tokenize(line)
                 stepName = tokens.first ?? "<empty>"
                 let primitives = try await BatchStepParser.parseStepTokens(

--- a/Tests/BatchAXCacheTests.swift
+++ b/Tests/BatchAXCacheTests.swift
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: Apache-2.0
+@testable import iOSSimBackend
+import Foundation
+import Testing
+
+// Coverage for the `--ax-cache` policy plumbing. Historically the
+// policy was parsed but never consulted — every selector resolution
+// refetched the AX tree, so `perBatch` / `perStep` / `none` behaved
+// identically. These tests pin the documented semantics at the unit
+// level with an injected fetcher (no simulator needed); the live-UI
+// counterparts are the SIM_USE_E2E-gated BatchTests.
+
+@MainActor
+private final class FakeAXFetcher {
+    private(set) var fetchCount = 0
+    /// Swappable between calls so a test can simulate on-screen state
+    /// changing underneath a cached snapshot.
+    var tree: [AccessibilityElement]
+
+    init(tree: [AccessibilityElement]) {
+        self.tree = tree
+    }
+
+    func fetch() -> [AccessibilityElement] {
+        fetchCount += 1
+        return tree
+    }
+}
+
+/// Builds a flat root array of actionable Buttons, one per label,
+/// each with a distinct non-empty frame so center-point resolution works.
+private func makeButtonTree(labels: [String]) throws -> [AccessibilityElement] {
+    let elements = labels.enumerated().map { index, label in
+        """
+        {"type": "Button", "frame": {"x": 0, "y": \(index * 100), "width": 100, "height": 40}, "AXLabel": "\(label)", "enabled": true}
+        """
+    }.joined(separator: ",")
+    return try JSONDecoder().decode([AccessibilityElement].self, from: Data("[\(elements)]".utf8))
+}
+
+@MainActor
+private func makeContext(
+    policy: AXCachePolicy,
+    fetcher: FakeAXFetcher,
+    waitTimeout: TimeInterval = 0,
+    pollInterval: TimeInterval = 0.01
+) -> BatchContext {
+    BatchContext(
+        simulatorUDID: "FAKE-UDID",
+        axCachePolicy: policy,
+        typeSubmissionMode: .chunked,
+        typeChunkSize: 200,
+        waitTimeout: waitTimeout,
+        pollInterval: pollInterval,
+        fetchElements: { _, _ in fetcher.fetch() }
+    )
+}
+
+private let quietLogger = SimUseLogger(writeToStdErr: false)
+
+@Suite("Batch — AX cache policies (BatchContext)")
+@MainActor
+struct BatchContextAXCacheTests {
+    @Test("perBatch serves one snapshot across step boundaries")
+    func perBatchCachesAcrossSteps() async throws {
+        let fetcher = FakeAXFetcher(tree: try makeButtonTree(labels: ["Old"]))
+        let context = makeContext(policy: .perBatch, fetcher: fetcher)
+
+        context.beginStep()
+        let first = try await context.accessibilityRoots(logger: quietLogger)
+        fetcher.tree = try makeButtonTree(labels: ["New"])
+        context.beginStep()
+        let second = try await context.accessibilityRoots(logger: quietLogger)
+
+        #expect(fetcher.fetchCount == 1, "perBatch must fetch exactly once for the whole run")
+        #expect(first.first?.AXLabel == "Old")
+        #expect(second.first?.AXLabel == "Old", "second step must see the stale cached snapshot")
+    }
+
+    @Test("perBatch forceRefresh refetches and replaces the cache")
+    func perBatchForceRefreshUpdatesCache() async throws {
+        let fetcher = FakeAXFetcher(tree: try makeButtonTree(labels: ["Old"]))
+        let context = makeContext(policy: .perBatch, fetcher: fetcher)
+
+        _ = try await context.accessibilityRoots(logger: quietLogger)
+        fetcher.tree = try makeButtonTree(labels: ["New"])
+        let refreshed = try await context.accessibilityRoots(logger: quietLogger, forceRefresh: true)
+        let cached = try await context.accessibilityRoots(logger: quietLogger)
+
+        #expect(fetcher.fetchCount == 2, "forceRefresh must refetch; the follow-up call must not")
+        #expect(refreshed.first?.AXLabel == "New")
+        #expect(cached.first?.AXLabel == "New", "cache must hold the refreshed snapshot")
+    }
+
+    @Test("perStep caches within a step and clears at beginStep")
+    func perStepClearsAtStepBoundary() async throws {
+        let fetcher = FakeAXFetcher(tree: try makeButtonTree(labels: ["Old"]))
+        let context = makeContext(policy: .perStep, fetcher: fetcher)
+
+        context.beginStep()
+        _ = try await context.accessibilityRoots(logger: quietLogger)
+        _ = try await context.accessibilityRoots(logger: quietLogger)
+        #expect(fetcher.fetchCount == 1, "within one step perStep must reuse the snapshot")
+
+        fetcher.tree = try makeButtonTree(labels: ["New"])
+        context.beginStep()
+        let roots = try await context.accessibilityRoots(logger: quietLogger)
+        #expect(fetcher.fetchCount == 2, "a new step must refetch under perStep")
+        #expect(roots.first?.AXLabel == "New")
+    }
+
+    @Test("none always fetches, even within a step")
+    func noneNeverCaches() async throws {
+        let fetcher = FakeAXFetcher(tree: try makeButtonTree(labels: ["Old"]))
+        let context = makeContext(policy: .none, fetcher: fetcher)
+
+        context.beginStep()
+        _ = try await context.accessibilityRoots(logger: quietLogger)
+        fetcher.tree = try makeButtonTree(labels: ["New"])
+        let roots = try await context.accessibilityRoots(logger: quietLogger)
+
+        #expect(fetcher.fetchCount == 2, "policy none must fetch on every call")
+        #expect(roots.first?.AXLabel == "New")
+    }
+}
+
+@Suite("Batch — AX cache policies (poller provider)")
+@MainActor
+struct AccessibilityPollerProviderTests {
+    @Test("poll ticks force-refresh: provider sees (false) then (true)")
+    func pollTickForcesRefresh() async throws {
+        let missTree = try makeButtonTree(labels: ["Other"])
+        let hitTree = try makeButtonTree(labels: ["Target"])
+        var providerCalls: [Bool] = []
+
+        let point = try await AccessibilityPoller.resolveWithPolling(
+            query: .label("Target"),
+            simulatorUDID: "FAKE-UDID",
+            waitTimeout: 2,
+            pollInterval: 0.01,
+            rootsProvider: { forceRefresh in
+                providerCalls.append(forceRefresh)
+                return forceRefresh ? hitTree : missTree
+            },
+            logger: quietLogger
+        )
+
+        #expect(providerCalls == [false, true],
+                "initial attempt must respect the cache; poll ticks must bust it")
+        #expect(point.x == 50)
+        #expect(point.y == 20)
+    }
+
+    @Test("waitTimeout 0 makes a single cache-respecting attempt")
+    func zeroTimeoutSingleAttempt() async throws {
+        let missTree = try makeButtonTree(labels: ["Other"])
+        var providerCalls: [Bool] = []
+
+        await #expect(throws: ElementResolutionError.self) {
+            _ = try await AccessibilityPoller.resolveWithPolling(
+                query: .label("Target"),
+                simulatorUDID: "FAKE-UDID",
+                waitTimeout: 0,
+                pollInterval: 0.01,
+                rootsProvider: { forceRefresh in
+                    providerCalls.append(forceRefresh)
+                    return missTree
+                },
+                logger: quietLogger
+            )
+        }
+        #expect(providerCalls == [false])
+    }
+}
+
+@Suite("Batch — AX cache policies (step parser integration)")
+@MainActor
+struct BatchAXCacheStepParserTests {
+    private func parseTap(label: String, context: BatchContext) async throws -> [BatchPrimitive] {
+        context.beginStep()
+        return try await BatchStepParser.parseStepTokens(
+            ["tap", "--label", label],
+            globalUDID: "FAKE-UDID",
+            context: context,
+            logger: quietLogger
+        )
+    }
+
+    @Test("perBatch: two tap-by-label steps share one fetch")
+    func perBatchSharesFetchAcrossTapSteps() async throws {
+        let fetcher = FakeAXFetcher(tree: try makeButtonTree(labels: ["First", "Second"]))
+        let context = makeContext(policy: .perBatch, fetcher: fetcher)
+
+        _ = try await parseTap(label: "First", context: context)
+        _ = try await parseTap(label: "Second", context: context)
+
+        #expect(fetcher.fetchCount == 1)
+    }
+
+    @Test("perStep: each tap-by-label step fetches its own snapshot")
+    func perStepFetchesPerTapStep() async throws {
+        let fetcher = FakeAXFetcher(tree: try makeButtonTree(labels: ["First", "Second"]))
+        let context = makeContext(policy: .perStep, fetcher: fetcher)
+
+        _ = try await parseTap(label: "First", context: context)
+        _ = try await parseTap(label: "Second", context: context)
+
+        #expect(fetcher.fetchCount == 2)
+    }
+
+    // Unit mirror of the E2E "perBatch cache fails after state change"
+    // (BatchTests.perBatchCacheCanFailOnStateChange): with waitTimeout 0
+    // the second step resolves against the stale snapshot and must fail.
+    @Test("perBatch + waitTimeout 0: stale snapshot fails a later step")
+    func perBatchStaleSnapshotFailsLaterStep() async throws {
+        let fetcher = FakeAXFetcher(tree: try makeButtonTree(labels: ["Trigger"]))
+        let context = makeContext(policy: .perBatch, fetcher: fetcher)
+
+        _ = try await parseTap(label: "Trigger", context: context)
+        fetcher.tree = try makeButtonTree(labels: ["Trigger", "Target"])
+
+        await #expect(throws: ElementResolutionError.self) {
+            _ = try await parseTap(label: "Target", context: context)
+        }
+        #expect(fetcher.fetchCount == 1, "waitTimeout 0 must not refetch under perBatch")
+    }
+
+    // Unit mirror of the E2E "wait-timeout can wait for delayed element"
+    // (BatchTests.waitTimeoutFindsDelayedElement): under the default
+    // perBatch policy, poll ticks must bypass the cache and the refreshed
+    // snapshot must replace it for later steps.
+    @Test("perBatch + waitTimeout: polling refetches and updates the cache")
+    func perBatchPollingBypassesAndUpdatesCache() async throws {
+        let fetcher = FakeAXFetcher(tree: try makeButtonTree(labels: ["Trigger"]))
+        let context = makeContext(policy: .perBatch, fetcher: fetcher, waitTimeout: 2)
+
+        _ = try await parseTap(label: "Trigger", context: context)
+        fetcher.tree = try makeButtonTree(labels: ["Trigger", "Delayed"])
+        _ = try await parseTap(label: "Delayed", context: context)
+
+        #expect(fetcher.fetchCount == 2, "one initial fetch + one forced poll refetch")
+
+        let cached = try await context.accessibilityRoots(logger: quietLogger)
+        #expect(fetcher.fetchCount == 2, "later reads must hit the refreshed cache")
+        #expect(cached.contains { $0.AXLabel == "Delayed" })
+    }
+}

--- a/Tests/BatchTests.swift
+++ b/Tests/BatchTests.swift
@@ -9,7 +9,7 @@ struct BatchTests {
         try await TestHelpers.launchPlaygroundApp(to: "tap-test")
 
         try await TestHelpers.runSimUseCommand(
-            "batch --step \"tap -x 180 -y 360\" --step \"tap -x 220 -y 420\"",
+            "ios batch --step \"tap -x 180 -y 360\" --step \"tap -x 220 -y 420\"",
             simulatorUDID: defaultSimulatorUDID
         )
 
@@ -36,7 +36,7 @@ struct BatchTests {
         defer { try? FileManager.default.removeItem(at: tempFile) }
 
         try await TestHelpers.runSimUseCommand(
-            "batch --file \"\(tempFile.path)\"",
+            "ios batch --file \"\(tempFile.path)\"",
             simulatorUDID: defaultSimulatorUDID
         )
 
@@ -51,7 +51,7 @@ struct BatchTests {
         let udid = try TestHelpers.requireSimulatorUDID()
         let simUsePath = try TestHelpers.getSimUsePath()
 
-        let command = "printf 'tap -x 160 -y 350\\ntap -x 200 -y 410\\n' | \"\(simUsePath)\" batch --stdin --udid \"\(udid)\""
+        let command = "printf 'tap -x 160 -y 350\\ntap -x 200 -y 410\\n' | \"\(simUsePath)\" ios batch --stdin --udid \"\(udid)\""
         let result = try await CommandRunner.run(command)
         #expect(result.exitCode == 0)
 
@@ -65,7 +65,7 @@ struct BatchTests {
         try await TestHelpers.launchPlaygroundApp(to: "batch-test")
 
         let result = try await TestHelpers.runSimUseCommandAllowFailure(
-            "batch --continue-on-error --wait-timeout 2 --poll-interval 0.1 --ax-cache perStep --step \"unknown-command\" --step \"tap --label 'Trigger State Change'\" --step \"tap --label 'State Target'\"",
+            "ios batch --continue-on-error --wait-timeout 2 --poll-interval 0.1 --ax-cache perStep --step \"unknown-command\" --step \"tap --label 'Trigger State Change'\" --step \"tap --label 'State Target'\"",
             simulatorUDID: defaultSimulatorUDID
         )
 
@@ -82,7 +82,7 @@ struct BatchTests {
         try await TestHelpers.launchPlaygroundApp(to: "batch-test")
 
         let result = try await TestHelpers.runSimUseCommandAllowFailure(
-            "batch --ax-cache perBatch --step \"tap --label 'Trigger State Change'\" --step \"tap --label 'State Target'\"",
+            "ios batch --ax-cache perBatch --step \"tap --label 'Trigger State Change'\" --step \"tap --label 'State Target'\"",
             simulatorUDID: defaultSimulatorUDID
         )
 
@@ -95,7 +95,7 @@ struct BatchTests {
         try await TestHelpers.launchPlaygroundApp(to: "batch-test")
 
         try await TestHelpers.runSimUseCommand(
-            "batch --ax-cache perStep --step \"tap --label 'Trigger State Change'\" --step \"tap --label 'State Target'\"",
+            "ios batch --ax-cache perStep --step \"tap --label 'Trigger State Change'\" --step \"tap --label 'State Target'\"",
             simulatorUDID: defaultSimulatorUDID
         )
 
@@ -108,7 +108,7 @@ struct BatchTests {
         try await TestHelpers.launchPlaygroundApp(to: "batch-test")
 
         try await TestHelpers.runSimUseCommand(
-            "batch --wait-timeout 5 --poll-interval 0.1 --step \"tap --label 'Trigger Delayed Element'\" --step \"tap --label 'Delayed Target'\"",
+            "ios batch --wait-timeout 5 --poll-interval 0.1 --step \"tap --label 'Trigger Delayed Element'\" --step \"tap --label 'Delayed Target'\"",
             simulatorUDID: defaultSimulatorUDID
         )
 
@@ -121,7 +121,7 @@ struct BatchTests {
         try await TestHelpers.launchPlaygroundApp(to: "batch-test")
 
         let result = try await TestHelpers.runSimUseCommandAllowFailure(
-            "batch --wait-timeout 0 --step \"tap --label 'Trigger Delayed Element'\" --step \"tap --label 'Delayed Target'\"",
+            "ios batch --wait-timeout 0 --step \"tap --label 'Trigger Delayed Element'\" --step \"tap --label 'Delayed Target'\"",
             simulatorUDID: defaultSimulatorUDID
         )
 
@@ -134,7 +134,7 @@ struct BatchTests {
         try await TestHelpers.launchPlaygroundApp(to: "batch-login-flow")
 
         try await TestHelpers.runSimUseCommand(
-            "batch --ax-cache perStep --wait-timeout 6 --poll-interval 0.1 --step \"type 'cam@example.com'\" --step \"tap --label Continue\" --step \"type 'supersecret'\" --step \"tap --label 'Sign In'\" --step \"tap --label 'Open Settings'\" --step \"tap --label 'Toggle Preference'\"",
+            "ios batch --ax-cache perStep --wait-timeout 6 --poll-interval 0.1 --step \"type 'cam@example.com'\" --step \"tap --label Continue\" --step \"type 'supersecret'\" --step \"tap --label 'Sign In'\" --step \"tap --label 'Open Settings'\" --step \"tap --label 'Toggle Preference'\"",
             simulatorUDID: defaultSimulatorUDID
         )
 
@@ -153,7 +153,7 @@ struct BatchTests {
         try await TestHelpers.launchPlaygroundApp(to: "batch-login-flow")
 
         let result = try await TestHelpers.runSimUseCommandAllowFailure(
-            "batch --ax-cache perStep --wait-timeout 0 --step \"type 'cam@example.com'\" --step \"tap --label Continue\" --step \"type 'supersecret'\" --step \"tap --label 'Sign In'\" --step \"tap --label 'Open Settings'\"",
+            "ios batch --ax-cache perStep --wait-timeout 0 --step \"type 'cam@example.com'\" --step \"tap --label Continue\" --step \"type 'supersecret'\" --step \"tap --label 'Sign In'\" --step \"tap --label 'Open Settings'\"",
             simulatorUDID: defaultSimulatorUDID
         )
 
@@ -166,7 +166,7 @@ struct BatchTests {
         try await TestHelpers.launchPlaygroundApp(to: "batch-test")
 
         try await TestHelpers.runSimUseCommand(
-            "batch --ax-cache perStep --step \"tap --label-contains 'Trigger State'\" --step \"tap --label 'State Target'\"",
+            "ios batch --ax-cache perStep --step \"tap --label-contains 'Trigger State'\" --step \"tap --label 'State Target'\"",
             simulatorUDID: defaultSimulatorUDID
         )
 
@@ -183,7 +183,7 @@ struct BatchTests {
         // through the batch step parser without altering existing
         // semantics.
         try await TestHelpers.runSimUseCommand(
-            "batch --ax-cache perStep --step \"tap --label 'Trigger State Change' --frame maxY=0.8r\" --step \"tap --label 'State Target'\"",
+            "ios batch --ax-cache perStep --step \"tap --label 'Trigger State Change' --frame maxY=0.8r\" --step \"tap --label 'State Target'\"",
             simulatorUDID: defaultSimulatorUDID
         )
 
@@ -196,7 +196,7 @@ struct BatchTests {
         try await TestHelpers.launchPlaygroundApp(to: "batch-test")
 
         try await TestHelpers.runSimUseCommand(
-            "batch --ax-cache perStep --step \"tap --label-regex '^Trigger State Change$'\" --step \"tap --label 'State Target'\"",
+            "ios batch --ax-cache perStep --step \"tap --label-regex '^Trigger State Change$'\" --step \"tap --label 'State Target'\"",
             simulatorUDID: defaultSimulatorUDID
         )
 
@@ -212,7 +212,7 @@ struct BatchTests {
 
         await #expect(throws: (any Error).self) {
             try await TestHelpers.runSimUseCommand(
-                "batch --step \"tap -x 100 -y 200\" --file \"\(tempFile.path)\"",
+                "ios batch --step \"tap -x 100 -y 200\" --file \"\(tempFile.path)\"",
                 simulatorUDID: defaultSimulatorUDID
             )
         }

--- a/skills/sim-use/references/batch-reference.md
+++ b/skills/sim-use/references/batch-reference.md
@@ -20,7 +20,7 @@ Use this reference when generating or reviewing `sim-use ios batch` commands.
 - `--file <path>`: read one step per line from file.
 - `--stdin`: read one step per line from stdin.
 - `--continue-on-error`: keep running after a failed step; report failures at end.
-- `--ax-cache perBatch|perStep|none`: selector tap AX snapshot reuse policy.
+- `--ax-cache perBatch|perStep|none`: selector tap AX snapshot reuse policy. `perBatch` (default) resolves every selector against one snapshot fetched at first use; `perStep` refetches at each step; `none` never caches. `--wait-timeout` polling always refetches (and updates the cache).
 - `--type-submission chunked|composite`: submission mode for `type` steps.
 - `--type-chunk-size <n>`: chunk size when using chunked submission.
 - `--wait-timeout <seconds>`: maximum seconds to poll for selector-based elements before failing (0 = no waiting, default).


### PR DESCRIPTION
## Problem

`sim-use ios batch --ax-cache perBatch|perStep|none` was a complete no-op:

- `BatchContext.accessibilityRoots(logger:forceRefresh:)` had **zero callers** — the only place `axCachePolicy` was read was inside that dead method, whose `.perStep` and `.none` case bodies were byte-identical anyway, and `forceRefresh` was never passed `true`.
- Selector-based tap steps resolved through `AccessibilityPoller.resolveWithPolling`, which called `AccessibilityFetcher.fetchAccessibilityElements` directly — a fresh full-tree fetch on every step, cache never consulted.

So the documented default (`perBatch` "reuses one AX snapshot for the whole run") silently behaved like `none`, paying a full AX tree fetch per selector step.

## Fix

Wire the cache in with the semantics the docs and the E2E tests already promise:

| Policy | Behaviour |
|---|---|
| `perBatch` (default) | One snapshot fetched at first use, reused across all steps. `forceRefresh` refetches **and replaces** the cache. |
| `perStep` | Snapshot cached within the current step only; the step loop calls the new `BatchContext.beginStep()` at each boundary to drop it. |
| `none` | Fetches on every resolution, never caches (differs from `perStep` only when one step resolves multiple selectors). |
| `--wait-timeout` polling | Initial attempt respects the cache; every poll tick passes `forceRefresh: true`, so delayed elements are found under any policy and the refreshed snapshot propagates to later `perBatch` steps. |

Plumbing:

- `AccessibilityPoller.resolveWithPolling` gains an optional `rootsProvider: (_ forceRefresh: Bool) async throws -> [AccessibilityElement]`. Batch tap resolution passes the `BatchContext` cache through it; non-batch callers (`ios tap`, `paste --via-menu`) pass nothing and keep the historical fetch-every-time behaviour.
- `BatchContext` gains an injectable `fetchElements` fetcher (production default unchanged) so the policy semantics are unit-testable without a booted simulator.
- `--ax-cache` help text, README, and `skills/sim-use/references/batch-reference.md` clarified to match.

## Tests

New `Tests/BatchAXCacheTests.swift` (10 tests, fetch-counting fake fetcher, no simulator needed):

- `BatchContext`: perBatch caches across `beginStep()` (stale snapshot served, 1 fetch); `forceRefresh` refetches + updates cache; perStep clears at step boundary; `none` always fetches.
- Poller provider contract: called with `(false)` then `(true)` across a poll tick; single `(false)` attempt when `--wait-timeout 0`.
- Parser-level integration through `BatchStepParser.parseStepTokens`: two tap-by-label steps → 1 fetch under perBatch, 2 under perStep; unit mirrors of the E2E stale-snapshot-fails and delayed-element-found scenarios.

`make test`: 589 tests / 118 suites green (baseline before this change: 579 / 115).

Note: the SIM_USE_E2E-gated `BatchTests` (`perBatchCacheCanFailOnStateChange`, `perStepCacheHandlesStateChange`, `waitTimeoutFindsDelayedElement`) pin these exact semantics against a live UI; not run here — no booted simulator. The new unit tests mirror those scenarios with a fake fetcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
