### PR TITLE
fix: gate cached HID connection reuse on simulator boot identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Cached HID connection is now validated against the simulator's boot instance before reuse, so a simulator shut down and re-booted under the same UDID gets a fresh connection instead of hanging the daemon (or failing every command) on the dead one until restart. Additionally, any failed HID perform drops the cached connection, and failures that provably happened before delivery (dead mach port) are transparently retried once against a rebuilt session.
 - Daemon client no longer tears down a healthy daemon and re-executes the command when the daemon answers with a command-level error (element not found, etc.). Failed commands now surface immediately instead of paying a full daemon respawn, and side-effecting commands are no longer executed twice.
 - Daemon shutdown no longer deletes the socket/pidfile of a successor daemon that took the paths over, which previously chained invisible orphan daemons.
 - Daemon base directory under `/tmp` is now validated on every run (symlinks, foreign owners rejected; loose permissions tightened to 0700) instead of trusting whatever was pre-created there.

--- a/Sources/iOSSimBackend/HID/HIDBootIdentity.swift
+++ b/Sources/iOSSimBackend/HID/HIDBootIdentity.swift
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+import Foundation
+
+/// Boot-instance identity for the per-UDID HID connection cache.
+///
+/// A cached `FBSimulatorHID` is only usable against the boot it was
+/// created for: its mach port dies with `launchd_sim`. A simulator that
+/// is shut down and re-booted under the same UDID still passes
+/// `makeSession`'s `state == .booted` re-check, and on current
+/// SimulatorKit a send through the dead port never invokes its
+/// completion (observed live on Xcode 26.5 / iOS 26.2), so the failure
+/// cannot even be caught after the fact — reuse has to be gated before
+/// anything is sent.
+///
+/// The token is the modification date of
+/// `<dataDirectory>/var/run/launchd_bootstrap.plist`, which
+/// CoreSimulator rewrites on every boot. Reading it is a single stat —
+/// cheap enough to run on every cache hit — and needs no private API
+/// (`FBSimulator.dataDirectory` is public surface).
+enum HIDBootIdentity {
+
+    /// Whether a cached connection may be reused. Unknown tokens fail
+    /// closed: rebuilding the connection costs milliseconds, while
+    /// reusing a dead one hangs the daemon until restart.
+    static func isReusable(cachedToken: Date?, currentToken: Date?) -> Bool {
+        guard let cachedToken, let currentToken else { return false }
+        return cachedToken == currentToken
+    }
+
+    /// The current boot token for a simulator, or nil when the marker
+    /// (or the data directory itself) is unavailable.
+    static func token(dataDirectory: String?) -> Date? {
+        guard let dataDirectory else { return nil }
+        let markerPath = URL(fileURLWithPath: dataDirectory)
+            .appendingPathComponent("var/run/launchd_bootstrap.plist")
+            .path
+        let attributes = try? FileManager.default.attributesOfItem(atPath: markerPath)
+        return attributes?[.modificationDate] as? Date
+    }
+}

--- a/Sources/iOSSimBackend/HID/HIDInteractor.swift
+++ b/Sources/iOSSimBackend/HID/HIDInteractor.swift
@@ -14,8 +14,17 @@ public struct HIDInteractor {
         public let hid: FBSimulatorHID
     }
 
-    // Cache for HID connections per simulator
-    private static var hidConnections: [String: FBSimulatorHID] = [:]
+    // Cache for HID connections per simulator. Each entry carries the
+    // boot token it was created against (see HIDBootIdentity): the
+    // connection's mach port dies with that boot, and a send through a
+    // dead port hangs on current SimulatorKit, so reuse must be gated
+    // on the token before anything is sent.
+    private struct CachedConnection {
+        let hid: FBSimulatorHID
+        let bootToken: Date?
+    }
+
+    private static var hidConnections: [String: CachedConnection] = [:]
 
     /// Configurable stabilization delay to ensure HID events are fully processed
     /// Can be set via SIM_USE_HID_STABILIZATION_MS environment variable
@@ -61,6 +70,31 @@ public struct HIDInteractor {
     }
 
     public static func performHIDEvent(_ event: FBSimulatorHIDEvent, in session: Session, logger: SimUseLogger) async throws {
+        do {
+            try await performHIDEventOnce(event, in: session, logger: logger)
+        } catch {
+            // Fail-invalidate + cautious retry-once: see HIDPerformRecovery
+            // for the decision rules and why only dead-transport errors
+            // are safe to re-perform.
+            try await HIDPerformRecovery.recover(from: error, invalidate: {
+                logger.error().log("HID event failed (\(error.localizedDescription)); dropping cached HID connection for \(session.simulatorUDID)")
+                clearHIDConnection(for: session.simulatorUDID)
+            }, rebuildAndRetry: {
+                logger.info().log("Dead HID transport for \(session.simulatorUDID); rebuilding session and retrying once...")
+                let freshSession = try await makeSession(for: session.simulatorUDID, logger: logger)
+                do {
+                    try await performHIDEventOnce(event, in: freshSession, logger: logger)
+                } catch {
+                    // Keep the "a failed perform never leaves its
+                    // connection cached" invariant on the retry path too.
+                    clearHIDConnection(for: session.simulatorUDID)
+                    throw error
+                }
+            })
+        }
+    }
+
+    private static func performHIDEventOnce(_ event: FBSimulatorHIDEvent, in session: Session, logger: SimUseLogger) async throws {
         logger.info().log("Performing HID event...")
         let eventFuture = event.perform(on: session.hid)
         _ = try await FutureBridge.value(eventFuture)
@@ -79,16 +113,24 @@ public struct HIDInteractor {
 
     // Get or create a cached HID connection (matching CompanionLib's connectToHID behavior)
     private static func getOrCreateHIDConnection(for simulator: FBSimulator, logger: SimUseLogger) async throws -> FBSimulatorHID {
-        if let existingHID = hidConnections[simulator.udid] {
-            logger.info().log("Using existing HID connection for simulator \(simulator.udid)")
-            return existingHID
+        let currentToken = HIDBootIdentity.token(dataDirectory: simulator.dataDirectory)
+        if let cached = hidConnections[simulator.udid] {
+            if HIDBootIdentity.isReusable(cachedToken: cached.bootToken, currentToken: currentToken) {
+                logger.info().log("Using existing HID connection for simulator \(simulator.udid)")
+                return cached.hid
+            }
+            // The simulator was re-booted (or the boot marker is
+            // unreadable) since the connection was made: the cached
+            // handle's mach port is dead and must not be sent through.
+            logger.info().log("Boot token changed for simulator \(simulator.udid); discarding cached HID connection")
+            hidConnections.removeValue(forKey: simulator.udid)
         }
 
         logger.info().log("Creating new HID connection for simulator \(simulator.udid)...")
         let hidFuture = simulator.connectToHID()
         let hid = try await FutureBridge.value(hidFuture)
 
-        hidConnections[simulator.udid] = hid
+        hidConnections[simulator.udid] = CachedConnection(hid: hid, bootToken: currentToken)
         logger.info().log("HID connection created and cached for simulator \(simulator.udid)")
 
         return hid

--- a/Sources/iOSSimBackend/HID/HIDPerformRecovery.swift
+++ b/Sources/iOSSimBackend/HID/HIDPerformRecovery.swift
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+import Foundation
+
+/// Recovery decision for a failed `FBSimulatorHIDEvent` perform.
+///
+/// A simulator that is shut down and re-booted under the same UDID
+/// passes `makeSession`'s `state == .booted` re-check, so the cached
+/// `FBSimulatorHID` — whose mach port belongs to the previous boot —
+/// is handed back and every perform fails. The daemon's stale-simulator
+/// cleanup never fires for these failures (the message doesn't match
+/// `DaemonErrorKind.isStaleSimulatorMessage`), which used to poison the
+/// UDID until the daemon restarted.
+///
+/// Every perform failure therefore invalidates the cached connection:
+/// that is cheap and safe, because the next command rebuilds it. The
+/// retry decision is stricter. `FBSimulatorHIDEvent` composites (tap,
+/// swipe, type) deliver one mach message per sub-event and short-circuit
+/// on the first failure, so a blind re-perform could double-apply
+/// sub-events that were already delivered. Retry is gated on
+/// dead-transport errors only, where delivery to the currently-booted
+/// simulator instance provably never happened:
+///
+/// - `mach_msg_send` returning `MACH_SEND_INVALID_DEST` means the kernel
+///   refused the message — the port died with the previous boot and the
+///   failing sub-event reached nothing. Earlier sub-events of the same
+///   composite either failed the same way (port dead from the start,
+///   the reboot-window case) or were delivered to the *previous* boot,
+///   which is gone; re-performing against the current boot cannot
+///   double-apply on any live UI. SimulatorKit's
+///   `SimDeviceLegacyHIDClient.HIDError` renders this case as
+///   "Mach port invalid, device disconnected" (verified against the
+///   Xcode 26.x binary).
+/// - A client that never obtained its HID event port renders as
+///   "Mach port not connected, device may not be ready yet"; nothing
+///   was ever sent through it.
+/// - FBSimulatorControl's own "Cannot Connect, HID client has already
+///   been disposed of" is emitted before any send by construction.
+///
+/// Every other message — including SimulatorKit's generic
+/// "Mach return error <code>" (e.g. a send timeout that can hit the
+/// middle of a composite while earlier touches were delivered) — gets
+/// `invalidateOnly`: the current command fails, the next one self-heals
+/// against a fresh connection.
+public enum HIDPerformRecovery: Equatable {
+    case invalidateAndRetry
+    case invalidateOnly
+
+    /// Message fragments that prove the failing event never reached the
+    /// currently-booted simulator instance. Sources: SimulatorKit's
+    /// `SimDeviceLegacyHIDClient.HIDError` descriptions,
+    /// FBSimulatorControl's `FBSimulatorHID.connect`, and
+    /// `mach_error_string(MACH_SEND_INVALID_DEST)` for wrappers that
+    /// render the raw kern_return_t.
+    private static let deadTransportMarkers = [
+        "Mach port invalid",
+        "Mach port not connected",
+        "has already been disposed",
+        "invalid destination port",
+    ]
+
+    public static func classify(_ error: Error) -> HIDPerformRecovery {
+        classify(message: error.localizedDescription)
+    }
+
+    public static func classify(message: String) -> HIDPerformRecovery {
+        for marker in deadTransportMarkers where message.contains(marker) {
+            return .invalidateAndRetry
+        }
+        return .invalidateOnly
+    }
+
+    /// Applies the recovery decision for a failed perform. `invalidate`
+    /// always runs first so the rebuild path cannot observe the dead
+    /// cache entry; `rebuildAndRetry` runs at most once and its error —
+    /// fresher than the original (e.g. "is not booted. Current state"
+    /// when the simulator went away for good, which the daemon
+    /// classifies as stale) — is the one propagated.
+    ///
+    /// Injected closures keep the FB* types out of unit tests;
+    /// `HIDInteractor.performHIDEvent` binds them to
+    /// `clearHIDConnection(for:)` and a `makeSession` rebuild.
+    @MainActor
+    public static func recover(
+        from error: Error,
+        invalidate: () -> Void,
+        rebuildAndRetry: () async throws -> Void
+    ) async throws {
+        invalidate()
+        guard classify(error) == .invalidateAndRetry else {
+            throw error
+        }
+        try await rebuildAndRetry()
+    }
+}

--- a/Tests/HIDBootIdentityTests.swift
+++ b/Tests/HIDBootIdentityTests.swift
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+@testable import iOSSimBackend
+import Foundation
+import Testing
+
+// The HID connection cache is only valid for the boot instance it was
+// created against: a simulator shut down and re-booted under the same
+// UDID passes the `state == .booted` re-check while the cached mach
+// port is dead — and on current SimulatorKit the send against it never
+// completes (observed live on Xcode 26.5 / iOS 26.2: the perform hangs,
+// so no error ever reaches the failure-classification path).
+//
+// `HIDBootIdentity` therefore gates cache reuse on a boot token: the
+// mtime of `<dataDirectory>/var/run/launchd_bootstrap.plist`, which
+// CoreSimulator rewrites on every boot. Pure decision + filesystem
+// probe are tested here without FB* types.
+
+@Suite("HIDBootIdentity.isReusable")
+struct HIDBootIdentityReusableTests {
+    private let bootA = Date(timeIntervalSince1970: 1_782_991_697)
+    private let bootB = Date(timeIntervalSince1970: 1_782_995_000)
+
+    @Test("Same token on both sides allows reuse")
+    func sameTokenReuses() {
+        #expect(HIDBootIdentity.isReusable(cachedToken: bootA, currentToken: bootA))
+    }
+
+    @Test("A changed token (reboot) rejects reuse")
+    func changedTokenRejects() {
+        #expect(!HIDBootIdentity.isReusable(cachedToken: bootA, currentToken: bootB))
+    }
+
+    @Test("Unknown tokens reject reuse: rebuilding is cheap, a dead port hangs")
+    func unknownTokensReject() {
+        // If the marker cannot be read on either side we cannot prove
+        // the boot is the same one the connection was created against.
+        // Failing closed costs one rebuild (~ms); failing open risks an
+        // unrecoverable hang on a dead mach port.
+        #expect(!HIDBootIdentity.isReusable(cachedToken: nil, currentToken: bootA))
+        #expect(!HIDBootIdentity.isReusable(cachedToken: bootA, currentToken: nil))
+        #expect(!HIDBootIdentity.isReusable(cachedToken: nil, currentToken: nil))
+    }
+}
+
+@Suite("HIDBootIdentity.token")
+struct HIDBootIdentityTokenTests {
+
+    private func makeTempDataDirectory() throws -> URL {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("HIDBootIdentityTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("var/run"),
+            withIntermediateDirectories: true
+        )
+        return root
+    }
+
+    @Test("Token is the boot marker's modification date")
+    func tokenReadsMarkerMtime() throws {
+        let dataDirectory = try makeTempDataDirectory()
+        defer { try? FileManager.default.removeItem(at: dataDirectory) }
+        let marker = dataDirectory.appendingPathComponent("var/run/launchd_bootstrap.plist")
+        FileManager.default.createFile(atPath: marker.path, contents: Data("boot".utf8))
+
+        let token = HIDBootIdentity.token(dataDirectory: dataDirectory.path)
+        let expected = try FileManager.default
+            .attributesOfItem(atPath: marker.path)[.modificationDate] as? Date
+        #expect(token != nil)
+        #expect(token == expected)
+    }
+
+    @Test("Rewriting the marker (a new boot) changes the token")
+    func rewrittenMarkerChangesToken() throws {
+        let dataDirectory = try makeTempDataDirectory()
+        defer { try? FileManager.default.removeItem(at: dataDirectory) }
+        let marker = dataDirectory.appendingPathComponent("var/run/launchd_bootstrap.plist")
+        FileManager.default.createFile(atPath: marker.path, contents: Data("boot-1".utf8))
+        let first = HIDBootIdentity.token(dataDirectory: dataDirectory.path)
+
+        // Simulate the next boot rewriting the marker some time later.
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date().addingTimeInterval(60)],
+            ofItemAtPath: marker.path
+        )
+        let second = HIDBootIdentity.token(dataDirectory: dataDirectory.path)
+
+        #expect(first != nil)
+        #expect(second != nil)
+        #expect(first != second)
+    }
+
+    @Test("Missing marker file yields nil")
+    func missingMarkerIsNil() throws {
+        let dataDirectory = try makeTempDataDirectory()
+        defer { try? FileManager.default.removeItem(at: dataDirectory) }
+        #expect(HIDBootIdentity.token(dataDirectory: dataDirectory.path) == nil)
+    }
+
+    @Test("Nil data directory yields nil")
+    func nilDataDirectoryIsNil() {
+        #expect(HIDBootIdentity.token(dataDirectory: nil) == nil)
+    }
+}

--- a/Tests/HIDPerformRecoveryTests.swift
+++ b/Tests/HIDPerformRecoveryTests.swift
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+@testable import iOSSimBackend
+import Foundation
+import Testing
+
+// Coverage for the rebooted-simulator HID cache poisoning fix: a
+// simulator shut down and re-booted under the same UDID passes
+// `makeSession`'s `state == .booted` re-check, so the daemon reuses
+// the cached `FBSimulatorHID` whose mach port belongs to the previous
+// boot. The resulting perform failure did not match
+// `DaemonErrorKind.isStaleSimulatorMessage`, so the stale cleanup
+// never fired and the UDID stayed broken until daemon restart.
+//
+// The fix is fail-invalidate + cautious retry-once, decided by
+// `HIDPerformRecovery`. FB* types cannot be constructed in unit
+// tests, so the decision logic is a pure classifier over the error
+// message and the orchestration takes injected closures; these tests
+// cover both. `HIDInteractor.performHIDEvent` wires the closures to
+// `clearHIDConnection(for:)` and a `makeSession` rebuild.
+
+// MARK: - Fixtures
+
+private struct MessageError: LocalizedError {
+    let errorDescription: String?
+    init(_ message: String) { self.errorDescription = message }
+}
+
+// MARK: - Classification rules
+
+@Suite("HIDPerformRecovery.classify")
+struct HIDPerformRecoveryClassifyTests {
+
+    // Dead-transport errors: the kernel refused (or could not accept)
+    // the Indigo message, so nothing reached the currently-booted
+    // simulator instance. Rebuilding the session and re-performing
+    // cannot double-apply the event.
+
+    @Test("SimulatorKit MACH_SEND_INVALID_DEST wording maps to invalidateAndRetry")
+    func machPortInvalid() {
+        // SimDeviceLegacyHIDClient.HIDError when mach_msg_send returns
+        // MACH_SEND_INVALID_DEST — the exact signature of a cached HID
+        // handle whose port died with the previous boot.
+        let error = MessageError("Mach port invalid, device disconnected")
+        #expect(HIDPerformRecovery.classify(error) == .invalidateAndRetry)
+    }
+
+    @Test("SimulatorKit nil-port wording maps to invalidateAndRetry")
+    func machPortNotConnected() {
+        // SimDeviceLegacyHIDClient.HIDError when the client never
+        // obtained a legacy HID event port: no event was ever sent
+        // through this client.
+        let error = MessageError("Mach port not connected, device may not be ready yet")
+        #expect(HIDPerformRecovery.classify(error) == .invalidateAndRetry)
+    }
+
+    @Test("FBSimulatorControl disposed-client wording maps to invalidateAndRetry")
+    func disposedClient() {
+        // FBSimulatorHID.connect after disconnect; emitted before any
+        // send, so a retry is safe by construction.
+        let error = MessageError("Cannot Connect, HID client has already been disposed of")
+        #expect(HIDPerformRecovery.classify(error) == .invalidateAndRetry)
+    }
+
+    @Test("mach_error_string wording for a dead destination maps to invalidateAndRetry")
+    func machErrorString() {
+        // Defensive: some wrappers render kern_return_t via
+        // mach_error_string, which yields this text for
+        // MACH_SEND_INVALID_DEST.
+        let error = MessageError("(ipc/send) invalid destination port")
+        #expect(HIDPerformRecovery.classify(error) == .invalidateAndRetry)
+    }
+
+    @Test("Substring match is enough; surrounding text is fine")
+    func substringMatch() {
+        let error = MessageError("Error Domain=... {Mach port invalid, device disconnected}")
+        #expect(HIDPerformRecovery.classify(error) == .invalidateAndRetry)
+    }
+
+    // Everything else: the transport may have been alive when earlier
+    // sub-events of a composite gesture were delivered, so a blind
+    // re-perform could double-apply them. Invalidate only.
+
+    @Test("Generic mach send failures map to invalidateOnly")
+    func genericMachReturn() {
+        // SimulatorKit renders every kern_return_t other than
+        // MACH_SEND_INVALID_DEST as "Mach return error <code>"; e.g. a
+        // send timeout can hit an event in the middle of a composite
+        // gesture whose earlier touches were already delivered.
+        let error = MessageError("Mach return error 268435460")
+        #expect(HIDPerformRecovery.classify(error) == .invalidateOnly)
+    }
+
+    @Test("Semantic HID failures map to invalidateOnly")
+    func semanticFailures() {
+        #expect(HIDPerformRecovery.classify(
+            MessageError("MessageForMouseNSEvent returned nil for multi-touch event")) == .invalidateOnly)
+        #expect(HIDPerformRecovery.classify(
+            MessageError("Failed to allocate IndigoHIDMessage")) == .invalidateOnly)
+    }
+
+    @Test("Unrelated and empty messages map to invalidateOnly")
+    func unrelatedFallsBack() {
+        #expect(HIDPerformRecovery.classify(MessageError("Something else entirely")) == .invalidateOnly)
+        #expect(HIDPerformRecovery.classify(MessageError("")) == .invalidateOnly)
+    }
+}
+
+// MARK: - Recovery orchestration
+
+@Suite("HIDPerformRecovery.recover")
+@MainActor
+struct HIDPerformRecoveryRecoverTests {
+
+    @Test("Dead-transport failure invalidates, then retries once; success is swallowed")
+    func deadTransportRetries() async throws {
+        var calls: [String] = []
+        try await HIDPerformRecovery.recover(
+            from: MessageError("Mach port invalid, device disconnected"),
+            invalidate: { calls.append("invalidate") },
+            rebuildAndRetry: { calls.append("retry") }
+        )
+        // Invalidation must precede the retry: the rebuild path goes
+        // through the connection cache and must not see the dead entry.
+        #expect(calls == ["invalidate", "retry"])
+    }
+
+    @Test("Non-retryable failure invalidates and rethrows the original error; no retry")
+    func otherInvalidatesOnly() async {
+        var calls: [String] = []
+        let original = MessageError("Mach return error 268435460")
+        await #expect {
+            try await HIDPerformRecovery.recover(
+                from: original,
+                invalidate: { calls.append("invalidate") },
+                rebuildAndRetry: { calls.append("retry") }
+            )
+        } throws: { error in
+            error.localizedDescription == original.localizedDescription
+        }
+        #expect(calls == ["invalidate"])
+    }
+
+    @Test("A failing retry propagates the retry error, not the original")
+    func retryFailurePropagates() async {
+        // The fresher error matters downstream: if the simulator went
+        // away between invalidation and the retry, the rebuild fails
+        // with "not found in set" / "is not booted. Current state",
+        // which the daemon classifies as staleSimulator and uses to
+        // self-terminate.
+        var calls: [String] = []
+        await #expect {
+            try await HIDPerformRecovery.recover(
+                from: MessageError("Mach port invalid, device disconnected"),
+                invalidate: { calls.append("invalidate") },
+                rebuildAndRetry: {
+                    calls.append("retry")
+                    throw MessageError("Simulator with UDID ABCD is not booted. Current state: 1")
+                }
+            )
+        } throws: { error in
+            error.localizedDescription.contains("is not booted. Current state")
+        }
+        #expect(calls == ["invalidate", "retry"])
+    }
+}


### PR DESCRIPTION
## Problem

`HIDInteractor` keeps a per-UDID cache of `FBSimulatorHID` connections with no liveness check on reuse. A simulator that is shut down and **re-booted under the same UDID** passes `makeSession`'s `state == .booted` re-check, so the daemon hands every verb the cached connection whose mach port belongs to the previous boot.

The existing invalidation path (`DaemonDispatch.platformStaleCleanup` → `clearHIDConnection(for:)`) only fires when a verb error matches `DaemonErrorKind.isStaleSimulatorMessage` ("not found in set" / "is not booted. Current state"). The dead-connection failure matches neither, so it was classified `.other` and the UDID stayed broken until daemon restart.

**Live repro made it worse than reported**: on Xcode 26.5 / iOS 26.2, sending through the dead port doesn't error at all — SimulatorKit never invokes the send completion, so `event.perform` **hangs the daemon mid-request indefinitely** (verified with a wedged daemon; last log line is "Performing HID event...", main thread idle in the run loop). No after-the-fact error classification can catch that.

## Fix

Two layers:

**1. Pre-send boot-identity gate (handles the reboot window, including the hang).**
Each cache entry records the mtime of `<dataDirectory>/var/run/launchd_bootstrap.plist`, which CoreSimulator rewrites on every boot (public API only — `FBSimulator.dataDirectory` + one stat per cache hit). On reuse, a token mismatch — or an unreadable marker, failing closed — discards the entry and builds a fresh connection before anything is sent. Rebuilding costs milliseconds; reusing a dead port hangs forever.

**2. Fail-invalidate + cautious retry-once (handles dead transports that do surface errors).**
Any failed perform now always drops the cached connection, so the next command self-heals. The event is re-performed once, against a freshly built session, **only** when the error message proves nothing reached the currently-booted simulator instance:

- `"Mach port invalid, device disconnected"` — SimulatorKit's `SimDeviceLegacyHIDClient.HIDError` for `MACH_SEND_INVALID_DEST` (taxonomy recovered from the Xcode 26.x SimulatorKit binary: nil port / `MACH_SEND_INVALID_DEST` / other kern returns map to three distinct wordings)
- `"Mach port not connected, device may not be ready yet"` — client never obtained its HID port; nothing was ever sent
- `"has already been disposed"` — `FBSimulatorHID.connect` after disconnect, emitted before any send
- `"(ipc/send) invalid destination port"` — defensive, `mach_error_string` rendering of the same kern return

### Retry-safety reasoning

`FBSimulatorHIDEvent` composites (tap = down + up, etc.) send one mach message per sub-event and short-circuit on the first failure. For the gated errors above, the kernel refused (or the client never had a route for) the failing message, and any earlier sub-events either failed identically or were delivered to the *previous* boot, which no longer exists — so a single re-perform cannot double-apply on any live UI. Everything else — notably SimulatorKit's generic `"Mach return error <code>"` (e.g. a send timeout hitting the middle of a composite whose earlier touches were delivered) — stays invalidate-only, consistent with the recent daemon ambiguous-outcome work that avoids double-applied side-effecting verbs.

## Testing

- 18 new unit tests (`HIDBootIdentityTests`, `HIDPerformRecoveryTests`): token derivation from a temp data-directory fixture, reuse truth table (unknown tokens fail closed), error classification, and recovery orchestration (invalidate-before-retry ordering, no-retry rethrow, retry-error propagation) — decision logic is factored into `HIDBootIdentity` / `HIDPerformRecovery` with injected closures so no FB* types are needed in tests.
- Full suite: **597 tests / 119 suites green** (baseline 579/115).
- Live end-to-end on iPhone 17 Pro (iOS 26.2): `button home` → `simctl shutdown` + `boot` with the daemon surviving → `button home` succeeds in ~1s via "Boot token changed … discarding cached HID connection" → fresh connection. Previously this hung the daemon indefinitely.

## Known limitation

A port that dies *without* a reboot (same boot token, e.g. HID stack breakage inside a still-booted sim) and hangs rather than errors is not covered; that would need a perform watchdog, which risks interacting with legitimately long performs (swipes/holds up to 10s) and is left out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
