### PR TITLE
Add whitespace-tolerant selector matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - JSON output no longer emits the legacy `udid` key (dual-emitted since the `deviceId` transition); `deviceId` is the canonical key in `devices --json`, `daemon stop/status --json`, and Viewer API responses. Inputs (daemon wire decode, Viewer API requests) still accept `udid` as a deprecated alias, to be removed in a future release.
+- `--label`/`--value` exact matching and `--label-contains` now fall back to whitespace-collapsed comparison when the exact pass finds nothing, so a multi-line `AXLabel` (which the compact `describe-ui` outline renders space-joined) matches the space-joined string an agent copies back. Existing exact matches are unaffected — the fallback only runs when the exact pass matched zero elements.
 - Daemon client now retries a command once against the same daemon when the simulator reports the post-boot `transient_booting` readiness gap, matching the long-documented behaviour.
 - Bridge `/swipe` now accepts durations up to 10 s (previously silently clamped to 5 s), covering the full `--duration` range the CLI validates for long-press holds. Bridge `versionCode` bumped to 16.
 - `ios type` builds one HID session for the whole string instead of re-initialising FBSimulatorControl per character.

--- a/Sources/iOSSimBackend/A11y/AccessibilityElement.swift
+++ b/Sources/iOSSimBackend/A11y/AccessibilityElement.swift
@@ -87,6 +87,30 @@ public struct AccessibilityElement: Decodable {
         AXLabel?.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    /// AXLabel with every internal run of whitespace (spaces, tabs, newlines)
+    /// collapsed to a single space and the ends trimmed. The compact
+    /// `describe-ui` outline renders a multi-line AXLabel space-joined, so an
+    /// agent that copies a label out of the outline and passes it back to
+    /// `--label` supplies a space-joined string that never equals the
+    /// newline-bearing AXLabel under exact comparison. Matching on the
+    /// collapsed form lets that round-trip succeed.
+    public var collapsedLabel: String? {
+        AccessibilityElement.collapseWhitespace(AXLabel)
+    }
+
+    /// `collapsedLabel` counterpart for AXValue, used by the `--value`
+    /// whitespace-tolerant fallback.
+    public var collapsedValue: String? {
+        AccessibilityElement.collapseWhitespace(AXValue)
+    }
+
+    /// Collapse internal whitespace runs to single spaces and trim. Returns
+    /// nil for a nil input; an all-whitespace string collapses to "".
+    public static func collapseWhitespace(_ string: String?) -> String? {
+        guard let string else { return nil }
+        return string.split(whereSeparator: { $0.isWhitespace }).joined(separator: " ")
+    }
+
     public var normalizedUniqueId: String? {
         AXUniqueId?.trimmingCharacters(in: .whitespacesAndNewlines)
     }

--- a/Sources/iOSSimBackend/A11y/AccessibilityTargetResolver.swift
+++ b/Sources/iOSSimBackend/A11y/AccessibilityTargetResolver.swift
@@ -321,7 +321,15 @@ public struct AccessibilityTargetResolver {
             )
         case .label(let rawValue):
             let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
-            let matches = allElements.filter { $0.normalizedLabel == value }
+            var matches = allElements.filter { $0.normalizedLabel == value }
+            if matches.isEmpty, let collapsedQuery = AccessibilityElement.collapseWhitespace(rawValue) {
+                // Whitespace-tolerant fallback: a multi-line AXLabel renders
+                // space-joined in the compact outline, so the exact query the
+                // agent copies back never equals the newline-bearing label.
+                // Only runs when the exact pass found nothing, so existing
+                // exact matches are never altered.
+                matches = allElements.filter { $0.collapsedLabel == collapsedQuery }
+            }
             return try selectBestLabelMatch(
                 matches,
                 kind: "--label",
@@ -330,7 +338,10 @@ public struct AccessibilityTargetResolver {
             )
         case .value(let rawValue):
             let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
-            let matches = allElements.filter { $0.normalizedValue == value }
+            var matches = allElements.filter { $0.normalizedValue == value }
+            if matches.isEmpty, let collapsedQuery = AccessibilityElement.collapseWhitespace(rawValue) {
+                matches = allElements.filter { $0.collapsedValue == collapsedQuery }
+            }
             return try selectBestLabelMatch(
                 matches,
                 kind: "--value",
@@ -339,7 +350,12 @@ public struct AccessibilityTargetResolver {
             )
         case .labelContains(let rawValue):
             let needle = rawValue
-            let matches = allElements.filter { ($0.normalizedLabel ?? "").contains(needle) }
+            var matches = allElements.filter { ($0.normalizedLabel ?? "").contains(needle) }
+            if matches.isEmpty,
+               let collapsedNeedle = AccessibilityElement.collapseWhitespace(rawValue),
+               !collapsedNeedle.isEmpty {
+                matches = allElements.filter { ($0.collapsedLabel ?? "").contains(collapsedNeedle) }
+            }
             return try selectBestLabelMatch(
                 matches,
                 kind: "--label-contains",

--- a/Tests/WhitespaceLabelMatchTests.swift
+++ b/Tests/WhitespaceLabelMatchTests.swift
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+@testable import iOSSimBackend
+@testable import SimUseCore
+import Foundation
+import Testing
+
+private func makeElement(
+    type: String? = nil,
+    label: String? = nil,
+    value: String? = nil,
+    frame: (x: Double, y: Double, w: Double, h: Double)? = (0, 0, 100, 50)
+) throws -> AccessibilityElement {
+    var dict: [String: Any] = [:]
+    if let type { dict["type"] = type }
+    if let label { dict["AXLabel"] = label }
+    if let value { dict["AXValue"] = value }
+    if let frame {
+        dict["frame"] = ["x": frame.x, "y": frame.y, "width": frame.w, "height": frame.h]
+    }
+    let data = try JSONSerialization.data(withJSONObject: dict)
+    return try JSONDecoder().decode(AccessibilityElement.self, from: data)
+}
+
+@Suite("Whitespace-tolerant label matching")
+struct WhitespaceLabelMatchTests {
+    @Test("multi-line AXLabel matches a space-joined --label query")
+    func multilineLabelMatchesSpaceJoined() throws {
+        // Real Flutter AXLabel carries newlines; the compact outline renders it
+        // space-joined. The space-joined query must still resolve.
+        let roots = [try makeElement(type: "StaticText", label: "드라이브\nOTT\n64%\nFIR", frame: (0, 100, 200, 80))]
+        let point = try AccessibilityTargetResolver.resolveCenterPoint(
+            roots: roots, query: .label("드라이브 OTT 64% FIR"))
+        #expect(point.x == 100)
+        #expect(point.y == 140)
+    }
+
+    @Test("exact single-line --label still matches (back-compat)")
+    func exactSingleLineStillMatches() throws {
+        let roots = [try makeElement(type: "Button", label: "퍼포먼스", frame: (0, 0, 80, 40))]
+        let point = try AccessibilityTargetResolver.resolveCenterPoint(
+            roots: roots, query: .label("퍼포먼스"))
+        #expect(point.x == 40)
+        #expect(point.y == 20)
+    }
+
+    @Test("exact --label match wins over a collapsed multi-line sibling")
+    func exactMatchWinsBeforeCollapsedFallback() throws {
+        let roots = [
+            try makeElement(type: "Button", label: "A B", frame: (0, 0, 80, 40)),
+            try makeElement(type: "Button", label: "A\nB", frame: (0, 100, 80, 40)),
+        ]
+        let point = try AccessibilityTargetResolver.resolveCenterPoint(
+            roots: roots, query: .label("A B"))
+        #expect(point.y == 20)
+    }
+
+    @Test("--label-contains matches a space-joined substring of a multi-line label")
+    func labelContainsCollapsed() throws {
+        let roots = [try makeElement(type: "Cell", label: "드라이브\nOTT\n64%\nFIR", frame: (10, 20, 100, 40))]
+        let point = try AccessibilityTargetResolver.resolveCenterPoint(
+            roots: roots, query: .labelContains("OTT 64%"))
+        #expect(point.x == 60)
+        #expect(point.y == 40)
+    }
+
+    @Test("collapsed empty --label-contains needle does not match everything")
+    func emptyCollapsedContainsNeedleDoesNotMatchEverything() throws {
+        let roots = [try makeElement(type: "Cell", label: "Anything", frame: (10, 20, 100, 40))]
+        do {
+            _ = try AccessibilityTargetResolver.resolveCenterPoint(
+                roots: roots, query: .labelContains(" \n\t "))
+            Issue.record("Expected all-whitespace contains query to remain not-found")
+        } catch let error as ElementResolutionError {
+            guard case .notFound = error else {
+                Issue.record("Wrong case: \(error)")
+                return
+            }
+        }
+    }
+
+    @Test("--value tolerates internal whitespace differences")
+    func valueCollapsed() throws {
+        let roots = [try makeElement(type: "StaticText", value: "1 234\nkm", frame: (0, 0, 100, 50))]
+        let point = try AccessibilityTargetResolver.resolveCenterPoint(
+            roots: roots, query: .value("1 234 km"))
+        #expect(point.x == 50)
+        #expect(point.y == 25)
+    }
+
+    @Test("collapseWhitespace collapses runs and trims; nil passes through")
+    func collapseHelper() {
+        #expect(AccessibilityElement.collapseWhitespace("  a\n\n b\tc  ") == "a b c")
+        #expect(AccessibilityElement.collapseWhitespace("single") == "single")
+        #expect(AccessibilityElement.collapseWhitespace(nil) == nil)
+    }
+}


### PR DESCRIPTION
## Summary
Split from #24. This makes selector matching tolerate whitespace differences only after exact matching fails.

- `--label` / `--value`: exact match first, then whitespace-collapsed comparison if no exact match exists
- `--label-contains`: same fallback behavior for contains matching
- Empty collapsed contains needles do not match everything

## Tests
- `swift test --filter WhitespaceLabelMatchTests`

Signed-off-by: joonyeonglim <lyt970120@gmail.com>