### PR TITLE
Surface BGRA stream-video failures as non-zero exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Daemon client now retries a command once against the same daemon when the simulator reports the post-boot `transient_booting` readiness gap, matching the long-documented behaviour.
 - Bridge `/swipe` now accepts durations up to 10 s (previously silently clamped to 5 s), covering the full `--duration` range the CLI validates for long-press holds. Bridge `versionCode` bumped to 16.
 - `ios type` builds one HID session for the whole string instead of re-initialising FBSimulatorControl per character.
+- `ios stream-video --format` help now marks `bgra` as experimental (no frame count is reported for that format).
 
 ### Fixed
 
@@ -24,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Daemon no longer shuts itself down in the middle of a request that runs longer than the idle timeout (e.g. `tap --wait-timeout` beyond the timeout, or a long `batch`). The idle timer now defers shutdown while a request is in flight.
 - Daemon client no longer respawns and resends a command when the daemon drops the connection *after* receiving the request (a possible mid-execution crash). Such ambiguous outcomes now surface a dedicated error with a hint to re-observe the screen before retrying, so a side-effecting verb (tap/type/swipe) is never silently applied twice. Pre-delivery failures (connect/write) still respawn as before.
 - `keyboard-state` now routes through the per-UDID daemon like every other verb (amortised init) and surfaces crash advisories and error `Hint:` lines; a vestigial `run()` override had silently opted it out. The `soft`/`hidden`/failure exit codes are unchanged.
+- `ios stream-video` with the BGRA pixel format no longer exits 0 when the underlying stream fails to start or dies mid-stream; startup and mid-stream errors now terminate the streaming loop and surface as a non-zero exit instead of a stderr-only message.
 
 ## [0.9.0] - 2026-06-29
 

--- a/Sources/iOSSimBackend/Util/VideoCommandSupport.swift
+++ b/Sources/iOSSimBackend/Util/VideoCommandSupport.swift
@@ -36,6 +36,36 @@ public final class CancellationFlag: @unchecked Sendable {
     }
 }
 
+/// Thread-safe, set-once error capture for callback-based FBFutures.
+///
+/// The BGRA stream reports failures through `FBFuture` completion
+/// callbacks on a background queue with no continuation to resume —
+/// the stream runs until a signal arrives. The command loop polls this
+/// box instead, so the first failure terminates streaming and surfaces
+/// as a thrown error rather than being lost to stderr.
+public final class FirstErrorBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _error: Error?
+
+    public init() {}
+
+    /// Records `error` unless one is already recorded; later calls are no-ops.
+    public func set(_ error: Error) {
+        lock.lock()
+        defer { lock.unlock() }
+        if _error == nil {
+            _error = error
+        }
+    }
+
+    /// The first error recorded, or nil if none has been.
+    public var first: Error? {
+        lock.lock()
+        defer { lock.unlock() }
+        return _error
+    }
+}
+
 /// Sleep that wakes early when `flag` is cancelled.
 ///
 /// `Task.sleep` is not interruptible from a signal handler, so a vanilla

--- a/Sources/iOSSimBackend/Verbs/IOSSimStreamVideoCommand.swift
+++ b/Sources/iOSSimBackend/Verbs/IOSSimStreamVideoCommand.swift
@@ -42,7 +42,7 @@ public struct IOSSimStreamVideoCommand: SimUseExecutableCommand {
 
     @OptionGroup public var device: DeviceOptions
 
-    @Option(help: "Output format: mjpeg, raw, ffmpeg, bgra (default: mjpeg)")
+    @Option(help: "Output format: mjpeg, raw, ffmpeg, bgra (default: mjpeg; bgra is experimental: no frame count is reported)")
     public var format: OutputFormat = .mjpeg
 
     @Option(help: "Frames per second (1-30, default: 10)")
@@ -249,13 +249,30 @@ public struct IOSSimStreamVideoCommand: SimUseExecutableCommand {
             let videoStream = try await FutureBridge.value(videoStreamFuture)
             let startFuture = videoStream.startStreaming(stdoutConsumer)
 
+            // The private startStreaming future can resolve with an error at
+            // any point (attach failure during startup, or later), and the
+            // operation's `completed` future is the mid-stream termination
+            // channel. Neither has a continuation to resume — box the first
+            // error and let the wait loop below pick it up, so failures
+            // surface as a non-zero exit instead of a stderr line.
+            let streamError = FirstErrorBox()
             startFuture.onQueue(BridgeQueues.videoStreamQueue, notifyOfCompletion: { future in
                 if let error = future.error {
                     FileHandle.standardError.write(Data("Stream initialization error: \(error)\n".utf8))
+                    streamError.set(error)
+                }
+            })
+            videoStream.completed.onQueue(BridgeQueues.videoStreamQueue, notifyOfCompletion: { future in
+                if let error = future.error {
+                    FileHandle.standardError.write(Data("Stream terminated with error: \(error)\n".utf8))
+                    streamError.set(error)
                 }
             })
 
             try await Task.sleep(nanoseconds: 1_000_000_000)
+            if let error = streamError.first {
+                throw error
+            }
             FileHandle.standardError.write(Data("BGRA stream is now running...\n".utf8))
 
             while true {
@@ -265,7 +282,16 @@ public struct IOSSimStreamVideoCommand: SimUseExecutableCommand {
                 if cancellationFlag.isCancelled() {
                     break
                 }
+                if streamError.first != nil {
+                    break
+                }
                 try? await cancellableSleep(seconds: 0.1, flag: cancellationFlag)
+            }
+
+            // A dead stream cannot be stopped gracefully — stopStreaming on
+            // it fails with a secondary error that would mask the original.
+            if let error = streamError.first {
+                throw error
             }
 
             FileHandle.standardError.write(Data("\nStopping BGRA stream...\n".utf8))

--- a/Tests/FirstErrorBoxTests.swift
+++ b/Tests/FirstErrorBoxTests.swift
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+import Foundation
+import Testing
+@testable import iOSSimBackend
+
+/// Pins the semantics `streamBGRA` relies on: the box is empty until an
+/// error is set, the first error wins (later sets are no-ops), and
+/// concurrent sets from callback queues elect exactly one winner.
+@Suite("FirstErrorBox — set-once error capture")
+struct FirstErrorBoxTests {
+
+    private struct StubError: Error, Equatable {
+        let id: Int
+    }
+
+    @Test("Empty until an error is set")
+    func emptyBeforeSet() {
+        let box = FirstErrorBox()
+        #expect(box.first == nil)
+    }
+
+    @Test("Read after set returns the stored error")
+    func readAfterSet() {
+        let box = FirstErrorBox()
+        box.set(StubError(id: 1))
+        #expect(box.first as? StubError == StubError(id: 1))
+    }
+
+    @Test("First error wins; later sets are ignored")
+    func firstErrorWins() {
+        let box = FirstErrorBox()
+        box.set(StubError(id: 1))
+        box.set(StubError(id: 2))
+        #expect(box.first as? StubError == StubError(id: 1))
+    }
+
+    @Test("Concurrent sets elect exactly one stable winner")
+    func concurrentSetsSingleWinner() {
+        let box = FirstErrorBox()
+        DispatchQueue.concurrentPerform(iterations: 64) { index in
+            box.set(StubError(id: index))
+        }
+        let winner = box.first as? StubError
+        #expect(winner != nil)
+        // The value must not change once observed.
+        #expect(box.first as? StubError == winner)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes deferred review item D12: `ios stream-video --format bgra` could exit 0 having streamed nothing.

The BGRA path only wrote `startStreaming` failures to stderr from the `FBFuture` completion callback — the error was never thrown and never affected the exit code. Errors arriving after the 1-second startup window (mid-stream death) were ignored entirely.

## Changes

- **`FirstErrorBox`** (`Sources/iOSSimBackend/Util/VideoCommandSupport.swift`) — thread-safe, set-once error capture, placed next to `CancellationFlag` which it complements. The FB futures complete on a background queue with no continuation to resume; the command loop polls the box instead.
- **`streamBGRA`** (`Sources/iOSSimBackend/Verbs/IOSSimStreamVideoCommand.swift`) — boxes the first error from both the private `startStreaming` future (which per the idb source can resolve with an error at any point, not just during startup) and the operation's `completed` future (the mid-stream termination channel). The command now:
  - fails fast after the existing 1 s startup grace period if the start future already errored;
  - breaks out of the streaming wait loop when an error arrives later;
  - throws the boxed error *before* attempting the graceful stop — `stopStreaming` on a dead stream fails with a secondary error that would mask the original.
- **Help text** — `--format` now notes bgra is experimental and reports no frame count.
- **`Tests/FirstErrorBoxTests.swift`** — pins the box semantics: empty-until-set, read-after-set, first-error-wins, and concurrent sets electing exactly one stable winner.

Deliberately **not** changed (accepted rough edges per review): the fixed 1 s startup sleep, the never-closed stdout `FBFileWriter` (fd stays open by design with `closeOnEndOfFile: false`), and the hardcoded zero-frame `ExecutionResult` for BGRA — the experimental note in the help covers the missing summary.

## Testing

- `make build` + `make test`: 583 tests / 116 suites green (baseline 579/115 + 4 new).
- The streaming happy path and live failure injection need a booted simulator, which is not available in this environment — **no E2E verification was performed**. The error-propagation logic is exercised only through the `FirstErrorBox` unit tests; a manual spot-check of `ios stream-video --format bgra` against a live simulator is recommended before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
