### PR TITLE
Add ergonomic swipe coordinate pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - GitHub Actions CI (`.github/workflows/tests.yml`): Swift unit tests on macOS hosted runners (idb-derived FB XCFrameworks cached between runs), bridge Kotlin JVM unit tests on ubuntu, and a bridge protocol parity check — all for every push and pull request targeting `main`.
 - `make build` / `make test` condense swift output via [xcsift](https://github.com/ldomaradzki/xcsift) (TOON summary; test coverage report) when it is installed — strictly optional, plain swift output otherwise; `SIM_USE_XCSIFT=0` forces plain output.
+- `swipe` now accepts `--from x,y --to x,y` and positional `x,y x,y` coordinates on top-level, iOS, Android, and iOS batch surfaces while keeping the existing four coordinate flags.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ sim-use tap --id Safari --device $UDID
 sim-use tap --label "Safari" --device $UDID
 sim-use tap --value "On" --device $UDID
 
+sim-use swipe --from 100,300 --to 300,100 --device $UDID
+sim-use swipe 100,300 300,100 --device $UDID
 sim-use swipe --start-x 100 --start-y 300 --end-x 300 --end-y 100 --device $UDID
 sim-use swipe --start-x 50 --start-y 500 --end-x 350 --end-y 500 --duration 2.0 --delta 25 --device $UDID
 

--- a/Sources/AndroidBackend/Verbs/AndroidSwipeCommand.swift
+++ b/Sources/AndroidBackend/Verbs/AndroidSwipeCommand.swift
@@ -11,9 +11,6 @@ import SimUseCore
 /// already speaks the top-level form can drop `android` in front
 /// without re-learning the argument shape.
 ///
-/// The legacy `--from x,y` / `--to x,y` / millisecond `--duration`
-/// shape that 0.5.x shipped is rejected at validate time with a
-/// pointer to the new flags.
 public struct AndroidSwipeCommand: SimUseExecutableCommand {
     public static let configuration = CommandConfiguration(
         commandName: "swipe",
@@ -22,17 +19,29 @@ public struct AndroidSwipeCommand: SimUseExecutableCommand {
 
     @OptionGroup public var device: AndroidDeviceOptions
 
+    @Argument(help: ArgumentHelp(
+        "Optional positional coordinate pairs: <from x,y> <to x,y>. Exclusive with --from/--to and --start-x/--start-y/--end-x/--end-y.",
+        valueName: "x,y"
+    ))
+    public var coordinatePairs: [CoordinatePair] = []
+
+    @Option(name: .customLong("from"), help: ArgumentHelp("Starting coordinate pair.", valueName: "x,y"))
+    public var from: CoordinatePair?
+
+    @Option(name: .customLong("to"), help: ArgumentHelp("Ending coordinate pair.", valueName: "x,y"))
+    public var to: CoordinatePair?
+
     @Option(name: .customLong("start-x"), help: "The X coordinate of the starting point (pixels).")
-    public var startX: Double
+    public var startX: Double?
 
     @Option(name: .customLong("start-y"), help: "The Y coordinate of the starting point (pixels).")
-    public var startY: Double
+    public var startY: Double?
 
     @Option(name: .customLong("end-x"), help: "The X coordinate of the end point (pixels).")
-    public var endX: Double
+    public var endX: Double?
 
     @Option(name: .customLong("end-y"), help: "The Y coordinate of the end point (pixels).")
-    public var endY: Double
+    public var endY: Double?
 
     @Option(name: .customLong("duration"), help: "Duration of the swipe in seconds (default 0.3).")
     public var duration: Double = 0.3
@@ -55,6 +64,7 @@ public struct AndroidSwipeCommand: SimUseExecutableCommand {
     public var simulatorUDIDForDaemon: String? { device.resolved }
 
     public func validate() throws {
+        _ = try resolvedCoordinates()
         guard duration >= 0 else {
             throw ValidationError("--duration must be non-negative.")
         }
@@ -66,18 +76,28 @@ public struct AndroidSwipeCommand: SimUseExecutableCommand {
         }
     }
 
+    public func resolvedCoordinates() throws -> SwipeCoordinates {
+        try SwipeCoordinateResolver.resolve(
+            startX: startX, startY: startY,
+            endX: endX, endY: endY,
+            from: from, to: to,
+            positional: coordinatePairs
+        )
+    }
+
     public mutating func resolveDeferredArguments() throws {
         try device.resolve()
     }
 
     public func execute() async throws -> ExecutionResult {
+        let coords = try resolvedCoordinates()
         if let preDelay, preDelay > 0 {
-            Thread.sleep(forTimeInterval: preDelay)
+            try await Task.sleep(nanoseconds: UInt64(preDelay * 1_000_000_000))
         }
-        let sx = Int(startX.rounded())
-        let sy = Int(startY.rounded())
-        let ex = Int(endX.rounded())
-        let ey = Int(endY.rounded())
+        let sx = Int(coords.startX.rounded())
+        let sy = Int(coords.startY.rounded())
+        let ex = Int(coords.endX.rounded())
+        let ey = Int(coords.endY.rounded())
         let durationMs = max(1, Int((duration * 1000).rounded()))
         try Self.performSwipe(
             udid: device.resolved,
@@ -86,16 +106,19 @@ public struct AndroidSwipeCommand: SimUseExecutableCommand {
             durationMs: durationMs
         )
         if let postDelay, postDelay > 0 {
-            Thread.sleep(forTimeInterval: postDelay)
+            try await Task.sleep(nanoseconds: UInt64(postDelay * 1_000_000_000))
         }
         return ExecutionResult()
     }
 
     public func format(_ result: ExecutionResult) -> CommandOutput {
-        let sx = Int(startX.rounded())
-        let sy = Int(startY.rounded())
-        let ex = Int(endX.rounded())
-        let ey = Int(endY.rounded())
+        guard let coords = try? resolvedCoordinates() else {
+            return CommandOutput(stdout: "✓ Swipe completed successfully\n")
+        }
+        let sx = Int(coords.startX.rounded())
+        let sy = Int(coords.startY.rounded())
+        let ex = Int(coords.endX.rounded())
+        let ey = Int(coords.endY.rounded())
         let durationMs = max(1, Int((duration * 1000).rounded()))
         return CommandOutput(
             stdout: "✓ Swipe (\(sx),\(sy)) → (\(ex),\(ey)) completed successfully\n",

--- a/Sources/SimUse/Commands/Swipe.swift
+++ b/Sources/SimUse/Commands/Swipe.swift
@@ -19,17 +19,29 @@ struct Swipe: SimUseExecutableCommand {
         abstract: "Perform a swipe gesture from one point to another on the screen."
     )
 
+    @Argument(help: ArgumentHelp(
+        "Optional positional coordinate pairs: <from x,y> <to x,y>. Exclusive with --from/--to and --start-x/--start-y/--end-x/--end-y.",
+        valueName: "x,y"
+    ))
+    var coordinatePairs: [CoordinatePair] = []
+
+    @Option(name: .customLong("from"), help: ArgumentHelp("Starting coordinate pair.", valueName: "x,y"))
+    var from: CoordinatePair?
+
+    @Option(name: .customLong("to"), help: ArgumentHelp("Ending coordinate pair.", valueName: "x,y"))
+    var to: CoordinatePair?
+
     @Option(name: .customLong("start-x"), help: "The X coordinate of the starting point.")
-    var startX: Double
+    var startX: Double?
 
     @Option(name: .customLong("start-y"), help: "The Y coordinate of the starting point.")
-    var startY: Double
+    var startY: Double?
 
     @Option(name: .customLong("end-x"), help: "The X coordinate of the ending point.")
-    var endX: Double
+    var endX: Double?
 
     @Option(name: .customLong("end-y"), help: "The Y coordinate of the ending point.")
-    var endY: Double
+    var endY: Double?
 
     @Option(name: .customLong("duration"), help: "Duration of the swipe in seconds.")
     var duration: Double?
@@ -63,17 +75,35 @@ struct Swipe: SimUseExecutableCommand {
     /// happens to consume them as Doubles but the user-facing
     /// numbers stay readable.
     func format(_ result: ExecutionResult) -> CommandOutput {
-        let sx = Int(startX.rounded())
-        let sy = Int(startY.rounded())
-        let ex = Int(endX.rounded())
-        let ey = Int(endY.rounded())
+        guard let coords = try? resolvedCoordinates() else {
+            return .line("✓ Swipe completed successfully")
+        }
+        let sx = Int(coords.startX.rounded())
+        let sy = Int(coords.startY.rounded())
+        let ex = Int(coords.endX.rounded())
+        let ey = Int(coords.endY.rounded())
         return .line("✓ Swipe (\(sx),\(sy)) → (\(ex),\(ey)) completed successfully")
     }
 
     func validate() throws {
+        _ = try IOSSimSwipeCommand.validateOptions(
+            startX: startX, startY: startY,
+            endX: endX, endY: endY,
+            from: from, to: to,
+            positionalPairs: coordinatePairs,
+            duration: duration,
+            delta: delta,
+            preDelay: preDelay,
+            postDelay: postDelay
+        )
+    }
+
+    func resolvedCoordinates() throws -> SwipeCoordinates {
         try IOSSimSwipeCommand.validateOptions(
             startX: startX, startY: startY,
             endX: endX, endY: endY,
+            from: from, to: to,
+            positionalPairs: coordinatePairs,
             duration: duration,
             delta: delta,
             preDelay: preDelay,
@@ -91,18 +121,42 @@ struct Swipe: SimUseExecutableCommand {
     }
 
     private func executeIOSSim() async throws -> ExecutionResult {
-        var sub = IOSSimSwipeCommand()
-        sub.startX = startX
-        sub.startY = startY
-        sub.endX = endX
-        sub.endY = endY
-        sub.duration = duration
-        sub.delta = delta
-        sub.preDelay = preDelay
-        sub.postDelay = postDelay
-        sub.device = device
-        sub.json = json
+        let coords = try resolvedCoordinates()
+        var sub = try makeIOSSimForwarder(coords: coords)
+        try sub.resolveDeferredArguments()
         return try await sub.execute()
+    }
+
+    func makeIOSSimForwarder(coords: SwipeCoordinates) throws -> IOSSimSwipeCommand {
+        var argv = [
+            "--start-x", Self.formatArgument(coords.startX),
+            "--start-y", Self.formatArgument(coords.startY),
+            "--end-x", Self.formatArgument(coords.endX),
+            "--end-y", Self.formatArgument(coords.endY)
+        ]
+        if let duration {
+            argv += ["--duration", Self.formatArgument(duration)]
+        }
+        if let delta {
+            argv += ["--delta", Self.formatArgument(delta)]
+        }
+        if let preDelay {
+            argv += ["--pre-delay", Self.formatArgument(preDelay)]
+        }
+        if let postDelay {
+            argv += ["--post-delay", Self.formatArgument(postDelay)]
+        }
+        if !device.resolved.isEmpty {
+            argv += ["--device", device.resolved]
+        }
+        if json.enabled {
+            argv.append("--json")
+        }
+        return try IOSSimSwipeCommand.parse(argv)
+    }
+
+    private static func formatArgument(_ value: Double) -> String {
+        value.rounded() == value ? String(Int(value)) : String(value)
     }
 
     /// Android dispatch. `duration` (iOS seconds) is re-mapped to
@@ -112,16 +166,17 @@ struct Swipe: SimUseExecutableCommand {
     /// `pre-delay` / `post-delay` honored via `Task.sleep` around
     /// the bridge call — mirrors `Gesture.swift`'s `executeAndroid`.
     private func executeAndroid() async throws -> ExecutionResult {
+        let coords = try resolvedCoordinates()
         let durationMs = max(1, Int((duration ?? 0.3) * 1000))
         if let preDelay, preDelay > 0 {
             try await Task.sleep(nanoseconds: UInt64(preDelay * 1_000_000_000))
         }
         try AndroidSwipeCommand.performSwipe(
             udid: device.resolved,
-            startX: Int(startX),
-            startY: Int(startY),
-            endX: Int(endX),
-            endY: Int(endY),
+            startX: Int(coords.startX),
+            startY: Int(coords.startY),
+            endX: Int(coords.endX),
+            endY: Int(coords.endY),
             durationMs: durationMs
         )
         if let postDelay, postDelay > 0 {

--- a/Sources/SimUseCore/SwipeCoordinates.swift
+++ b/Sources/SimUseCore/SwipeCoordinates.swift
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+import ArgumentParser
+import Foundation
+
+public struct CoordinatePair: ExpressibleByArgument, Codable, Equatable, Sendable {
+    public let x: Double
+    public let y: Double
+
+    public init(x: Double, y: Double) {
+        self.x = x
+        self.y = y
+    }
+
+    public init?(argument: String) {
+        guard let parsed = Self.parse(argument) else { return nil }
+        self = parsed
+    }
+
+    private static func parse(_ raw: String) -> CoordinatePair? {
+        let parts = raw.split(separator: ",", omittingEmptySubsequences: false)
+        guard parts.count == 2 else { return nil }
+        let xRaw = parts[0].trimmingCharacters(in: .whitespacesAndNewlines)
+        let yRaw = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let x = Double(xRaw), let y = Double(yRaw) else { return nil }
+        return CoordinatePair(x: x, y: y)
+    }
+}
+
+public struct SwipeCoordinates: Codable, Equatable, Sendable {
+    public let startX: Double
+    public let startY: Double
+    public let endX: Double
+    public let endY: Double
+
+    public init(startX: Double, startY: Double, endX: Double, endY: Double) {
+        self.startX = startX
+        self.startY = startY
+        self.endX = endX
+        self.endY = endY
+    }
+}
+
+public enum SwipeCoordinateResolver {
+    public static func resolve(
+        startX: Double?,
+        startY: Double?,
+        endX: Double?,
+        endY: Double?,
+        from: CoordinatePair?,
+        to: CoordinatePair?,
+        positional: [CoordinatePair]
+    ) throws -> SwipeCoordinates {
+        guard positional.count <= 2 else {
+            throw ValidationError("Swipe accepts at most two positional coordinate pairs: <from x,y> <to x,y>.")
+        }
+
+        let legacyValues = [startX, startY, endX, endY]
+        let legacyCount = legacyValues.compactMap { $0 }.count
+        let hasLegacy = legacyCount == 4
+        let partialLegacy = legacyCount > 0 && legacyCount < 4
+        let hasNamedPair = from != nil && to != nil
+        let partialNamedPair = (from != nil) != (to != nil)
+        let hasPositionalPair = positional.count == 2
+        let partialPositionalPair = positional.count == 1
+
+        if partialLegacy || partialNamedPair || partialPositionalPair {
+            throw ValidationError("Specify swipe coordinates using one complete form only: --from x,y --to x,y, positional <x,y> <x,y>, or all of --start-x --start-y --end-x --end-y.")
+        }
+
+        let completedForms = [hasLegacy, hasNamedPair, hasPositionalPair].filter { $0 }.count
+        guard completedForms > 0 else {
+            throw ValidationError("Specify swipe coordinates with --from x,y --to x,y, positional <x,y> <x,y>, or all of --start-x --start-y --end-x --end-y.")
+        }
+        guard completedForms == 1 else {
+            throw ValidationError("Specify only one swipe coordinate form: --from/--to, positional <x,y> <x,y>, or --start-x/--start-y/--end-x/--end-y.")
+        }
+
+        if hasLegacy {
+            return SwipeCoordinates(
+                startX: startX!, startY: startY!,
+                endX: endX!, endY: endY!
+            )
+        }
+        if let from, let to {
+            return SwipeCoordinates(startX: from.x, startY: from.y, endX: to.x, endY: to.y)
+        }
+        return SwipeCoordinates(
+            startX: positional[0].x, startY: positional[0].y,
+            endX: positional[1].x, endY: positional[1].y
+        )
+    }
+}

--- a/Sources/iOSSimBackend/Batch/Command+BatchConvertible.swift
+++ b/Sources/iOSSimBackend/Batch/Command+BatchConvertible.swift
@@ -93,13 +93,14 @@ extension IOSSimTapCommand: BatchConvertible {
 
 extension IOSSimSwipeCommand: BatchConvertible {
     public func toBatchPrimitives(context: BatchContext, logger: SimUseLogger) async throws -> [BatchPrimitive] {
+        let coords = try resolvedCoordinates()
         let swipeDuration = duration ?? 1.0
         let swipeDelta = delta ?? 50.0
         let swipeEvent = FBSimulatorHIDEvent.swipe(
-            startX,
-            yStart: startY,
-            xEnd: endX,
-            yEnd: endY,
+            coords.startX,
+            yStart: coords.startY,
+            xEnd: coords.endX,
+            yEnd: coords.endY,
             delta: swipeDelta,
             duration: swipeDuration
         )

--- a/Sources/iOSSimBackend/Verbs/IOSSimSwipeCommand.swift
+++ b/Sources/iOSSimBackend/Verbs/IOSSimSwipeCommand.swift
@@ -19,17 +19,29 @@ public struct IOSSimSwipeCommand: SimUseExecutableCommand {
         abstract: "Perform a swipe gesture from one point to another on the screen."
     )
 
+    @Argument(help: ArgumentHelp(
+        "Optional positional coordinate pairs: <from x,y> <to x,y>. Exclusive with --from/--to and --start-x/--start-y/--end-x/--end-y.",
+        valueName: "x,y"
+    ))
+    public var coordinatePairs: [CoordinatePair] = []
+
+    @Option(name: .customLong("from"), help: ArgumentHelp("Starting coordinate pair.", valueName: "x,y"))
+    public var from: CoordinatePair?
+
+    @Option(name: .customLong("to"), help: ArgumentHelp("Ending coordinate pair.", valueName: "x,y"))
+    public var to: CoordinatePair?
+
     @Option(name: .customLong("start-x"), help: "The X coordinate of the starting point.")
-    public var startX: Double
+    public var startX: Double?
 
     @Option(name: .customLong("start-y"), help: "The Y coordinate of the starting point.")
-    public var startY: Double
+    public var startY: Double?
 
     @Option(name: .customLong("end-x"), help: "The X coordinate of the ending point.")
-    public var endX: Double
+    public var endX: Double?
 
     @Option(name: .customLong("end-y"), help: "The Y coordinate of the ending point.")
-    public var endY: Double
+    public var endY: Double?
 
     @Option(name: .customLong("duration"), help: "Duration of the swipe in seconds.")
     public var duration: Double?
@@ -60,17 +72,22 @@ public struct IOSSimSwipeCommand: SimUseExecutableCommand {
     /// Match the top-level `Swipe` and `AndroidSwipeCommand` so direct
     /// `sim-use ios swipe` calls aren't silent on success.
     public func format(_ result: ExecutionResult) -> CommandOutput {
-        let sx = Int(startX.rounded())
-        let sy = Int(startY.rounded())
-        let ex = Int(endX.rounded())
-        let ey = Int(endY.rounded())
+        guard let coords = try? resolvedCoordinates() else {
+            return .line("✓ Swipe completed successfully")
+        }
+        let sx = Int(coords.startX.rounded())
+        let sy = Int(coords.startY.rounded())
+        let ex = Int(coords.endX.rounded())
+        let ey = Int(coords.endY.rounded())
         return .line("✓ Swipe (\(sx),\(sy)) → (\(ex),\(ey)) completed successfully")
     }
 
     public func validate() throws {
-        try Self.validateOptions(
+        _ = try Self.validateOptions(
             startX: startX, startY: startY,
             endX: endX, endY: endY,
+            from: from, to: to,
+            positionalPairs: coordinatePairs,
             duration: duration,
             delta: delta,
             preDelay: preDelay,
@@ -82,16 +99,25 @@ public struct IOSSimSwipeCommand: SimUseExecutableCommand {
     /// cross-platform forwarder runs the same rules without
     /// re-implementing them.
     public static func validateOptions(
-        startX: Double,
-        startY: Double,
-        endX: Double,
-        endY: Double,
+        startX: Double?,
+        startY: Double?,
+        endX: Double?,
+        endY: Double?,
+        from: CoordinatePair? = nil,
+        to: CoordinatePair? = nil,
+        positionalPairs: [CoordinatePair] = [],
         duration: Double?,
         delta: Double?,
         preDelay: Double?,
         postDelay: Double?
-    ) throws {
-        guard startX >= 0, startY >= 0, endX >= 0, endY >= 0 else {
+    ) throws -> SwipeCoordinates {
+        let coords = try SwipeCoordinateResolver.resolve(
+            startX: startX, startY: startY,
+            endX: endX, endY: endY,
+            from: from, to: to,
+            positional: positionalPairs
+        )
+        guard coords.startX >= 0, coords.startY >= 0, coords.endX >= 0, coords.endY >= 0 else {
             throw ValidationError("Coordinates must be non-negative values.")
         }
 
@@ -107,7 +133,7 @@ public struct IOSSimSwipeCommand: SimUseExecutableCommand {
             }
         }
 
-        guard startX != endX || startY != endY else {
+        guard coords.startX != coords.endX || coords.startY != coords.endY else {
             throw ValidationError("Start and end points must be different.")
         }
 
@@ -122,6 +148,21 @@ public struct IOSSimSwipeCommand: SimUseExecutableCommand {
                 throw ValidationError("Post-delay must be between 0 and 10 seconds.")
             }
         }
+
+        return coords
+    }
+
+    public func resolvedCoordinates() throws -> SwipeCoordinates {
+        try Self.validateOptions(
+            startX: startX, startY: startY,
+            endX: endX, endY: endY,
+            from: from, to: to,
+            positionalPairs: coordinatePairs,
+            duration: duration,
+            delta: delta,
+            preDelay: preDelay,
+            postDelay: postDelay
+        )
     }
 
     public func execute() async throws -> ExecutionResult {
@@ -129,10 +170,11 @@ public struct IOSSimSwipeCommand: SimUseExecutableCommand {
         try await setup(logger: logger)
         try await performGlobalSetup(logger: logger)
 
+        let coords = try resolvedCoordinates()
         let swipeDuration = duration ?? 1.0
         let swipeDelta = delta ?? 50.0
 
-        logger.info().log("Performing swipe from (\(startX), \(startY)) to (\(endX), \(endY))")
+        logger.info().log("Performing swipe from (\(coords.startX), \(coords.startY)) to (\(coords.endX), \(coords.endY))")
         logger.info().log("Duration: \(swipeDuration)s, Delta: \(swipeDelta)px")
 
         var events: [FBSimulatorHIDEvent] = []
@@ -143,10 +185,10 @@ public struct IOSSimSwipeCommand: SimUseExecutableCommand {
         }
 
         let swipeEvent = FBSimulatorHIDEvent.swipe(
-            startX,
-            yStart: startY,
-            xEnd: endX,
-            yEnd: endY,
+            coords.startX,
+            yStart: coords.startY,
+            xEnd: coords.endX,
+            yEnd: coords.endY,
             delta: swipeDelta,
             duration: swipeDuration
         )

--- a/Tests/BatchPasteStepTests.swift
+++ b/Tests/BatchPasteStepTests.swift
@@ -133,4 +133,14 @@ struct BatchPasteStepParsingTests {
         #expect(action.label.contains("\(utf8Count)"),
                 "expected pbcopy label to mention the full \(utf8Count)-byte payload; got '\(action.label)'")
     }
+
+    @Test("`swipe --from x,y --to x,y` is accepted as a batch step")
+    func swipePairCoordinates() async throws {
+        let primitives = try await parse(["swipe", "--from", "10,20", "--to", "30,40"])
+        #expect(primitives.count == 1)
+        guard case .hidMergeable = primitives[0] else {
+            Issue.record("swipe should produce one mergeable HID primitive; got \(primitives)")
+            return
+        }
+    }
 }

--- a/Tests/SwipeForwarderTests.swift
+++ b/Tests/SwipeForwarderTests.swift
@@ -18,7 +18,7 @@ struct SwipeForwarderTests {
     @Test("Top-level Swipe validation delegates to IOSSimSwipeCommand (negative coords)")
     func negativeCoordsRejected() {
         do {
-            try IOSSimSwipeCommand.validateOptions(
+            _ = try IOSSimSwipeCommand.validateOptions(
                 startX: -1, startY: 0, endX: 10, endY: 10,
                 duration: nil, delta: nil,
                 preDelay: nil, postDelay: nil
@@ -34,7 +34,7 @@ struct SwipeForwarderTests {
     @Test("Same start and end is rejected")
     func samePointRejected() {
         do {
-            try IOSSimSwipeCommand.validateOptions(
+            _ = try IOSSimSwipeCommand.validateOptions(
                 startX: 100, startY: 100, endX: 100, endY: 100,
                 duration: nil, delta: nil,
                 preDelay: nil, postDelay: nil
@@ -50,7 +50,7 @@ struct SwipeForwarderTests {
     @Test("Non-positive duration is rejected")
     func nonPositiveDurationRejected() {
         do {
-            try IOSSimSwipeCommand.validateOptions(
+            _ = try IOSSimSwipeCommand.validateOptions(
                 startX: 100, startY: 100, endX: 200, endY: 200,
                 duration: 0, delta: nil,
                 preDelay: nil, postDelay: nil
@@ -66,7 +66,7 @@ struct SwipeForwarderTests {
     @Test("Out-of-range pre-delay is rejected")
     func preDelayOutOfRangeRejected() {
         do {
-            try IOSSimSwipeCommand.validateOptions(
+            _ = try IOSSimSwipeCommand.validateOptions(
                 startX: 100, startY: 100, endX: 200, endY: 200,
                 duration: nil, delta: nil,
                 preDelay: 11, postDelay: nil
@@ -112,15 +112,85 @@ struct SwipeForwarderTests {
         let topLevel = try Swipe.parse(argv)
         let subCmd = try IOSSimSwipeCommand.parse(argv)
 
-        #expect(topLevel.startX == 100)
-        #expect(subCmd.startX == 100)
-        #expect(topLevel.endY == 400)
-        #expect(subCmd.endY == 400)
+        #expect(try topLevel.resolvedCoordinates().startX == 100)
+        #expect(try subCmd.resolvedCoordinates().startX == 100)
+        #expect(try topLevel.resolvedCoordinates().endY == 400)
+        #expect(try subCmd.resolvedCoordinates().endY == 400)
         #expect(topLevel.duration == 0.5)
         #expect(subCmd.duration == 0.5)
         #expect(topLevel.delta == 20)
         #expect(subCmd.delta == 20)
         #expect(topLevel.jsonOutput == true)
         #expect(subCmd.jsonOutput == true)
+    }
+
+    @Test("ArgumentParser parses --from/--to on top-level, iOS, and Android swipe")
+    func pairFlagsParseAcrossSurfaces() throws {
+        let argv = ["--from", "100,200", "--to", "300,400", "--udid", "9CD7C6E7-45B3-4E59-BBF2-4D12A9457CD0"]
+        let topLevel = try Swipe.parse(argv)
+        let subCmd = try IOSSimSwipeCommand.parse(argv)
+        let android = try AndroidSwipeCommand.parse(["--from", "100,200", "--to", "300,400", "--device", "emulator-5554"])
+
+        #expect(try topLevel.resolvedCoordinates() == SwipeCoordinates(startX: 100, startY: 200, endX: 300, endY: 400))
+        #expect(try subCmd.resolvedCoordinates() == SwipeCoordinates(startX: 100, startY: 200, endX: 300, endY: 400))
+        #expect(try android.resolvedCoordinates() == SwipeCoordinates(startX: 100, startY: 200, endX: 300, endY: 400))
+    }
+
+    @Test("ArgumentParser parses positional coordinate pairs")
+    func positionalPairsParse() throws {
+        let topLevel = try Swipe.parse(["100,200", "300,400", "--udid", "9CD7C6E7-45B3-4E59-BBF2-4D12A9457CD0"])
+        let subCmd = try IOSSimSwipeCommand.parse(["100,200", "300,400", "--udid", "9CD7C6E7-45B3-4E59-BBF2-4D12A9457CD0"])
+
+        #expect(try topLevel.resolvedCoordinates() == SwipeCoordinates(startX: 100, startY: 200, endX: 300, endY: 400))
+        #expect(try subCmd.resolvedCoordinates() == SwipeCoordinates(startX: 100, startY: 200, endX: 300, endY: 400))
+    }
+
+    @Test("Top-level iOS forwarder builds a parser-backed subcommand")
+    func topLevelIOSForwarderBuildsParserBackedSubcommand() throws {
+        var topLevel = try Swipe.parse([
+            "--from", "100,200",
+            "--to", "300,400",
+            "--duration", "0.5",
+            "--delta", "20",
+            "--pre-delay", "0.1",
+            "--post-delay", "0.1",
+            "--udid", "9CD7C6E7-45B3-4E59-BBF2-4D12A9457CD0",
+            "--json"
+        ])
+        topLevel.device.resolved = "9CD7C6E7-45B3-4E59-BBF2-4D12A9457CD0"
+        let expected = SwipeCoordinates(startX: 100, startY: 200, endX: 300, endY: 400)
+        let subCmd = try topLevel.makeIOSSimForwarder(coords: expected)
+
+        #expect(try subCmd.resolvedCoordinates() == expected)
+        #expect(subCmd.duration == 0.5)
+        #expect(subCmd.delta == 20)
+        #expect(subCmd.preDelay == 0.1)
+        #expect(subCmd.postDelay == 0.1)
+        #expect(subCmd.jsonOutput == true)
+    }
+
+    @Test("Swipe coordinate forms cannot be mixed or partial")
+    func coordinateFormsRejectMixes() throws {
+        #expect(throws: ValidationError.self) {
+            _ = try SwipeCoordinateResolver.resolve(
+                startX: 100, startY: nil, endX: nil, endY: nil,
+                from: nil, to: nil,
+                positional: []
+            )
+        }
+        #expect(throws: ValidationError.self) {
+            _ = try SwipeCoordinateResolver.resolve(
+                startX: 100, startY: 200, endX: 300, endY: 400,
+                from: CoordinatePair(x: 100, y: 200), to: CoordinatePair(x: 300, y: 400),
+                positional: []
+            )
+        }
+        #expect(throws: ValidationError.self) {
+            _ = try SwipeCoordinateResolver.resolve(
+                startX: nil, startY: nil, endX: nil, endY: nil,
+                from: nil, to: nil,
+                positional: []
+            )
+        }
     }
 }

--- a/skills/sim-use/SKILL.md
+++ b/skills/sim-use/SKILL.md
@@ -68,6 +68,7 @@ sim-use screenshot --device <UDID> --output after.png
 | Android back | `sim-use button back --device <UDID>` |
 | Wait for animation | `sleep 0.4` between commands, or `--pre-delay 0.5` |
 | Toggle/switch | `sim-use tap @N --duration 0.05 --device <UDID>` (UISwitch needs a brief hold) |
+| Swipe | `sim-use swipe --from 50,500 --to 350,500 --device <UDID>` |
 | Pinch zoom in | `sim-use gesture pinch-out --device <UDID>` (two-finger spread) |
 | Rotate | `sim-use gesture rotate-cw --angle 90 --device <UDID>` |
 

--- a/skills/sim-use/references/batch-reference.md
+++ b/skills/sim-use/references/batch-reference.md
@@ -4,7 +4,7 @@ Use this reference when generating or reviewing `sim-use ios batch` commands.
 
 ## Supported step commands
 - `tap`
-- `swipe`
+- `swipe` (`--from x,y --to x,y`, positional `x,y x,y`, or legacy `--start-x/--start-y/--end-x/--end-y`)
 - `gesture`
 - `touch`
 - `type`

--- a/skills/sim-use/references/cheatsheet.md
+++ b/skills/sim-use/references/cheatsheet.md
@@ -60,7 +60,7 @@ sim-use paste 'text' --via-menu --target-id <id>  # iOS edit menu (soft keyboard
 ```bash
 sim-use gesture scroll-up           # scroll-up = content moves up = page down
 sim-use gesture scroll-down         # page up
-sim-use swipe --start-x 50 --start-y 500 --end-x 350 --end-y 500
+sim-use swipe --from 50,500 --to 350,500
 sim-use long-press @5               # default 0.8s hold
 sim-use long-press --label "Photos" # selector targeting
 sim-use long-press @5 --duration 1.2  # custom hold time


### PR DESCRIPTION
## Summary
Split from #24. This updates `swipe` to accept coordinate-pair forms:

- `--from x,y --to x,y`
- positional `x,y x,y`

The existing four-flag form continues to work. Validation requires exactly one complete form across the top-level, iOS, Android, and iOS batch paths.

## Tests
- `swift test --filter SwipeForwarderTests` (10 tests passed)
- `swift test --filter BatchPasteStepTests` (8 tests passed)
- `make build`
- `make test` (640 tests passed)

## Live simulator spot check
- Booted simulator: `8B707AC1-3089-4AF6-9BFF-F8CC9465CAA0`
- `swipe --from 20,240 --to 180,240 --json` returned `{"data":{},"ok":true}`
- `swipe 30,280 190,280 --json` returned `{"data":{},"ok":true}`
- legacy `swipe --start-x 40 --start-y 300 --end-x 200 --end-y 300 --json` returned `{"data":{},"ok":true}`

Signed-off-by: joonyeonglim <lyt970120@gmail.com>