### PR TITLE
Stop emitting legacy udid JSON key; deviceId is canonical (Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- JSON output no longer emits the legacy `udid` key (dual-emitted since the `deviceId` transition); `deviceId` is the canonical key in `devices --json`, `daemon stop/status --json`, and Viewer API responses. Inputs (daemon wire decode, Viewer API requests) still accept `udid` as a deprecated alias, to be removed in a future release.
 - Daemon client now retries a command once against the same daemon when the simulator reports the post-boot `transient_booting` readiness gap, matching the long-documented behaviour.
 - Bridge `/swipe` now accepts durations up to 10 s (previously silently clamped to 5 s), covering the full `--duration` range the CLI validates for long-press holds. Bridge `versionCode` bumped to 16.
 - `ios type` builds one HID session for the whole string instead of re-initialising FBSimulatorControl per character.

--- a/Sources/SimUse/Commands/Daemon.swift
+++ b/Sources/SimUse/Commands/Daemon.swift
@@ -122,8 +122,9 @@ struct Daemon: AsyncParsableCommand {
             /// Present when a per-daemon step failed but we still continued.
             let error: String?
 
-            /// New cross-platform synonym for `udid`. Drop the `udid`
-            /// key in Phase 2 once all consumers have migrated.
+            /// `deviceId` is the canonical wire key; `udid` is only
+            /// accepted on decode as a deprecated fallback (to be
+            /// removed in a future release).
             private enum CodingKeys: String, CodingKey {
                 case udid, deviceId, pid, method, stopped, error
             }
@@ -148,7 +149,6 @@ struct Daemon: AsyncParsableCommand {
 
             func encode(to encoder: Encoder) throws {
                 var c = encoder.container(keyedBy: CodingKeys.self)
-                try c.encode(udid, forKey: .udid)
                 try c.encode(udid, forKey: .deviceId)
                 try c.encode(pid, forKey: .pid)
                 try c.encode(method, forKey: .method)
@@ -307,8 +307,9 @@ struct Daemon: AsyncParsableCommand {
             let reachable: Bool
             let error: String?
 
-            /// Transitional dual-key for the device identifier. Drop the
-            /// `udid` key in Phase 2 once consumers have migrated.
+            /// `deviceId` is the canonical wire key; `udid` is only
+            /// accepted on decode as a deprecated fallback (to be
+            /// removed in a future release).
             private enum CodingKeys: String, CodingKey {
                 case udid, deviceId, pid, uptimeSeconds, simUseVersion, protocolVersion,
                      socketPath, logPath, reachable, error
@@ -352,7 +353,6 @@ struct Daemon: AsyncParsableCommand {
 
             func encode(to encoder: Encoder) throws {
                 var c = encoder.container(keyedBy: CodingKeys.self)
-                try c.encode(udid, forKey: .udid)
                 try c.encode(udid, forKey: .deviceId)
                 try c.encode(pid, forKey: .pid)
                 try c.encode(uptimeSeconds, forKey: .uptimeSeconds)

--- a/Sources/SimUse/Commands/Devices.swift
+++ b/Sources/SimUse/Commands/Devices.swift
@@ -33,7 +33,7 @@ struct Devices: SimUseExecutableCommand {
             "ok": true,
             "data": {
               "devices": [
-                {"deviceId": "...", "udid": "...",  // udid kept as deprecated alias of deviceId
+                {"deviceId": "...",
                  "name": "...", "platform": "ios|android",
                  "state": "Booted|Shutdown|device|offline|...", "runtime": "iOS 18.6|Android|..."},
                 ...

--- a/Sources/SimUse/Viewer/ViewerAPIHandlers.swift
+++ b/Sources/SimUse/Viewer/ViewerAPIHandlers.swift
@@ -39,14 +39,13 @@ struct ViewerAPIHandlers {
             let data = (envelope["data"] as? [String: Any]) ?? [:]
             let rawDevices = (data["devices"] as? [[String: Any]]) ?? []
             let simplified: [[String: Any]] = rawDevices.map { d in
-                // Prefer the new `deviceId` key; fall back to `udid`
-                // for compatibility with payloads emitted before the
-                // dual-key transition. Forward both keys downstream so
-                // legacy SPA clients keep working.
+                // Prefer the canonical `deviceId` key; fall back to
+                // `udid` for compatibility with payloads emitted before
+                // the dual-key transition. Only `deviceId` is forwarded
+                // downstream — the SPA reads that key exclusively.
                 let id = (d["deviceId"] as? String) ?? (d["udid"] as? String) ?? ""
                 var slim: [String: Any] = [:]
                 slim["deviceId"] = id
-                slim["udid"] = id
                 slim["name"] = d["name"] ?? ""
                 slim["platform"] = d["platform"] ?? ""
                 slim["runtime"] = d["runtime"] ?? ""
@@ -58,7 +57,7 @@ struct ViewerAPIHandlers {
         }
     }
 
-    // MARK: - GET /api/snapshot?udid=…
+    // MARK: - GET /api/snapshot?deviceId=…
 
     func snapshot(_ request: HTTPRequest) async -> HTTPResponse {
         // Accept either `deviceId` (new) or `udid` (deprecated alias) on
@@ -84,7 +83,6 @@ struct ViewerAPIHandlers {
                 "ok": true,
                 "capturedAt": iso8601Now(),
                 "deviceId": deviceId,
-                "udid": deviceId,
                 "outline": outline ?? "",
                 "entries": data["entries"] ?? [],
                 "lists": data["lists"] ?? [],

--- a/Sources/SimUseCore/Device.swift
+++ b/Sources/SimUseCore/Device.swift
@@ -16,10 +16,10 @@ import Foundation
 /// just want "can I act on this now?" should use `isUsable`, which
 /// applies the per-platform rule.
 public struct Device: Codable, Equatable, Hashable, Sendable {
-    /// Custom keys for transitional dual-key device-id encoding. The
-    /// `udid` key is the historic name; `deviceId` is the new
-    /// cross-platform synonym. Until Phase 2 drops `udid`, we emit
-    /// both and accept either on decode (preferring `deviceId`).
+    /// Custom keys for the device-id wire migration. `deviceId` is the
+    /// canonical cross-platform key and the only one emitted; `udid`
+    /// is the historic name, still accepted on decode as a deprecated
+    /// fallback (to be removed in a future release).
     private enum CodingKeys: String, CodingKey {
         case udid
         case deviceId
@@ -91,10 +91,6 @@ public struct Device: Codable, Equatable, Hashable, Sendable {
 
     public func encode(to encoder: Encoder) throws {
         var c = encoder.container(keyedBy: CodingKeys.self)
-        // Emit both keys during the transition. Drop `udid` in Phase 2
-        // once known consumers (Viewer, agent scripts, dashboards) all
-        // read `deviceId`.
-        try c.encode(udid, forKey: .udid)
         try c.encode(udid, forKey: .deviceId)
         try c.encode(name, forKey: .name)
         try c.encode(platform, forKey: .platform)

--- a/Tests/AndroidBackendTests/AndroidJSONEnvelopeTests.swift
+++ b/Tests/AndroidBackendTests/AndroidJSONEnvelopeTests.swift
@@ -113,7 +113,8 @@ final class AndroidJSONEnvelopeTests: XCTestCase {
         // shape on Android UDIDs.
         XCTAssertTrue(json.hasPrefix(#"{"data":{"devices":["#), json)
         XCTAssertTrue(json.hasSuffix(#"]},"ok":true}"#), json)
-        XCTAssertTrue(json.contains(#""udid":"emulator-5554""#), json)
+        XCTAssertTrue(json.contains(#""deviceId":"emulator-5554""#), json)
+        XCTAssertFalse(json.contains(#""udid""#), "legacy `udid` key must not be emitted: \(json)")
         XCTAssertTrue(json.contains(#""platform":"android""#), json)
     }
 }

--- a/Tests/DaemonProtocolTests.swift
+++ b/Tests/DaemonProtocolTests.swift
@@ -176,3 +176,81 @@ struct DaemonProtocolVersionTests {
         #expect(DaemonProtocol.version >= 1)
     }
 }
+
+// MARK: - daemon stop --json entry (device-id key Phase 2)
+
+@Suite("Daemon.Stop.StopEntry codable")
+struct DaemonStopEntryCodableTests {
+    @Test("Encoding emits deviceId and omits the legacy udid key")
+    func encodeEmitsDeviceIdOnly() throws {
+        let entry = Daemon.Stop.StopEntry(
+            udid: "UDID-1", pid: 42, method: "stop", stopped: true, error: nil
+        )
+        let text = jsonString(try encoderStable().encode(entry))
+        #expect(text == #"{"deviceId":"UDID-1","method":"stop","pid":42,"stopped":true}"#)
+        #expect(!text.contains(#""udid""#))
+    }
+
+    @Test("Decoding accepts legacy udid-only payloads")
+    func decodeLegacyUDIDOnly() throws {
+        let payload = #"{"udid":"legacy","pid":7,"method":"sigterm","stopped":false,"error":"boom"}"#
+        let entry = try JSONDecoder().decode(Daemon.Stop.StopEntry.self, from: Data(payload.utf8))
+        #expect(entry.udid == "legacy")
+        #expect(entry.pid == 7)
+        #expect(entry.method == "sigterm")
+        #expect(entry.stopped == false)
+        #expect(entry.error == "boom")
+    }
+
+    @Test("Decoding prefers deviceId when both keys are present")
+    func decodePrefersDeviceId() throws {
+        let payload = #"{"deviceId":"new","udid":"old","pid":1,"method":"none","stopped":true}"#
+        let entry = try JSONDecoder().decode(Daemon.Stop.StopEntry.self, from: Data(payload.utf8))
+        #expect(entry.udid == "new")
+    }
+}
+
+// MARK: - daemon status --json entry (device-id key Phase 2)
+
+@Suite("Daemon.Status.StatusEntry codable")
+struct DaemonStatusEntryCodableTests {
+    @Test("Encoding emits deviceId and omits the legacy udid key")
+    func encodeEmitsDeviceIdOnly() throws {
+        let entry = Daemon.Status.StatusEntry(
+            udid: "UDID-9",
+            pid: 9,
+            uptimeSeconds: 12.5,
+            simUseVersion: "1.0.0",
+            protocolVersion: 3,
+            socketPath: "/s",
+            logPath: "/l",
+            reachable: true,
+            error: nil
+        )
+        let text = jsonString(try encoderStable().encode(entry))
+        #expect(text == #"{"deviceId":"UDID-9","logPath":"/l","pid":9,"protocolVersion":3,"reachable":true,"simUseVersion":"1.0.0","socketPath":"/s","uptimeSeconds":12.5}"#)
+        #expect(!text.contains(#""udid""#))
+    }
+
+    @Test("Decoding accepts legacy udid-only payloads")
+    func decodeLegacyUDIDOnly() throws {
+        let payload = #"""
+        {"udid":"legacy","pid":3,"uptimeSeconds":0,"simUseVersion":"","protocolVersion":0,
+         "socketPath":"/sock","logPath":"/log","reachable":false,"error":"unreachable"}
+        """#
+        let entry = try JSONDecoder().decode(Daemon.Status.StatusEntry.self, from: Data(payload.utf8))
+        #expect(entry.udid == "legacy")
+        #expect(entry.reachable == false)
+        #expect(entry.error == "unreachable")
+    }
+
+    @Test("Decoding prefers deviceId when both keys are present")
+    func decodePrefersDeviceId() throws {
+        let payload = #"""
+        {"deviceId":"new","udid":"old","pid":3,"uptimeSeconds":1,"simUseVersion":"v",
+         "protocolVersion":1,"socketPath":"/sock","logPath":"/log","reachable":true}
+        """#
+        let entry = try JSONDecoder().decode(Daemon.Status.StatusEntry.self, from: Data(payload.utf8))
+        #expect(entry.udid == "new")
+    }
+}

--- a/Tests/SimUseCoreTests/DeviceModelTests.swift
+++ b/Tests/SimUseCoreTests/DeviceModelTests.swift
@@ -47,12 +47,13 @@ final class DeviceModelTests: XCTestCase {
         encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
         let json = String(data: try encoder.encode(d), encoding: .utf8)
         // Field order is sorted (sortedKeys); platform is the rawValue
-        // string, not an integer. `deviceId` is the new cross-platform
-        // synonym for `udid`; both keys are emitted with identical
-        // values during the deprecation window so existing Viewer / jq
-        // consumers keep working. Drop `udid` from this assertion in
-        // Phase 2 once it is removed from the wire.
-        XCTAssertEqual(json, #"{"deviceId":"u","name":"n","platform":"ios","runtime":"iOS 18.6","state":"Booted","udid":"u"}"#)
+        // string, not an integer. `deviceId` is the canonical wire key;
+        // the legacy `udid` key was dual-emitted during the deprecation
+        // window and is no longer written as of Phase 2. Decoding still
+        // accepts `udid`-only payloads (see testJSONAcceptsUDIDOnly).
+        XCTAssertEqual(json, #"{"deviceId":"u","name":"n","platform":"ios","runtime":"iOS 18.6","state":"Booted"}"#)
+        XCTAssertFalse(json?.contains(#""udid""#) ?? true,
+                       "legacy `udid` key must not be emitted, got: \(json ?? "nil")")
     }
 
     func testJSONAcceptsDeviceIdOnly() throws {

--- a/Tools/Viewer/README.md
+++ b/Tools/Viewer/README.md
@@ -38,7 +38,7 @@ make viewer        # or: scripts/build-viewer.sh
 ## API endpoints
 
 - `GET /api/devices` — list booted simulators and connected Android devices.
-- `GET /api/snapshot?udid=<UDID>` — `sim-use ui --json` → `{ screen, entries, outline, capturedAt }`.
+- `GET /api/snapshot?deviceId=<DEVICE_ID>` — `sim-use ui --json` → `{ screen, entries, outline, capturedAt }`. `udid=` is still accepted as a deprecated alias.
 - `POST /api/tap` — replay `sim-use tap @N` on the selected element.
 
 ## Controls

--- a/Tools/Viewer/src/App.tsx
+++ b/Tools/Viewer/src/App.tsx
@@ -5,7 +5,7 @@ import type { Device, Snapshot } from "./types";
 
 export default function App() {
   const [devices, setDevices] = useState<Device[]>([]);
-  const [udid, setUdid] = useState<string>("");
+  const [deviceId, setDeviceId] = useState<string>("");
   const [snapshot, setSnapshot] = useState<Snapshot | null>(null);
   const [selectedAt, setSelectedAt] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -24,9 +24,9 @@ export default function App() {
       const body = await res.json();
       if (!body.ok) throw new Error(body.error ?? "devices fetch failed");
       setDevices(body.devices as Device[]);
-      setUdid((current) => {
-        if (current && body.devices.some((d: Device) => d.udid === current)) return current;
-        return body.devices[0]?.udid ?? "";
+      setDeviceId((current) => {
+        if (current && body.devices.some((d: Device) => d.deviceId === current)) return current;
+        return body.devices[0]?.deviceId ?? "";
       });
     } catch (err) {
       setError(String((err as Error).message));
@@ -34,13 +34,13 @@ export default function App() {
   }, []);
 
   const fetchSnapshot = useCallback(async () => {
-    if (!udid) return;
+    if (!deviceId) return;
     abortRef.current?.abort();
     const controller = new AbortController();
     abortRef.current = controller;
     setError(null);
     try {
-      const res = await fetch(`/api/snapshot?udid=${encodeURIComponent(udid)}`, {
+      const res = await fetch(`/api/snapshot?deviceId=${encodeURIComponent(deviceId)}`, {
         signal: controller.signal,
       });
       const body = await res.json();
@@ -50,7 +50,7 @@ export default function App() {
       if ((err as Error).name === "AbortError") return;
       setError(String((err as Error).message));
     }
-  }, [udid]);
+  }, [deviceId]);
 
   useEffect(() => {
     refreshDevices();
@@ -59,7 +59,7 @@ export default function App() {
   // Changing simulators invalidates any prior tap feedback.
   useEffect(() => {
     setTapStatus(null);
-  }, [udid]);
+  }, [deviceId]);
 
   // Sequential sampler: each tick awaits the previous fetch before
   // scheduling the next, so a single describe-ui that takes longer than
@@ -88,29 +88,29 @@ export default function App() {
       setPlaying(false);
       return;
     }
-    if (!udid) return;
+    if (!deviceId) return;
     setPlaying(true);
     // Fire the first shot immediately so the canvas isn't blank until
     // the first interval tick lands (which on 5s feels like forever).
     fetchSnapshot();
-  }, [playing, udid, fetchSnapshot]);
+  }, [playing, deviceId, fetchSnapshot]);
 
   // Switching simulators or clearing the selected UDID must stop the
   // sampler — the in-flight fetch targets the old UDID and the new one
   // hasn't been primed yet.
   useEffect(() => {
-    if (!udid) setPlaying(false);
-  }, [udid]);
+    if (!deviceId) setPlaying(false);
+  }, [deviceId]);
 
   const tapSelected = useCallback(async () => {
-    if (!udid || selectedAt == null) return;
+    if (!deviceId || selectedAt == null) return;
     setTapping(true);
     setTapStatus(null);
     try {
       const res = await fetch("/api/tap", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ udid, at: selectedAt }),
+        body: JSON.stringify({ deviceId, at: selectedAt }),
       });
       const body = await res.json();
       if (!body.ok) throw new Error(body.error ?? "tap failed");
@@ -127,7 +127,7 @@ export default function App() {
     } finally {
       setTapping(false);
     }
-  }, [udid, selectedAt, fetchSnapshot]);
+  }, [deviceId, selectedAt, fetchSnapshot]);
 
   // matchIds is null when no filter is active — downstream components
   // treat null as "everything passes" which keeps the default-happy path
@@ -220,9 +220,9 @@ export default function App() {
           <label>
             Device
             <select
-              value={udid}
+              value={deviceId}
               onChange={(e) => {
-                setUdid(e.target.value);
+                setDeviceId(e.target.value);
                 setSnapshot(null);
                 setSelectedAt(null);
                 setPlaying(false);
@@ -240,10 +240,10 @@ export default function App() {
                 // code's `?:` did that).
                 const isIos = d.platform === "ios";
                 const isAndroid = d.platform === "android";
-                const shortId = isIos ? d.udid.slice(0, 8) : d.udid;
+                const shortId = isIos ? d.deviceId.slice(0, 8) : d.deviceId;
                 const tag = isIos ? "iOS" : isAndroid ? "Android" : d.platform;
                 return (
-                  <option key={d.udid} value={d.udid}>
+                  <option key={d.deviceId} value={d.deviceId}>
                     [{tag}] {d.name} — {shortId}
                   </option>
                 );
@@ -259,7 +259,7 @@ export default function App() {
           <button
             className={`primary play-button ${playing ? "stop" : ""}`}
             onClick={togglePlay}
-            disabled={!udid}
+            disabled={!deviceId}
             title={playing ? "Stop sampling" : `Start sampling every ${intervalMs / 1000}s`}
           >
             {playing ? (
@@ -346,7 +346,7 @@ export default function App() {
             />
           ) : (
             <div className="placeholder">
-              {udid
+              {deviceId
                 ? "No snapshot yet. Click ▶ Play to start sampling."
                 : "Boot a simulator or attach an Android device, then select it above."}
             </div>

--- a/Tools/Viewer/src/Details.tsx
+++ b/Tools/Viewer/src/Details.tsx
@@ -83,7 +83,7 @@ export default function Details({
                 title="Copy CLI command"
                 onClick={() =>
                   navigator.clipboard?.writeText(
-                    `sim-use tap @${selected.aliases.at} --udid ${snapshot.udid}`,
+                    `sim-use tap @${selected.aliases.at} --device ${snapshot.deviceId}`,
                   )
                 }
               >

--- a/Tools/Viewer/src/types.ts
+++ b/Tools/Viewer/src/types.ts
@@ -60,7 +60,7 @@ export interface Screen {
 
 export interface Snapshot {
   capturedAt: string;
-  udid: string;
+  deviceId: string;
   /// `"ios"` and `"android"` are the only values sim-use emits
   /// today; treat anything else as a forward-compat hint and
   /// fall back to iOS-style rendering in the UI (the geometric
@@ -74,7 +74,7 @@ export interface Snapshot {
 }
 
 export interface Device {
-  udid: string;
+  deviceId: string;
   name: string;
   // Widened to allow future platforms (web, etc.); the strict
   // union was forcing every consumer to `unknown`-cast on

--- a/skills/sim-use/scripts/preflight.py
+++ b/skills/sim-use/scripts/preflight.py
@@ -108,17 +108,19 @@ def check_device_listed(ctx: Ctx) -> bool:
     if not ctx.device:
         booted = [d for d in devices if d.get("state", "").lower() in ("booted", "device")]
         if len(booted) == 1:
-            ctx.device = booted[0].get("udid") or booted[0].get("deviceId")
+            ctx.device = booted[0].get("deviceId") or booted[0].get("udid")
             ctx.platform = booted[0].get("platform")
             return True
         if len(booted) > 1:
-            names = [f"{d.get('name')} ({d.get('udid') or d.get('deviceId')})" for d in booted]
+            names = [f"{d.get('name')} ({d.get('deviceId') or d.get('udid')})" for d in booted]
             print(f"        Multiple devices found: {', '.join(names)}")
             print("        Re-run with --device <UDID> to pick one.")
         return False
 
     for d in devices:
-        did = d.get("udid") or d.get("deviceId", "")
+        # `deviceId` is the canonical key; `udid` covers older sim-use
+        # binaries that predate the rename.
+        did = d.get("deviceId") or d.get("udid", "")
         if did == ctx.device:
             ctx.platform = d.get("platform")
             return True


### PR DESCRIPTION
## Summary

Phase 2 of the `udid` → `deviceId` wire-key migration (deferred review item D17). Phase 1 dual-emitted both keys and taught decoders to prefer `deviceId`; this PR stops emitting the legacy `udid` key everywhere while keeping decode-side compatibility for one more release. Owner confirmed no external consumers need the legacy key.

## Emit sites removed (`udid` no longer written)

- `Sources/SimUseCore/Device.swift` — `Device.encode` (`devices --json` rows, iOS + Android)
- `Sources/SimUse/Commands/Daemon.swift` — `Stop.StopEntry.encode` (`daemon stop --json`)
- `Sources/SimUse/Commands/Daemon.swift` — `Status.StatusEntry.encode` (`daemon status --json`)
- `Sources/SimUse/Viewer/ViewerAPIHandlers.swift` — `GET /api/devices` response rows (`slim["udid"]`)
- `Sources/SimUse/Viewer/ViewerAPIHandlers.swift` — `GET /api/snapshot` response payload (`"udid"` field)
- `Sources/SimUse/Commands/Devices.swift` — `--json` help example updated to the new shape

## Fallbacks kept (deprecated, removal in a future release)

- `Device.init(from:)` — accepts `udid`-only payloads, prefers `deviceId`
- `StopEntry.init(from:)` / `StatusEntry.init(from:)` — same fallback order
- Viewer requests — `GET /api/snapshot?udid=…` query param and `POST /api/tap` `{"udid": …}` body still accepted as aliases of `deviceId`
- `--udid` CLI flags are untouched (separate deprecation track)

## Viewer SPA

The SPA read `.udid` from API responses, so it needed changes: `Tools/Viewer/src/{types.ts,App.tsx,Details.tsx}` now read `deviceId` and send `deviceId` in requests; the copy-command hint uses `--device`. Validated with `tsc -b`. The bundled dist is gitignored — regenerated by `make viewer` / release pipeline as usual. `Tools/Viewer/README.md` API docs updated.

## Skill script

`skills/sim-use/scripts/preflight.py` flips key preference to `deviceId` first, `udid` fallback for older sim-use binaries.

## Out of scope (verified, intentionally untouched)

- `DeviceResolver` / `SimctlDeviceLister` — parse simctl's own output
- `DaemonPingData.udid` — internal `_ping` daemon wire, never dual-keyed in Phase 1; both ends are in-process sim-use

## Tests

TDD: encode tests assert `deviceId` present and `udid` absent (exact-JSON match); decode tests assert legacy `udid`-only payloads still decode and `deviceId` wins when both keys are present.

- Updated: `Tests/SimUseCoreTests/DeviceModelTests.swift`, `Tests/AndroidBackendTests/AndroidJSONEnvelopeTests.swift`
- Added: `Daemon.Stop.StopEntry` / `Daemon.Status.StatusEntry` codable suites in `Tests/DaemonProtocolTests.swift`

`make test`: **585 tests / 117 suites passed** (baseline 579/115). Spot-checked live: `devices --json` and `daemon status --json` emit `deviceId` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
