### PR TITLE
Swipe coordinate pairs, whitespace-tolerant selector matching, and a full-screen tap advisory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `swipe` now accepts `--from x,y --to x,y` and positional `x,y x,y` coordinates on top-level, iOS, Android, and iOS batch surfaces while keeping the existing four coordinate flags.
+
 ### Changed
 
 - Daemon client now retries a command once against the same daemon when the simulator reports the post-boot `transient_booting` readiness gap, matching the long-documented behaviour.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `swipe` now accepts `--from x,y --to x,y` and positional `x,y x,y` coordinates on top-level, iOS, Android, and iOS batch surfaces while keeping the existing four coordinate flags.
+- `tap`/`long-press` now print a non-fatal `[i]` advisory to stderr when a `--label`/`--value`/`--label-contains` selector resolves to an element covering ≥90% of the screen — a common footgun on canvas-rendered UIs (e.g. Flutter) where a full-screen wrapper element makes the tap land on the screen centre instead of the intended control. The tap still fires; the advisory recommends a positional `@N`/`#N` alias or explicit coordinates.
 
 ### Changed
 
+- `--label`/`--value` exact matching and `--label-contains` now fall back to whitespace-collapsed comparison when the exact pass finds nothing, so a multi-line `AXLabel` (which the compact `describe-ui` outline renders space-joined) matches the space-joined string an agent copies back. Existing exact matches are unaffected — the fallback only runs when the exact pass matched zero elements.
 - Daemon client now retries a command once against the same daemon when the simulator reports the post-boot `transient_booting` readiness gap, matching the long-documented behaviour.
 - Bridge `/swipe` now accepts durations up to 10 s (previously silently clamped to 5 s), covering the full `--duration` range the CLI validates for long-press holds. Bridge `versionCode` bumped to 16.
 - `ios type` builds one HID session for the whole string instead of re-initialising FBSimulatorControl per character.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ sim-use tap --id Safari --device $UDID
 sim-use tap --label "Safari" --device $UDID
 sim-use tap --value "On" --device $UDID
 
+sim-use swipe --from 100,300 --to 300,100 --device $UDID
+sim-use swipe 100,300 300,100 --device $UDID
 sim-use swipe --start-x 100 --start-y 300 --end-x 300 --end-y 100 --device $UDID
 sim-use swipe --start-x 50 --start-y 500 --end-x 350 --end-y 500 --duration 2.0 --delta 25 --device $UDID
 

--- a/Sources/AndroidBackend/Verbs/AndroidSwipeCommand.swift
+++ b/Sources/AndroidBackend/Verbs/AndroidSwipeCommand.swift
@@ -11,9 +11,6 @@ import SimUseCore
 /// already speaks the top-level form can drop `android` in front
 /// without re-learning the argument shape.
 ///
-/// The legacy `--from x,y` / `--to x,y` / millisecond `--duration`
-/// shape that 0.5.x shipped is rejected at validate time with a
-/// pointer to the new flags.
 public struct AndroidSwipeCommand: SimUseExecutableCommand {
     public static let configuration = CommandConfiguration(
         commandName: "swipe",
@@ -22,17 +19,29 @@ public struct AndroidSwipeCommand: SimUseExecutableCommand {
 
     @OptionGroup public var device: AndroidDeviceOptions
 
+    @Argument(help: ArgumentHelp(
+        "Optional positional coordinate pairs: <from x,y> <to x,y>. Exclusive with --from/--to and --start-x/--start-y/--end-x/--end-y.",
+        valueName: "x,y"
+    ))
+    public var coordinatePairs: [CoordinatePair] = []
+
+    @Option(name: .customLong("from"), help: ArgumentHelp("Starting coordinate pair.", valueName: "x,y"))
+    public var from: CoordinatePair?
+
+    @Option(name: .customLong("to"), help: ArgumentHelp("Ending coordinate pair.", valueName: "x,y"))
+    public var to: CoordinatePair?
+
     @Option(name: .customLong("start-x"), help: "The X coordinate of the starting point (pixels).")
-    public var startX: Double
+    public var startX: Double?
 
     @Option(name: .customLong("start-y"), help: "The Y coordinate of the starting point (pixels).")
-    public var startY: Double
+    public var startY: Double?
 
     @Option(name: .customLong("end-x"), help: "The X coordinate of the end point (pixels).")
-    public var endX: Double
+    public var endX: Double?
 
     @Option(name: .customLong("end-y"), help: "The Y coordinate of the end point (pixels).")
-    public var endY: Double
+    public var endY: Double?
 
     @Option(name: .customLong("duration"), help: "Duration of the swipe in seconds (default 0.3).")
     public var duration: Double = 0.3
@@ -55,6 +64,7 @@ public struct AndroidSwipeCommand: SimUseExecutableCommand {
     public var simulatorUDIDForDaemon: String? { device.resolved }
 
     public func validate() throws {
+        _ = try resolvedCoordinates()
         guard duration >= 0 else {
             throw ValidationError("--duration must be non-negative.")
         }
@@ -66,18 +76,28 @@ public struct AndroidSwipeCommand: SimUseExecutableCommand {
         }
     }
 
+    public func resolvedCoordinates() throws -> SwipeCoordinates {
+        try SwipeCoordinateResolver.resolve(
+            startX: startX, startY: startY,
+            endX: endX, endY: endY,
+            from: from, to: to,
+            positional: coordinatePairs
+        )
+    }
+
     public mutating func resolveDeferredArguments() throws {
         try device.resolve()
     }
 
     public func execute() async throws -> ExecutionResult {
+        let coords = try resolvedCoordinates()
         if let preDelay, preDelay > 0 {
             Thread.sleep(forTimeInterval: preDelay)
         }
-        let sx = Int(startX.rounded())
-        let sy = Int(startY.rounded())
-        let ex = Int(endX.rounded())
-        let ey = Int(endY.rounded())
+        let sx = Int(coords.startX.rounded())
+        let sy = Int(coords.startY.rounded())
+        let ex = Int(coords.endX.rounded())
+        let ey = Int(coords.endY.rounded())
         let durationMs = max(1, Int((duration * 1000).rounded()))
         try Self.performSwipe(
             udid: device.resolved,
@@ -92,10 +112,13 @@ public struct AndroidSwipeCommand: SimUseExecutableCommand {
     }
 
     public func format(_ result: ExecutionResult) -> CommandOutput {
-        let sx = Int(startX.rounded())
-        let sy = Int(startY.rounded())
-        let ex = Int(endX.rounded())
-        let ey = Int(endY.rounded())
+        guard let coords = try? resolvedCoordinates() else {
+            return CommandOutput(stdout: "✓ Swipe completed successfully\n")
+        }
+        let sx = Int(coords.startX.rounded())
+        let sy = Int(coords.startY.rounded())
+        let ex = Int(coords.endX.rounded())
+        let ey = Int(coords.endY.rounded())
         let durationMs = max(1, Int((duration * 1000).rounded()))
         return CommandOutput(
             stdout: "✓ Swipe (\(sx),\(sy)) → (\(ex),\(ey)) completed successfully\n",

--- a/Sources/SimUse/Commands/Swipe.swift
+++ b/Sources/SimUse/Commands/Swipe.swift
@@ -19,17 +19,29 @@ struct Swipe: SimUseExecutableCommand {
         abstract: "Perform a swipe gesture from one point to another on the screen."
     )
 
+    @Argument(help: ArgumentHelp(
+        "Optional positional coordinate pairs: <from x,y> <to x,y>. Exclusive with --from/--to and --start-x/--start-y/--end-x/--end-y.",
+        valueName: "x,y"
+    ))
+    var coordinatePairs: [CoordinatePair] = []
+
+    @Option(name: .customLong("from"), help: ArgumentHelp("Starting coordinate pair.", valueName: "x,y"))
+    var from: CoordinatePair?
+
+    @Option(name: .customLong("to"), help: ArgumentHelp("Ending coordinate pair.", valueName: "x,y"))
+    var to: CoordinatePair?
+
     @Option(name: .customLong("start-x"), help: "The X coordinate of the starting point.")
-    var startX: Double
+    var startX: Double?
 
     @Option(name: .customLong("start-y"), help: "The Y coordinate of the starting point.")
-    var startY: Double
+    var startY: Double?
 
     @Option(name: .customLong("end-x"), help: "The X coordinate of the ending point.")
-    var endX: Double
+    var endX: Double?
 
     @Option(name: .customLong("end-y"), help: "The Y coordinate of the ending point.")
-    var endY: Double
+    var endY: Double?
 
     @Option(name: .customLong("duration"), help: "Duration of the swipe in seconds.")
     var duration: Double?
@@ -63,17 +75,35 @@ struct Swipe: SimUseExecutableCommand {
     /// happens to consume them as Doubles but the user-facing
     /// numbers stay readable.
     func format(_ result: ExecutionResult) -> CommandOutput {
-        let sx = Int(startX.rounded())
-        let sy = Int(startY.rounded())
-        let ex = Int(endX.rounded())
-        let ey = Int(endY.rounded())
+        guard let coords = try? resolvedCoordinates() else {
+            return .line("✓ Swipe completed successfully")
+        }
+        let sx = Int(coords.startX.rounded())
+        let sy = Int(coords.startY.rounded())
+        let ex = Int(coords.endX.rounded())
+        let ey = Int(coords.endY.rounded())
         return .line("✓ Swipe (\(sx),\(sy)) → (\(ex),\(ey)) completed successfully")
     }
 
     func validate() throws {
+        _ = try IOSSimSwipeCommand.validateOptions(
+            startX: startX, startY: startY,
+            endX: endX, endY: endY,
+            from: from, to: to,
+            positionalPairs: coordinatePairs,
+            duration: duration,
+            delta: delta,
+            preDelay: preDelay,
+            postDelay: postDelay
+        )
+    }
+
+    func resolvedCoordinates() throws -> SwipeCoordinates {
         try IOSSimSwipeCommand.validateOptions(
             startX: startX, startY: startY,
             endX: endX, endY: endY,
+            from: from, to: to,
+            positionalPairs: coordinatePairs,
             duration: duration,
             delta: delta,
             preDelay: preDelay,
@@ -91,11 +121,12 @@ struct Swipe: SimUseExecutableCommand {
     }
 
     private func executeIOSSim() async throws -> ExecutionResult {
+        let coords = try resolvedCoordinates()
         var sub = IOSSimSwipeCommand()
-        sub.startX = startX
-        sub.startY = startY
-        sub.endX = endX
-        sub.endY = endY
+        sub.startX = coords.startX
+        sub.startY = coords.startY
+        sub.endX = coords.endX
+        sub.endY = coords.endY
         sub.duration = duration
         sub.delta = delta
         sub.preDelay = preDelay
@@ -112,16 +143,17 @@ struct Swipe: SimUseExecutableCommand {
     /// `pre-delay` / `post-delay` honored via `Task.sleep` around
     /// the bridge call — mirrors `Gesture.swift`'s `executeAndroid`.
     private func executeAndroid() async throws -> ExecutionResult {
+        let coords = try resolvedCoordinates()
         let durationMs = max(1, Int((duration ?? 0.3) * 1000))
         if let preDelay, preDelay > 0 {
             try await Task.sleep(nanoseconds: UInt64(preDelay * 1_000_000_000))
         }
         try AndroidSwipeCommand.performSwipe(
             udid: device.resolved,
-            startX: Int(startX),
-            startY: Int(startY),
-            endX: Int(endX),
-            endY: Int(endY),
+            startX: Int(coords.startX),
+            startY: Int(coords.startY),
+            endX: Int(coords.endX),
+            endY: Int(coords.endY),
             durationMs: durationMs
         )
         if let postDelay, postDelay > 0 {

--- a/Sources/SimUseCore/SwipeCoordinates.swift
+++ b/Sources/SimUseCore/SwipeCoordinates.swift
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+import ArgumentParser
+import Foundation
+
+public struct CoordinatePair: ExpressibleByArgument, Codable, Equatable, Sendable {
+    public let x: Double
+    public let y: Double
+
+    public init(x: Double, y: Double) {
+        self.x = x
+        self.y = y
+    }
+
+    public init?(argument: String) {
+        guard let parsed = Self.parse(argument) else { return nil }
+        self = parsed
+    }
+
+    private static func parse(_ raw: String) -> CoordinatePair? {
+        let parts = raw.split(separator: ",", omittingEmptySubsequences: false)
+        guard parts.count == 2 else { return nil }
+        let xRaw = parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
+        let yRaw = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let x = Double(xRaw), let y = Double(yRaw) else { return nil }
+        return CoordinatePair(x: x, y: y)
+    }
+}
+
+public struct SwipeCoordinates: Codable, Equatable, Sendable {
+    public let startX: Double
+    public let startY: Double
+    public let endX: Double
+    public let endY: Double
+
+    public init(startX: Double, startY: Double, endX: Double, endY: Double) {
+        self.startX = startX
+        self.startY = startY
+        self.endX = endX
+        self.endY = endY
+    }
+}
+
+public enum SwipeCoordinateResolver {
+    public static func resolve(
+        startX: Double?,
+        startY: Double?,
+        endX: Double?,
+        endY: Double?,
+        from: CoordinatePair?,
+        to: CoordinatePair?,
+        positional: [CoordinatePair]
+    ) throws -> SwipeCoordinates {
+        guard positional.count <= 2 else {
+            throw ValidationError("Swipe accepts at most two positional coordinate pairs: <from x,y> <to x,y>.")
+        }
+
+        let legacyValues = [startX, startY, endX, endY]
+        let legacyCount = legacyValues.compactMap { $0 }.count
+        let hasLegacy = legacyCount == 4
+        let partialLegacy = legacyCount > 0 && legacyCount < 4
+        let hasNamedPair = from != nil && to != nil
+        let partialNamedPair = (from != nil) != (to != nil)
+        let hasPositionalPair = positional.count == 2
+        let partialPositionalPair = positional.count == 1
+
+        if partialLegacy || partialNamedPair || partialPositionalPair {
+            throw ValidationError("Specify swipe coordinates using one complete form only: --from x,y --to x,y, positional <x,y> <x,y>, or all of --start-x --start-y --end-x --end-y.")
+        }
+
+        let completedForms = [hasLegacy, hasNamedPair, hasPositionalPair].filter { $0 }.count
+        guard completedForms > 0 else {
+            throw ValidationError("Specify swipe coordinates with --from x,y --to x,y, positional <x,y> <x,y>, or all of --start-x --start-y --end-x --end-y.")
+        }
+        guard completedForms == 1 else {
+            throw ValidationError("Specify only one swipe coordinate form: --from/--to, positional <x,y> <x,y>, or --start-x/--start-y/--end-x/--end-y.")
+        }
+
+        if hasLegacy {
+            return SwipeCoordinates(
+                startX: startX!, startY: startY!,
+                endX: endX!, endY: endY!
+            )
+        }
+        if let from, let to {
+            return SwipeCoordinates(startX: from.x, startY: from.y, endX: to.x, endY: to.y)
+        }
+        return SwipeCoordinates(
+            startX: positional[0].x, startY: positional[0].y,
+            endX: positional[1].x, endY: positional[1].y
+        )
+    }
+}

--- a/Sources/iOSSimBackend/A11y/AccessibilityElement.swift
+++ b/Sources/iOSSimBackend/A11y/AccessibilityElement.swift
@@ -87,6 +87,30 @@ public struct AccessibilityElement: Decodable {
         AXLabel?.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    /// AXLabel with every internal run of whitespace (spaces, tabs, newlines)
+    /// collapsed to a single space and the ends trimmed. The compact
+    /// `describe-ui` outline renders a multi-line AXLabel space-joined, so an
+    /// agent that copies a label out of the outline and passes it back to
+    /// `--label` supplies a space-joined string that never equals the
+    /// newline-bearing AXLabel under exact comparison. Matching on the
+    /// collapsed form lets that round-trip succeed.
+    public var collapsedLabel: String? {
+        AccessibilityElement.collapseWhitespace(AXLabel)
+    }
+
+    /// `collapsedLabel` counterpart for AXValue, used by the `--value`
+    /// whitespace-tolerant fallback.
+    public var collapsedValue: String? {
+        AccessibilityElement.collapseWhitespace(AXValue)
+    }
+
+    /// Collapse internal whitespace runs to single spaces and trim. Returns
+    /// nil for a nil input; an all-whitespace string collapses to "".
+    public static func collapseWhitespace(_ string: String?) -> String? {
+        guard let string else { return nil }
+        return string.split(whereSeparator: { $0.isWhitespace }).joined(separator: " ")
+    }
+
     public var normalizedUniqueId: String? {
         AXUniqueId?.trimmingCharacters(in: .whitespacesAndNewlines)
     }

--- a/Sources/iOSSimBackend/A11y/AccessibilityTargetResolver.swift
+++ b/Sources/iOSSimBackend/A11y/AccessibilityTargetResolver.swift
@@ -8,6 +8,16 @@ public enum AccessibilityQuery {
     case value(String)
     case labelContains(String)
     case labelRegex(pattern: String)
+
+    /// The user-supplied string behind the query, for diagnostics.
+    public var displayValue: String {
+        switch self {
+        case .id(let v), .label(let v), .value(let v), .labelContains(let v):
+            return v
+        case .labelRegex(let pattern):
+            return pattern
+        }
+    }
 }
 
 public enum ElementResolutionError: LocalizedError, HintProviding {
@@ -276,6 +286,14 @@ public struct AccessibilityTargetResolver {
             throw ElementResolutionError.invalidFrame(reason: "Matched element has an invalid frame size (\(frame.width)x\(frame.height)).")
         }
 
+        if let advisory = FullScreenTapAdvisory.message(
+            matched: frame,
+            screen: roots.first?.frame,
+            query: query.displayValue
+        ) {
+            FileHandle.standardError.write(Data((advisory + "\n").utf8))
+        }
+
         let centerX = frame.x + (frame.width / 2.0)
         let centerY = frame.y + (frame.height / 2.0)
         return (x: centerX, y: centerY)
@@ -321,7 +339,15 @@ public struct AccessibilityTargetResolver {
             )
         case .label(let rawValue):
             let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
-            let matches = allElements.filter { $0.normalizedLabel == value }
+            var matches = allElements.filter { $0.normalizedLabel == value }
+            if matches.isEmpty, let collapsedQuery = AccessibilityElement.collapseWhitespace(rawValue) {
+                // Whitespace-tolerant fallback: a multi-line AXLabel renders
+                // space-joined in the compact outline, so the exact query the
+                // agent copies back never equals the newline-bearing label.
+                // Only runs when the exact pass found nothing, so existing
+                // exact matches are never altered.
+                matches = allElements.filter { $0.collapsedLabel == collapsedQuery }
+            }
             return try selectBestLabelMatch(
                 matches,
                 kind: "--label",
@@ -330,7 +356,10 @@ public struct AccessibilityTargetResolver {
             )
         case .value(let rawValue):
             let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
-            let matches = allElements.filter { $0.normalizedValue == value }
+            var matches = allElements.filter { $0.normalizedValue == value }
+            if matches.isEmpty, let collapsedQuery = AccessibilityElement.collapseWhitespace(rawValue) {
+                matches = allElements.filter { $0.collapsedValue == collapsedQuery }
+            }
             return try selectBestLabelMatch(
                 matches,
                 kind: "--value",
@@ -339,7 +368,12 @@ public struct AccessibilityTargetResolver {
             )
         case .labelContains(let rawValue):
             let needle = rawValue
-            let matches = allElements.filter { ($0.normalizedLabel ?? "").contains(needle) }
+            var matches = allElements.filter { ($0.normalizedLabel ?? "").contains(needle) }
+            if matches.isEmpty,
+               let collapsedNeedle = AccessibilityElement.collapseWhitespace(rawValue),
+               !collapsedNeedle.isEmpty {
+                matches = allElements.filter { ($0.collapsedLabel ?? "").contains(collapsedNeedle) }
+            }
             return try selectBestLabelMatch(
                 matches,
                 kind: "--label-contains",

--- a/Sources/iOSSimBackend/A11y/FullScreenTapAdvisory.swift
+++ b/Sources/iOSSimBackend/A11y/FullScreenTapAdvisory.swift
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+import Foundation
+
+/// Advisory for the case where a selector resolves to an element that covers
+/// almost the whole screen. Frameworks that render to a canvas (e.g. Flutter)
+/// wrap large regions in a single accessibility element whose frame spans the
+/// display; a `--label`/`--value`/`--label-contains` match on that wrapper taps
+/// the *screen centre*, silently missing the control the agent meant to hit.
+/// We surface a non-fatal `[i]` line so the tap still happens (back-compat) but
+/// the agent is told to use a more specific selector or explicit coordinates.
+///
+/// The decision is pure and unit-tested; emission is a stderr side-effect at
+/// the resolver so it never corrupts `--json` stdout.
+public enum FullScreenTapAdvisory {
+    /// Area fraction of the screen at or above which we warn.
+    public static let threshold = 0.9
+
+    /// Returns an advisory line when `matched` covers at least `threshold` of
+    /// `screen` by area. Returns nil when either frame is missing/degenerate or
+    /// the element is comfortably smaller than the screen.
+    public static func message(
+        matched: AccessibilityElement.Frame,
+        screen: AccessibilityElement.Frame?,
+        query: String
+    ) -> String? {
+        guard let screen, screen.width > 0, screen.height > 0 else { return nil }
+        guard matched.width > 0, matched.height > 0 else { return nil }
+        let screenArea = screen.width * screen.height
+        let matchedArea = matched.width * matched.height
+        let fraction = matchedArea / screenArea
+        guard fraction >= threshold else { return nil }
+        let pct = Int((fraction * 100).rounded())
+        return "[i] The element matching '\(query)' covers ~\(pct)% of the screen; "
+            + "tapping its centre may hit a full-screen wrapper rather than the intended "
+            + "control. Use a more specific selector (positional @N/#N) or explicit "
+            + "coordinates (-x/-y)."
+    }
+}

--- a/Sources/iOSSimBackend/Batch/Command+BatchConvertible.swift
+++ b/Sources/iOSSimBackend/Batch/Command+BatchConvertible.swift
@@ -90,13 +90,14 @@ extension IOSSimTapCommand: BatchConvertible {
 
 extension IOSSimSwipeCommand: BatchConvertible {
     public func toBatchPrimitives(context: BatchContext, logger: SimUseLogger) async throws -> [BatchPrimitive] {
+        let coords = try resolvedCoordinates()
         let swipeDuration = duration ?? 1.0
         let swipeDelta = delta ?? 50.0
         let swipeEvent = FBSimulatorHIDEvent.swipe(
-            startX,
-            yStart: startY,
-            xEnd: endX,
-            yEnd: endY,
+            coords.startX,
+            yStart: coords.startY,
+            xEnd: coords.endX,
+            yEnd: coords.endY,
             delta: swipeDelta,
             duration: swipeDuration
         )

--- a/Sources/iOSSimBackend/Verbs/IOSSimSwipeCommand.swift
+++ b/Sources/iOSSimBackend/Verbs/IOSSimSwipeCommand.swift
@@ -19,17 +19,29 @@ public struct IOSSimSwipeCommand: SimUseExecutableCommand {
         abstract: "Perform a swipe gesture from one point to another on the screen."
     )
 
+    @Argument(help: ArgumentHelp(
+        "Optional positional coordinate pairs: <from x,y> <to x,y>. Exclusive with --from/--to and --start-x/--start-y/--end-x/--end-y.",
+        valueName: "x,y"
+    ))
+    public var coordinatePairs: [CoordinatePair] = []
+
+    @Option(name: .customLong("from"), help: ArgumentHelp("Starting coordinate pair.", valueName: "x,y"))
+    public var from: CoordinatePair?
+
+    @Option(name: .customLong("to"), help: ArgumentHelp("Ending coordinate pair.", valueName: "x,y"))
+    public var to: CoordinatePair?
+
     @Option(name: .customLong("start-x"), help: "The X coordinate of the starting point.")
-    public var startX: Double
+    public var startX: Double?
 
     @Option(name: .customLong("start-y"), help: "The Y coordinate of the starting point.")
-    public var startY: Double
+    public var startY: Double?
 
     @Option(name: .customLong("end-x"), help: "The X coordinate of the ending point.")
-    public var endX: Double
+    public var endX: Double?
 
     @Option(name: .customLong("end-y"), help: "The Y coordinate of the ending point.")
-    public var endY: Double
+    public var endY: Double?
 
     @Option(name: .customLong("duration"), help: "Duration of the swipe in seconds.")
     public var duration: Double?
@@ -60,17 +72,22 @@ public struct IOSSimSwipeCommand: SimUseExecutableCommand {
     /// Match the top-level `Swipe` and `AndroidSwipeCommand` so direct
     /// `sim-use ios swipe` calls aren't silent on success.
     public func format(_ result: ExecutionResult) -> CommandOutput {
-        let sx = Int(startX.rounded())
-        let sy = Int(startY.rounded())
-        let ex = Int(endX.rounded())
-        let ey = Int(endY.rounded())
+        guard let coords = try? resolvedCoordinates() else {
+            return .line("✓ Swipe completed successfully")
+        }
+        let sx = Int(coords.startX.rounded())
+        let sy = Int(coords.startY.rounded())
+        let ex = Int(coords.endX.rounded())
+        let ey = Int(coords.endY.rounded())
         return .line("✓ Swipe (\(sx),\(sy)) → (\(ex),\(ey)) completed successfully")
     }
 
     public func validate() throws {
-        try Self.validateOptions(
+        _ = try Self.validateOptions(
             startX: startX, startY: startY,
             endX: endX, endY: endY,
+            from: from, to: to,
+            positionalPairs: coordinatePairs,
             duration: duration,
             delta: delta,
             preDelay: preDelay,
@@ -82,16 +99,25 @@ public struct IOSSimSwipeCommand: SimUseExecutableCommand {
     /// cross-platform forwarder runs the same rules without
     /// re-implementing them.
     public static func validateOptions(
-        startX: Double,
-        startY: Double,
-        endX: Double,
-        endY: Double,
+        startX: Double?,
+        startY: Double?,
+        endX: Double?,
+        endY: Double?,
+        from: CoordinatePair? = nil,
+        to: CoordinatePair? = nil,
+        positionalPairs: [CoordinatePair] = [],
         duration: Double?,
         delta: Double?,
         preDelay: Double?,
         postDelay: Double?
-    ) throws {
-        guard startX >= 0, startY >= 0, endX >= 0, endY >= 0 else {
+    ) throws -> SwipeCoordinates {
+        let coords = try SwipeCoordinateResolver.resolve(
+            startX: startX, startY: startY,
+            endX: endX, endY: endY,
+            from: from, to: to,
+            positional: positionalPairs
+        )
+        guard coords.startX >= 0, coords.startY >= 0, coords.endX >= 0, coords.endY >= 0 else {
             throw ValidationError("Coordinates must be non-negative values.")
         }
 
@@ -107,7 +133,7 @@ public struct IOSSimSwipeCommand: SimUseExecutableCommand {
             }
         }
 
-        guard startX != endX || startY != endY else {
+        guard coords.startX != coords.endX || coords.startY != coords.endY else {
             throw ValidationError("Start and end points must be different.")
         }
 
@@ -122,6 +148,21 @@ public struct IOSSimSwipeCommand: SimUseExecutableCommand {
                 throw ValidationError("Post-delay must be between 0 and 10 seconds.")
             }
         }
+
+        return coords
+    }
+
+    public func resolvedCoordinates() throws -> SwipeCoordinates {
+        try Self.validateOptions(
+            startX: startX, startY: startY,
+            endX: endX, endY: endY,
+            from: from, to: to,
+            positionalPairs: coordinatePairs,
+            duration: duration,
+            delta: delta,
+            preDelay: preDelay,
+            postDelay: postDelay
+        )
     }
 
     public func execute() async throws -> ExecutionResult {
@@ -129,20 +170,21 @@ public struct IOSSimSwipeCommand: SimUseExecutableCommand {
         try await setup(logger: logger)
         try await performGlobalSetup(logger: logger)
 
+        let coords = try resolvedCoordinates()
         let swipeDuration = duration ?? 1.0
         let swipeDelta = delta ?? 50.0
 
-        logger.info().log("Performing swipe from (\(startX), \(startY)) to (\(endX), \(endY))")
+        logger.info().log("Performing swipe from (\(coords.startX), \(coords.startY)) to (\(coords.endX), \(coords.endY))")
         logger.info().log("Duration: \(swipeDuration)s, Delta: \(swipeDelta)px")
 
         NotificationCenter.default.post(
             name: .hidSwipePerformed,
             object: nil,
             userInfo: [
-                "startX": startX,
-                "startY": startY,
-                "endX": endX,
-                "endY": endY,
+                "startX": coords.startX,
+                "startY": coords.startY,
+                "endX": coords.endX,
+                "endY": coords.endY,
                 "duration": swipeDuration,
                 "delta": swipeDelta
             ]
@@ -156,10 +198,10 @@ public struct IOSSimSwipeCommand: SimUseExecutableCommand {
         }
 
         let swipeEvent = FBSimulatorHIDEvent.swipe(
-            startX,
-            yStart: startY,
-            xEnd: endX,
-            yEnd: endY,
+            coords.startX,
+            yStart: coords.startY,
+            xEnd: coords.endX,
+            yEnd: coords.endY,
             delta: swipeDelta,
             duration: swipeDuration
         )

--- a/Tests/BatchPasteStepTests.swift
+++ b/Tests/BatchPasteStepTests.swift
@@ -133,4 +133,14 @@ struct BatchPasteStepParsingTests {
         #expect(action.label.contains("\(utf8Count)"),
                 "expected pbcopy label to mention the full \(utf8Count)-byte payload; got '\(action.label)'")
     }
+
+    @Test("`swipe --from x,y --to x,y` is accepted as a batch step")
+    func swipePairCoordinates() async throws {
+        let primitives = try await parse(["swipe", "--from", "10,20", "--to", "30,40"])
+        #expect(primitives.count == 1)
+        guard case .hidMergeable = primitives[0] else {
+            Issue.record("swipe should produce one mergeable HID primitive; got \(primitives)")
+            return
+        }
+    }
 }

--- a/Tests/FullScreenTapAdvisoryTests.swift
+++ b/Tests/FullScreenTapAdvisoryTests.swift
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+@testable import iOSSimBackend
+import Foundation
+import Testing
+
+private func frame(_ x: Double, _ y: Double, _ w: Double, _ h: Double) -> AccessibilityElement.Frame {
+    let dict: [String: Any] = ["x": x, "y": y, "width": w, "height": h]
+    // Frame is Decodable-only; build it through JSON like the AX pipeline does.
+    let data = try! JSONSerialization.data(withJSONObject: dict)
+    return try! JSONDecoder().decode(AccessibilityElement.Frame.self, from: data)
+}
+
+@Suite("FullScreenTapAdvisory")
+struct FullScreenTapAdvisoryTests {
+    private let screen = frame(0, 0, 400, 800)
+
+    @Test("warns when the matched element covers the whole screen")
+    func warnsOnFullScreen() {
+        let msg = FullScreenTapAdvisory.message(matched: frame(0, 0, 400, 800), screen: screen, query: "노브")
+        #expect(msg != nil)
+        #expect(msg?.contains("100%") == true)
+        #expect(msg?.contains("노브") == true)
+    }
+
+    @Test("warns at the 90% threshold")
+    func warnsAtThreshold() {
+        // 400x720 = 288000 / 320000 = 90%.
+        #expect(FullScreenTapAdvisory.message(matched: frame(0, 0, 400, 720), screen: screen, query: "x") != nil)
+    }
+
+    @Test("stays silent for a normal-sized control")
+    func silentForSmallElement() {
+        #expect(FullScreenTapAdvisory.message(matched: frame(10, 700, 80, 40), screen: screen, query: "x") == nil)
+    }
+
+    @Test("stays silent when a frame is missing or degenerate")
+    func silentForDegenerate() {
+        #expect(FullScreenTapAdvisory.message(matched: frame(0, 0, 400, 800), screen: nil, query: "x") == nil)
+        #expect(FullScreenTapAdvisory.message(matched: frame(0, 0, 0, 0), screen: screen, query: "x") == nil)
+    }
+}

--- a/Tests/SwipeForwarderTests.swift
+++ b/Tests/SwipeForwarderTests.swift
@@ -18,7 +18,7 @@ struct SwipeForwarderTests {
     @Test("Top-level Swipe validation delegates to IOSSimSwipeCommand (negative coords)")
     func negativeCoordsRejected() {
         do {
-            try IOSSimSwipeCommand.validateOptions(
+            _ = try IOSSimSwipeCommand.validateOptions(
                 startX: -1, startY: 0, endX: 10, endY: 10,
                 duration: nil, delta: nil,
                 preDelay: nil, postDelay: nil
@@ -34,7 +34,7 @@ struct SwipeForwarderTests {
     @Test("Same start and end is rejected")
     func samePointRejected() {
         do {
-            try IOSSimSwipeCommand.validateOptions(
+            _ = try IOSSimSwipeCommand.validateOptions(
                 startX: 100, startY: 100, endX: 100, endY: 100,
                 duration: nil, delta: nil,
                 preDelay: nil, postDelay: nil
@@ -50,7 +50,7 @@ struct SwipeForwarderTests {
     @Test("Non-positive duration is rejected")
     func nonPositiveDurationRejected() {
         do {
-            try IOSSimSwipeCommand.validateOptions(
+            _ = try IOSSimSwipeCommand.validateOptions(
                 startX: 100, startY: 100, endX: 200, endY: 200,
                 duration: 0, delta: nil,
                 preDelay: nil, postDelay: nil
@@ -66,7 +66,7 @@ struct SwipeForwarderTests {
     @Test("Out-of-range pre-delay is rejected")
     func preDelayOutOfRangeRejected() {
         do {
-            try IOSSimSwipeCommand.validateOptions(
+            _ = try IOSSimSwipeCommand.validateOptions(
                 startX: 100, startY: 100, endX: 200, endY: 200,
                 duration: nil, delta: nil,
                 preDelay: 11, postDelay: nil
@@ -112,15 +112,61 @@ struct SwipeForwarderTests {
         let topLevel = try Swipe.parse(argv)
         let subCmd = try IOSSimSwipeCommand.parse(argv)
 
-        #expect(topLevel.startX == 100)
-        #expect(subCmd.startX == 100)
-        #expect(topLevel.endY == 400)
-        #expect(subCmd.endY == 400)
+        #expect(try topLevel.resolvedCoordinates().startX == 100)
+        #expect(try subCmd.resolvedCoordinates().startX == 100)
+        #expect(try topLevel.resolvedCoordinates().endY == 400)
+        #expect(try subCmd.resolvedCoordinates().endY == 400)
         #expect(topLevel.duration == 0.5)
         #expect(subCmd.duration == 0.5)
         #expect(topLevel.delta == 20)
         #expect(subCmd.delta == 20)
         #expect(topLevel.jsonOutput == true)
         #expect(subCmd.jsonOutput == true)
+    }
+
+    @Test("ArgumentParser parses --from/--to on top-level, iOS, and Android swipe")
+    func pairFlagsParseAcrossSurfaces() throws {
+        let argv = ["--from", "100,200", "--to", "300,400", "--udid", "9CD7C6E7-45B3-4E59-BBF2-4D12A9457CD0"]
+        let topLevel = try Swipe.parse(argv)
+        let subCmd = try IOSSimSwipeCommand.parse(argv)
+        let android = try AndroidSwipeCommand.parse(["--from", "100,200", "--to", "300,400", "--device", "emulator-5554"])
+
+        #expect(try topLevel.resolvedCoordinates() == SwipeCoordinates(startX: 100, startY: 200, endX: 300, endY: 400))
+        #expect(try subCmd.resolvedCoordinates() == SwipeCoordinates(startX: 100, startY: 200, endX: 300, endY: 400))
+        #expect(try android.resolvedCoordinates() == SwipeCoordinates(startX: 100, startY: 200, endX: 300, endY: 400))
+    }
+
+    @Test("ArgumentParser parses positional coordinate pairs")
+    func positionalPairsParse() throws {
+        let topLevel = try Swipe.parse(["100,200", "300,400", "--udid", "9CD7C6E7-45B3-4E59-BBF2-4D12A9457CD0"])
+        let subCmd = try IOSSimSwipeCommand.parse(["100,200", "300,400", "--udid", "9CD7C6E7-45B3-4E59-BBF2-4D12A9457CD0"])
+
+        #expect(try topLevel.resolvedCoordinates() == SwipeCoordinates(startX: 100, startY: 200, endX: 300, endY: 400))
+        #expect(try subCmd.resolvedCoordinates() == SwipeCoordinates(startX: 100, startY: 200, endX: 300, endY: 400))
+    }
+
+    @Test("Swipe coordinate forms cannot be mixed or partial")
+    func coordinateFormsRejectMixes() throws {
+        #expect(throws: ValidationError.self) {
+            _ = try SwipeCoordinateResolver.resolve(
+                startX: 100, startY: nil, endX: nil, endY: nil,
+                from: nil, to: nil,
+                positional: []
+            )
+        }
+        #expect(throws: ValidationError.self) {
+            _ = try SwipeCoordinateResolver.resolve(
+                startX: 100, startY: 200, endX: 300, endY: 400,
+                from: CoordinatePair(x: 100, y: 200), to: CoordinatePair(x: 300, y: 400),
+                positional: []
+            )
+        }
+        #expect(throws: ValidationError.self) {
+            _ = try SwipeCoordinateResolver.resolve(
+                startX: nil, startY: nil, endX: nil, endY: nil,
+                from: nil, to: nil,
+                positional: []
+            )
+        }
     }
 }

--- a/Tests/WhitespaceLabelMatchTests.swift
+++ b/Tests/WhitespaceLabelMatchTests.swift
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+@testable import iOSSimBackend
+@testable import SimUseCore
+import Foundation
+import Testing
+
+private func makeElement(
+    type: String? = nil,
+    label: String? = nil,
+    value: String? = nil,
+    frame: (x: Double, y: Double, w: Double, h: Double)? = (0, 0, 100, 50)
+) throws -> AccessibilityElement {
+    var dict: [String: Any] = [:]
+    if let type { dict["type"] = type }
+    if let label { dict["AXLabel"] = label }
+    if let value { dict["AXValue"] = value }
+    if let frame {
+        dict["frame"] = ["x": frame.x, "y": frame.y, "width": frame.w, "height": frame.h]
+    }
+    let data = try JSONSerialization.data(withJSONObject: dict)
+    return try JSONDecoder().decode(AccessibilityElement.self, from: data)
+}
+
+@Suite("Whitespace-tolerant label matching")
+struct WhitespaceLabelMatchTests {
+    @Test("multi-line AXLabel matches a space-joined --label query")
+    func multilineLabelMatchesSpaceJoined() throws {
+        // Real Flutter AXLabel carries newlines; the compact outline renders it
+        // space-joined. The space-joined query must still resolve.
+        let roots = [try makeElement(type: "StaticText", label: "드라이브\nOTT\n64%\nFIR", frame: (0, 100, 200, 80))]
+        let point = try AccessibilityTargetResolver.resolveCenterPoint(
+            roots: roots, query: .label("드라이브 OTT 64% FIR"))
+        #expect(point.x == 100)
+        #expect(point.y == 140)
+    }
+
+    @Test("exact single-line --label still matches (back-compat)")
+    func exactSingleLineStillMatches() throws {
+        let roots = [try makeElement(type: "Button", label: "퍼포먼스", frame: (0, 0, 80, 40))]
+        let point = try AccessibilityTargetResolver.resolveCenterPoint(
+            roots: roots, query: .label("퍼포먼스"))
+        #expect(point.x == 40)
+        #expect(point.y == 20)
+    }
+
+    @Test("--label-contains matches a space-joined substring of a multi-line label")
+    func labelContainsCollapsed() throws {
+        let roots = [try makeElement(type: "Cell", label: "드라이브\nOTT\n64%\nFIR", frame: (10, 20, 100, 40))]
+        let point = try AccessibilityTargetResolver.resolveCenterPoint(
+            roots: roots, query: .labelContains("OTT 64%"))
+        #expect(point.x == 60)
+        #expect(point.y == 40)
+    }
+
+    @Test("--value tolerates internal whitespace differences")
+    func valueCollapsed() throws {
+        let roots = [try makeElement(type: "StaticText", value: "1 234\nkm", frame: (0, 0, 100, 50))]
+        let point = try AccessibilityTargetResolver.resolveCenterPoint(
+            roots: roots, query: .value("1 234 km"))
+        #expect(point.x == 50)
+        #expect(point.y == 25)
+    }
+
+    @Test("collapseWhitespace collapses runs and trims; nil passes through")
+    func collapseHelper() {
+        #expect(AccessibilityElement.collapseWhitespace("  a\n\n b\tc  ") == "a b c")
+        #expect(AccessibilityElement.collapseWhitespace("single") == "single")
+        #expect(AccessibilityElement.collapseWhitespace(nil) == nil)
+    }
+}

--- a/skills/sim-use/SKILL.md
+++ b/skills/sim-use/SKILL.md
@@ -66,6 +66,7 @@ sim-use screenshot --device <UDID> --output after.png
 | Android back | `sim-use button back --device <UDID>` |
 | Wait for animation | `sleep 0.4` between commands, or `--pre-delay 0.5` |
 | Toggle/switch | `sim-use tap @N --duration 0.05 --device <UDID>` (UISwitch needs a brief hold) |
+| Swipe | `sim-use swipe --from 50,500 --to 350,500 --device <UDID>` |
 | Pinch zoom in | `sim-use gesture pinch-out --device <UDID>` (two-finger spread) |
 | Rotate | `sim-use gesture rotate-cw --angle 90 --device <UDID>` |
 

--- a/skills/sim-use/references/batch-reference.md
+++ b/skills/sim-use/references/batch-reference.md
@@ -4,7 +4,7 @@ Use this reference when generating or reviewing `sim-use ios batch` commands.
 
 ## Supported step commands
 - `tap`
-- `swipe`
+- `swipe` (`--from x,y --to x,y`, positional `x,y x,y`, or legacy `--start-x/--start-y/--end-x/--end-y`)
 - `gesture`
 - `touch`
 - `type`

--- a/skills/sim-use/references/cheatsheet.md
+++ b/skills/sim-use/references/cheatsheet.md
@@ -60,7 +60,7 @@ sim-use paste 'text' --via-menu --target-id <id>  # iOS edit menu (soft keyboard
 ```bash
 sim-use gesture scroll-up           # scroll-up = content moves up = page down
 sim-use gesture scroll-down         # page up
-sim-use swipe --start-x 50 --start-y 500 --end-x 350 --end-y 500
+sim-use swipe --from 50,500 --to 350,500
 sim-use long-press @5               # default 0.8s hold
 sim-use long-press --label "Photos" # selector targeting
 sim-use long-press @5 --duration 1.2  # custom hold time


### PR DESCRIPTION
## Motivation

While using sim-use to drive **Flutter** apps on the iOS Simulator I hit three
small friction points. Each fix is additive and back-compatible; they're split
into two commits (swipe ergonomics; selector robustness).

## Changes

### 1. Ergonomic `swipe` coordinates
`swipe` required four separate options (`--start-x --start-y --end-x --end-y`)
while `tap` takes `-x/-y` and `describe-ui` takes `--point x,y`. This adds
`--from x,y --to x,y` and positional `x,y x,y` across the top-level, iOS,
Android, and iOS batch surfaces. The existing four flags keep working; exactly
one form must be fully specified.

### 2. Whitespace-tolerant selector matching
On canvas-rendered UIs the accessibility tree often exposes **multi-line**
`AXLabel`s. The compact `describe-ui` outline renders them space-joined, so the
string an agent copies back into `--label` never equals the newline-bearing
label under exact comparison. `--label`/`--value` exact matching and
`--label-contains` now fall back to a whitespace-collapsed comparison **only
when the exact pass finds nothing**, so existing exact matches are unaffected.

### 3. Full-screen tap advisory
Frameworks like Flutter wrap large regions in a single accessibility element
whose frame spans the whole screen. A `--label`/`--value`/`--label-contains`
selector that resolves to such a wrapper taps the **screen centre**, silently
missing the intended control. When a match covers ≥90% of the screen,
`resolveCenterPoint` now emits a non-fatal `[i]` advisory to **stderr** (so
`--json` stdout is never corrupted) recommending a positional `@N`/`#N` alias or
explicit coordinates. The tap still fires — behaviour is unchanged, only a
warning is added.

## Back-compatibility
All three changes are additive. No existing flag, output, or match result
changes: the swipe flags still work, exact label matches are untouched (the
whitespace fallback only runs on zero exact matches), and the advisory is a
stderr-only diagnostic that does not alter the tap.

## Tests
New: `Tests/WhitespaceLabelMatchTests.swift`, `Tests/FullScreenTapAdvisoryTests.swift`
(pure decision logic + resolver behaviour), plus extended swipe tests. Full
suite green locally: **592 tests / 117 suites pass** (`make build && make test`).

Commits are DCO signed off.