### PR TITLE
Surface full-screen tap advisory through the success envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions CI (`.github/workflows/tests.yml`): Swift unit tests on macOS hosted runners (idb-derived FB XCFrameworks cached between runs), bridge Kotlin JVM unit tests on ubuntu, and a bridge protocol parity check — all for every push and pull request targeting `main`.
 - `make build` / `make test` condense swift output via [xcsift](https://github.com/ldomaradzki/xcsift) (TOON summary; test coverage report) when it is installed — strictly optional, plain swift output otherwise; `SIM_USE_XCSIFT=0` forces plain output.
 - `swipe` now accepts `--from x,y --to x,y` and positional `x,y x,y` coordinates on top-level, iOS, Android, and iOS batch surfaces while keeping the existing four coordinate flags.
+- `tap`/`long-press` now surface a structured advisory when a label/value selector resolves to a near-full-screen element, so daemon-routed calls show the warning in terminal output and `--json` instead of burying it in the daemon log.
 
 ### Changed
 

--- a/Sources/SimUseCore/CommandAdvisory.swift
+++ b/Sources/SimUseCore/CommandAdvisory.swift
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+import Foundation
+
+/// Per-command informational advisory carried in the success envelope under
+/// `advisory`. Unlike `ProcessAdvisory` (`process`), this describes the
+/// command result itself and is rendered client-side so daemon stderr never
+/// swallows it.
+public struct CommandAdvisory: Codable, Equatable, Sendable {
+    public enum Kind: String, Codable, Equatable, Sendable {
+        case fullScreenTapTarget = "full_screen_tap_target"
+    }
+
+    public let kind: Kind
+    public let message: String
+
+    public init(kind: Kind, message: String) {
+        self.kind = kind
+        self.message = message
+    }
+}
+
+public protocol CommandAdvisoryProviding {
+    var commandAdvisory: CommandAdvisory? { get }
+}
+
+public enum CommandAdvisoryRenderer {
+    public static func banner(for advisory: CommandAdvisory) -> String {
+        "[i] \(advisory.message)"
+    }
+}

--- a/Sources/SimUseCore/Daemon/DaemonProtocol.swift
+++ b/Sources/SimUseCore/Daemon/DaemonProtocol.swift
@@ -54,12 +54,19 @@ public struct DaemonSuccessResponse<Data: Encodable>: Encodable {
     /// backward-compatible: omitted from the wire when nil, so older
     /// clients simply don't see it.
     public let advisory: ProcessAdvisory?
+    public let commandAdvisory: CommandAdvisory?
 
-    public init(id: String? = nil, data: Data, advisory: ProcessAdvisory? = nil) {
+    public init(
+        id: String? = nil,
+        data: Data,
+        advisory: ProcessAdvisory? = nil,
+        commandAdvisory: CommandAdvisory? = nil
+    ) {
         self.id = id
         self.ok = true
         self.data = data
         self.advisory = advisory
+        self.commandAdvisory = commandAdvisory
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -67,10 +74,11 @@ public struct DaemonSuccessResponse<Data: Encodable>: Encodable {
         if let id { try container.encode(id, forKey: .id) }
         try container.encode(ok, forKey: .ok)
         try container.encode(data, forKey: .data)
+        if let commandAdvisory { try container.encode(commandAdvisory, forKey: .advisory) }
         if let advisory, !advisory.isEmpty { try container.encode(advisory, forKey: .process) }
     }
 
-    private enum CodingKeys: String, CodingKey { case id, ok, data, process }
+    private enum CodingKeys: String, CodingKey { case id, ok, data, advisory, process }
 }
 
 public struct DaemonErrorResponse: Encodable {

--- a/Sources/SimUseCore/JSONEnvelopeWriter.swift
+++ b/Sources/SimUseCore/JSONEnvelopeWriter.swift
@@ -20,9 +20,14 @@ public enum JSONEnvelopeWriter {
     public static func writeSuccess<T: Encodable>(
         _ data: T,
         advisory: ProcessAdvisory? = nil,
+        commandAdvisory: CommandAdvisory? = nil,
         to handle: FileHandle = .standardOutput
     ) throws {
-        let encoded = try makeEncoder().encode(SuccessEnvelope(data: data, process: nonEmpty(advisory)))
+        let encoded = try makeEncoder().encode(SuccessEnvelope(
+            data: data,
+            advisory: commandAdvisory,
+            process: nonEmpty(advisory)
+        ))
         handle.write(encoded)
         handle.write(Data([0x0A]))
     }
@@ -49,8 +54,16 @@ public enum JSONEnvelopeWriter {
     /// Direct access for callers that need the encoded bytes without
     /// writing to a `FileHandle` (used by tests to snapshot the wire
     /// shape).
-    public static func encodeSuccess<T: Encodable>(_ data: T, advisory: ProcessAdvisory? = nil) throws -> Data {
-        try makeEncoder().encode(SuccessEnvelope(data: data, process: nonEmpty(advisory)))
+    public static func encodeSuccess<T: Encodable>(
+        _ data: T,
+        advisory: ProcessAdvisory? = nil,
+        commandAdvisory: CommandAdvisory? = nil
+    ) throws -> Data {
+        try makeEncoder().encode(SuccessEnvelope(
+            data: data,
+            advisory: commandAdvisory,
+            process: nonEmpty(advisory)
+        ))
     }
 
     /// Drop an empty advisory so the `process` key never appears with no
@@ -79,16 +92,18 @@ public enum JSONEnvelopeWriter {
 private struct SuccessEnvelope<T: Encodable>: Encodable {
     let ok: Bool = true
     let data: T
+    let advisory: CommandAdvisory?
     let process: ProcessAdvisory?
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(ok, forKey: .ok)
         try container.encode(data, forKey: .data)
+        if let advisory { try container.encode(advisory, forKey: .advisory) }
         if let process { try container.encode(process, forKey: .process) }
     }
 
-    private enum CodingKeys: String, CodingKey { case ok, data, process }
+    private enum CodingKeys: String, CodingKey { case ok, data, advisory, process }
 }
 
 private struct ErrorEnvelope: Encodable {

--- a/Sources/SimUseCore/Types/SimUseExecutableCommand+Daemon.swift
+++ b/Sources/SimUseCore/Types/SimUseExecutableCommand+Daemon.swift
@@ -17,7 +17,12 @@ extension SimUseExecutableCommand {
     public mutating func executeAsDaemonResponse(id: String?, advisory: ProcessAdvisory? = nil) async throws -> Data {
         try resolveDeferredArguments()
         let result = try await execute()
-        let envelope = DaemonSuccessResponse(id: id, data: result, advisory: advisory)
+        let envelope = DaemonSuccessResponse(
+            id: id,
+            data: result,
+            advisory: advisory,
+            commandAdvisory: (result as? CommandAdvisoryProviding)?.commandAdvisory
+        )
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
         return try encoder.encode(envelope)

--- a/Sources/SimUseCore/Types/SimUseExecutableCommand.swift
+++ b/Sources/SimUseCore/Types/SimUseExecutableCommand.swift
@@ -80,7 +80,11 @@ extension SimUseExecutableCommand {
                 try resolveDeferredArguments()
                 await clientPreflight()
                 let resolved = try await resolveExecutionResult()
-                try emitJSONSuccess(resolved.result, advisory: resolved.advisory)
+                try emitJSONSuccess(
+                    resolved.result,
+                    advisory: resolved.advisory,
+                    commandAdvisory: resolved.commandAdvisory
+                )
             } catch {
                 emitJSONError(error)
                 Darwin.exit(1)
@@ -99,6 +103,9 @@ extension SimUseExecutableCommand {
                 if let advisory = resolved.advisory,
                    let banner = ProcessAdvisoryRenderer.banner(for: advisory) {
                     FileHandle.standardOutput.write(Data((banner + "\n").utf8))
+                }
+                if let commandAdvisory = resolved.commandAdvisory {
+                    FileHandle.standardOutput.write(Data((CommandAdvisoryRenderer.banner(for: commandAdvisory) + "\n").utf8))
                 }
                 let output = format(result)
                 let tFormatted = DispatchTime.now()
@@ -137,11 +144,16 @@ extension SimUseExecutableCommand {
     /// Failures inside the daemon path are *not* retried in-process:
     /// they are surfaced verbatim so the user sees the same error the
     /// daemon would have produced.
-    private func resolveExecutionResult() async throws -> (result: ExecutionResult, advisory: ProcessAdvisory?) {
+    private func resolveExecutionResult() async throws -> (
+        result: ExecutionResult,
+        advisory: ProcessAdvisory?,
+        commandAdvisory: CommandAdvisory?
+    ) {
         guard shouldUseDaemon, let udid = simulatorUDIDForDaemon else {
             // In-process (standalone) path has no persistent tracker, so
             // it carries no cross-command process advisory.
-            return (try await execute(), nil)
+            let result = try await execute()
+            return (result, nil, (result as? CommandAdvisoryProviding)?.commandAdvisory)
         }
 
         let perf = ProcessInfo.processInfo.environment["SIM_USE_CLIENT_PERF"] == "1"
@@ -174,10 +186,12 @@ extension SimUseExecutableCommand {
 
         let result: ExecutionResult
         let advisory: ProcessAdvisory?
+        let commandAdvisory: CommandAdvisory?
         do {
             let payload = try JSONDecoder().decode(DaemonClientSuccessPayload<ExecutionResult>.self, from: responseData)
             result = payload.data
             advisory = payload.advisory
+            commandAdvisory = payload.commandAdvisory
         } catch {
             throw DaemonClientError.malformedResponse(underlying: error)
         }
@@ -192,7 +206,7 @@ extension SimUseExecutableCommand {
             ))
         }
 
-        return (result, advisory)
+        return (result, advisory, commandAdvisory)
     }
 
     /// Is this command eligible for daemon dispatch *right now*?
@@ -232,8 +246,16 @@ extension SimUseExecutableCommand {
         return result
     }
 
-    private func emitJSONSuccess(_ result: ExecutionResult, advisory: ProcessAdvisory?) throws {
-        try JSONEnvelopeWriter.writeSuccess(result, advisory: advisory)
+    private func emitJSONSuccess(
+        _ result: ExecutionResult,
+        advisory: ProcessAdvisory?,
+        commandAdvisory: CommandAdvisory?
+    ) throws {
+        try JSONEnvelopeWriter.writeSuccess(
+            result,
+            advisory: advisory,
+            commandAdvisory: commandAdvisory
+        )
     }
 
     private func emitJSONError(_ error: Error) {
@@ -251,12 +273,14 @@ public struct DaemonClientSuccessPayload<T: Decodable>: Decodable {
     /// the daemon attached one (issue #81). Absent on responses that
     /// predate the field or carry no event.
     public let advisory: ProcessAdvisory?
+    public let commandAdvisory: CommandAdvisory?
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.data = try container.decode(T.self, forKey: .data)
         self.advisory = try container.decodeIfPresent(ProcessAdvisory.self, forKey: .process)
+        self.commandAdvisory = try container.decodeIfPresent(CommandAdvisory.self, forKey: .advisory)
     }
 
-    private enum CodingKeys: String, CodingKey { case data, process }
+    private enum CodingKeys: String, CodingKey { case data, process, advisory }
 }

--- a/Sources/iOSSimBackend/A11y/AccessibilityPoller.swift
+++ b/Sources/iOSSimBackend/A11y/AccessibilityPoller.swift
@@ -18,6 +18,29 @@ public struct AccessibilityPoller {
         rootsProvider: RootsProvider? = nil,
         logger: SimUseLogger
     ) async throws -> (x: Double, y: Double) {
+        let target = try await resolveWithPollingTarget(
+            query: query,
+            simulatorUDID: simulatorUDID,
+            waitTimeout: waitTimeout,
+            pollInterval: pollInterval,
+            elementType: elementType,
+            frameFilter: frameFilter,
+            rootsProvider: rootsProvider,
+            logger: logger
+        )
+        return (x: target.x, y: target.y)
+    }
+
+    public static func resolveWithPollingTarget(
+        query: AccessibilityQuery,
+        simulatorUDID: String,
+        waitTimeout: TimeInterval,
+        pollInterval: TimeInterval,
+        elementType: String? = nil,
+        frameFilter: AccessibilityTargetResolver.FrameFilter? = nil,
+        rootsProvider: RootsProvider? = nil,
+        logger: SimUseLogger
+    ) async throws -> AccessibilityTargetResolver.ResolvedTarget {
         // Non-batch callers pass no provider and keep the historical
         // fetch-every-time behaviour; batch passes the BatchContext cache.
         let fetchRoots: RootsProvider = rootsProvider ?? { _ in
@@ -26,7 +49,7 @@ public struct AccessibilityPoller {
 
         let roots = try await fetchRoots(false)
         do {
-            return try AccessibilityTargetResolver.resolveCenterPoint(roots: roots, query: query, elementType: elementType, frameFilter: frameFilter)
+            return try AccessibilityTargetResolver.resolveTarget(roots: roots, query: query, elementType: elementType, frameFilter: frameFilter)
         } catch let error as ElementResolutionError where error.isRetryableDuringWait && waitTimeout > 0 {
             let clock = ContinuousClock()
             let deadline = clock.now + .seconds(waitTimeout)
@@ -38,7 +61,7 @@ public struct AccessibilityPoller {
 
                 let freshRoots = try await fetchRoots(true)
                 do {
-                    return try AccessibilityTargetResolver.resolveCenterPoint(roots: freshRoots, query: query, elementType: elementType, frameFilter: frameFilter)
+                    return try AccessibilityTargetResolver.resolveTarget(roots: freshRoots, query: query, elementType: elementType, frameFilter: frameFilter)
                 } catch let retryError as ElementResolutionError where retryError.isRetryableDuringWait {
                     lastError = retryError
                     continue

--- a/Sources/iOSSimBackend/A11y/AccessibilityTargetResolver.swift
+++ b/Sources/iOSSimBackend/A11y/AccessibilityTargetResolver.swift
@@ -8,6 +8,15 @@ public enum AccessibilityQuery {
     case value(String)
     case labelContains(String)
     case labelRegex(pattern: String)
+
+    public var tapAdvisoryQuery: String? {
+        switch self {
+        case .label(let value), .value(let value), .labelContains(let value):
+            return value
+        case .id, .labelRegex:
+            return nil
+        }
+    }
 }
 
 public enum ElementResolutionError: LocalizedError, HintProviding {
@@ -263,6 +272,27 @@ public struct AccessibilityTargetResolver {
         elementType: String? = nil,
         frameFilter: FrameFilter? = nil
     ) throws -> (x: Double, y: Double) {
+        let target = try resolveTarget(
+            roots: roots,
+            query: query,
+            elementType: elementType,
+            frameFilter: frameFilter
+        )
+        return (x: target.x, y: target.y)
+    }
+
+    public struct ResolvedTarget {
+        public let x: Double
+        public let y: Double
+        public let advisory: CommandAdvisory?
+    }
+
+    public static func resolveTarget(
+        roots: [AccessibilityElement],
+        query: AccessibilityQuery,
+        elementType: String? = nil,
+        frameFilter: FrameFilter? = nil
+    ) throws -> ResolvedTarget {
         var allElements = roots.flatMap { $0.flattened() }
 
         if let elementType {
@@ -293,7 +323,10 @@ public struct AccessibilityTargetResolver {
 
         let centerX = frame.x + (frame.width / 2.0)
         let centerY = frame.y + (frame.height / 2.0)
-        return (x: centerX, y: centerY)
+        let advisory = query.tapAdvisoryQuery.flatMap {
+            FullScreenTapAdvisory.advisory(matched: frame, roots: roots, query: $0)
+        }
+        return ResolvedTarget(x: centerX, y: centerY, advisory: advisory)
     }
 
     private static func matchElement(

--- a/Sources/iOSSimBackend/A11y/FullScreenTapAdvisory.swift
+++ b/Sources/iOSSimBackend/A11y/FullScreenTapAdvisory.swift
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+import Foundation
+import SimUseCore
+
+/// Warns when a selector resolves to a near-display-sized element. Canvas
+/// frameworks can expose a full-screen wrapper whose center is not the control
+/// the user meant to tap.
+public enum FullScreenTapAdvisory {
+    public static let threshold = 0.9
+
+    public static func advisory(
+        matched: AccessibilityElement.Frame,
+        roots: [AccessibilityElement],
+        query: String
+    ) -> CommandAdvisory? {
+        guard let screen = displayFrame(in: roots),
+              let message = message(matched: matched, screen: screen, query: query)
+        else { return nil }
+        return CommandAdvisory(kind: .fullScreenTapTarget, message: message)
+    }
+
+    public static func message(
+        matched: AccessibilityElement.Frame,
+        screen: AccessibilityElement.Frame,
+        query: String
+    ) -> String? {
+        guard screen.width > 0, screen.height > 0 else { return nil }
+        guard matched.width > 0, matched.height > 0 else { return nil }
+        let fraction = (matched.width * matched.height) / (screen.width * screen.height)
+        guard fraction >= threshold else { return nil }
+        let pct = Int((min(fraction, 1.0) * 100).rounded())
+        return "The element matching '\(query)' covers ~\(pct)% of the screen; " +
+            "tapping its center may hit a full-screen wrapper rather than the intended control. " +
+            "Use a positional @N/#N alias or explicit -x/-y coordinates."
+    }
+
+    private static func displayFrame(in roots: [AccessibilityElement]) -> AccessibilityElement.Frame? {
+        roots.compactMap(\.frame)
+            .filter { $0.width > 0 && $0.height > 0 }
+            .max { ($0.width * $0.height) < ($1.width * $1.height) }
+    }
+}

--- a/Sources/iOSSimBackend/Verbs/IOSSimTapCommand.swift
+++ b/Sources/iOSSimBackend/Verbs/IOSSimTapCommand.swift
@@ -98,13 +98,37 @@ public struct IOSSimTapCommand: SimUseExecutableCommand {
         return filter.isEmpty ? nil : filter
     }
 
-    public struct ExecutionResult: Codable {
+    public struct ExecutionResult: Codable, CommandAdvisoryProviding {
         public let x: Double
         public let y: Double
+        public let advisory: CommandAdvisory?
 
-        public init(x: Double, y: Double) {
+        public init(x: Double, y: Double, advisory: CommandAdvisory? = nil) {
             self.x = x
             self.y = y
+            self.advisory = advisory
+        }
+
+        public var commandAdvisory: CommandAdvisory? {
+            advisory
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case x
+            case y
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.x = try container.decode(Double.self, forKey: .x)
+            self.y = try container.decode(Double.self, forKey: .y)
+            self.advisory = nil
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(x, forKey: .x)
+            try container.encode(y, forKey: .y)
         }
     }
 
@@ -254,6 +278,7 @@ public struct IOSSimTapCommand: SimUseExecutableCommand {
 
         let resolvedPoint: (x: Double, y: Double)
         let resolvedDescription: String
+        let resolvedAdvisory: CommandAdvisory?
 
         if let alias {
             switch OutlineAliasResolver.parse(alias) {
@@ -262,6 +287,7 @@ public struct IOSSimTapCommand: SimUseExecutableCommand {
                     let resolved = try OutlineAliasResolver.resolve(alias, udid: device.resolved)
                     resolvedPoint = resolved.point
                     resolvedDescription = resolved.humanDescription
+                    resolvedAdvisory = nil
                 } catch {
                     if !jsonOutput {
                         print("Warning: \(error.localizedDescription) No tap performed.", to: &standardError)
@@ -274,7 +300,7 @@ public struct IOSSimTapCommand: SimUseExecutableCommand {
                 // handling. No alias cache read — the selector is
                 // self-contained and works across multiple snapshots.
                 do {
-                    resolvedPoint = try await AccessibilityPoller.resolveWithPolling(
+                    let target = try await AccessibilityPoller.resolveWithPollingTarget(
                         query: .id(uniqueId),
                         simulatorUDID: device.resolved,
                         waitTimeout: waitTimeout,
@@ -283,6 +309,8 @@ public struct IOSSimTapCommand: SimUseExecutableCommand {
                         frameFilter: frameFilter,
                         logger: logger
                     )
+                    resolvedPoint = (x: target.x, y: target.y)
+                    resolvedAdvisory = target.advisory
                     resolvedDescription = "#\(uniqueId) (AXUniqueId) at (\(resolvedPoint.x), \(resolvedPoint.y))"
                 } catch let error as ElementResolutionError {
                     if !jsonOutput {
@@ -296,6 +324,7 @@ public struct IOSSimTapCommand: SimUseExecutableCommand {
         } else if let pointX, let pointY {
             resolvedPoint = (x: pointX, y: pointY)
             resolvedDescription = "(\(pointX), \(pointY))"
+            resolvedAdvisory = nil
         } else {
             let query: AccessibilityQuery
             if let elementID {
@@ -313,7 +342,7 @@ public struct IOSSimTapCommand: SimUseExecutableCommand {
             }
 
             do {
-                resolvedPoint = try await AccessibilityPoller.resolveWithPolling(
+                let target = try await AccessibilityPoller.resolveWithPollingTarget(
                     query: query,
                     simulatorUDID: device.resolved,
                     waitTimeout: waitTimeout,
@@ -322,6 +351,8 @@ public struct IOSSimTapCommand: SimUseExecutableCommand {
                     frameFilter: frameFilter,
                     logger: logger
                 )
+                resolvedPoint = (x: target.x, y: target.y)
+                resolvedAdvisory = target.advisory
             } catch let error as ElementResolutionError {
                 if !jsonOutput {
                     print("Warning: \(error.localizedDescription) No tap performed.", to: &standardError)
@@ -403,7 +434,7 @@ public struct IOSSimTapCommand: SimUseExecutableCommand {
         }
 
         logger.info().log("Tap completed successfully")
-        return ExecutionResult(x: resolvedPoint.x, y: resolvedPoint.y)
+        return ExecutionResult(x: resolvedPoint.x, y: resolvedPoint.y, advisory: resolvedAdvisory)
     }
 
     public func format(_ result: ExecutionResult) -> CommandOutput {

--- a/Tests/DaemonProtocolTests.swift
+++ b/Tests/DaemonProtocolTests.swift
@@ -124,6 +124,16 @@ struct DaemonSuccessResponseTests {
         let text = jsonString(try encoderStable().encode(resp))
         #expect(text == #"{"data":{"count":3,"foo":"bar"},"ok":true,"process":{"events":[{"bundleId":"com.x","confidence":"high","kind":"disappeared","pid":100}],"pending":[]}}"#)
     }
+
+    @Test("Command advisory nests under the advisory key when present")
+    func commandAdvisoryNestsUnderAdvisory() throws {
+        let resp = DaemonSuccessResponse(
+            data: Payload(foo: "bar", count: 3),
+            commandAdvisory: CommandAdvisory(kind: .fullScreenTapTarget, message: "check target")
+        )
+        let text = jsonString(try encoderStable().encode(resp))
+        #expect(text == #"{"advisory":{"kind":"full_screen_tap_target","message":"check target"},"data":{"count":3,"foo":"bar"},"ok":true}"#)
+    }
 }
 
 // MARK: - DaemonPingData

--- a/Tests/FullScreenTapAdvisoryTests.swift
+++ b/Tests/FullScreenTapAdvisoryTests.swift
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+@testable import iOSSimBackend
+import Foundation
+import SimUseCore
+import Testing
+
+private func advisoryFrame(_ x: Double, _ y: Double, _ w: Double, _ h: Double) -> AccessibilityElement.Frame {
+    let dict: [String: Any] = ["x": x, "y": y, "width": w, "height": h]
+    let data = try! JSONSerialization.data(withJSONObject: dict)
+    return try! JSONDecoder().decode(AccessibilityElement.Frame.self, from: data)
+}
+
+private func advisoryElement(
+    type: String = "Application",
+    label: String = "App",
+    frame: AccessibilityElement.Frame,
+    children: [[String: Any]] = []
+) throws -> AccessibilityElement {
+    var dict: [String: Any] = [
+        "type": type,
+        "AXLabel": label,
+        "frame": ["x": frame.x, "y": frame.y, "width": frame.width, "height": frame.height],
+    ]
+    if !children.isEmpty {
+        dict["children"] = children
+    }
+    let data = try JSONSerialization.data(withJSONObject: dict)
+    return try JSONDecoder().decode(AccessibilityElement.self, from: data)
+}
+
+@Suite("FullScreenTapAdvisory")
+struct FullScreenTapAdvisoryTests {
+    private let screen = advisoryFrame(0, 0, 400, 800)
+
+    @Test("warns when matched element covers the display")
+    func warnsOnFullScreenMatch() {
+        let message = FullScreenTapAdvisory.message(
+            matched: advisoryFrame(0, 0, 400, 800),
+            screen: screen,
+            query: "Flutter wrapper"
+        )
+        #expect(message?.contains("100%") == true)
+        #expect(message?.contains("Flutter wrapper") == true)
+    }
+
+    @Test("warns at the 90% threshold")
+    func warnsAtThreshold() {
+        let message = FullScreenTapAdvisory.message(
+            matched: advisoryFrame(0, 0, 400, 720),
+            screen: screen,
+            query: "x"
+        )
+        #expect(message != nil)
+    }
+
+    @Test("stays silent for normal controls")
+    func silentForNormalControl() {
+        let message = FullScreenTapAdvisory.message(
+            matched: advisoryFrame(10, 700, 80, 40),
+            screen: screen,
+            query: "x"
+        )
+        #expect(message == nil)
+    }
+
+    @Test("uses the largest root frame as display denominator")
+    func usesLargestRootFrame() throws {
+        let keyboardRoot = try advisoryElement(
+            label: "Keyboard",
+            frame: advisoryFrame(0, 500, 400, 300)
+        )
+        let appRoot = try advisoryElement(
+            label: "App",
+            frame: screen,
+            children: [[
+                "type": "Button",
+                "AXLabel": "Submit",
+                "frame": ["x": 0, "y": 0, "width": 400, "height": 300],
+            ]]
+        )
+
+        let target = try AccessibilityTargetResolver.resolveTarget(
+            roots: [keyboardRoot, appRoot],
+            query: .label("Submit")
+        )
+
+        #expect(target.x == 200)
+        #expect(target.y == 150)
+        #expect(target.advisory == nil)
+    }
+
+    @Test("tap execution result keeps advisory out of data payload")
+    func tapResultDoesNotEncodeAdvisoryInData() throws {
+        let result = IOSSimTapCommand.ExecutionResult(
+            x: 10,
+            y: 20,
+            advisory: CommandAdvisory(kind: .fullScreenTapTarget, message: "check target")
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        let text = String(data: try encoder.encode(result), encoding: .utf8)
+        #expect(text == #"{"x":10,"y":20}"#)
+    }
+}

--- a/Tests/SimUseCoreTests/JSONEnvelopeWriterTests.swift
+++ b/Tests/SimUseCoreTests/JSONEnvelopeWriterTests.swift
@@ -57,6 +57,15 @@ struct JSONEnvelopeWriterTests {
         #expect(json == #"{"data":{"platform":"ios","visible":true},"ok":true,"process":{"events":[{"bundleId":"com.x","confidence":"high","kind":"disappeared","pid":100}],"pending":[]}}"#)
     }
 
+    @Test("success envelope carries command advisory under `advisory` when present")
+    func successEnvelopeWithCommandAdvisory() throws {
+        let payload = SamplePayload(platform: "ios", visible: true, imePackage: nil)
+        let advisory = CommandAdvisory(kind: .fullScreenTapTarget, message: "check target")
+        let bytes = try JSONEnvelopeWriter.encodeSuccess(payload, commandAdvisory: advisory)
+        let json = try #require(String(data: bytes, encoding: .utf8))
+        #expect(json == #"{"advisory":{"kind":"full_screen_tap_target","message":"check target"},"data":{"platform":"ios","visible":true},"ok":true}"#)
+    }
+
     @Test("success envelope omits `process` when advisory is nil or empty")
     func successEnvelopeAdvisoryOmitted() throws {
         let payload = SamplePayload(platform: "ios", visible: true, imePackage: nil)
@@ -64,6 +73,12 @@ struct JSONEnvelopeWriterTests {
         #expect(try #require(String(data: nilCase, encoding: .utf8)) == #"{"data":{"platform":"ios","visible":true},"ok":true}"#)
         let emptyCase = try JSONEnvelopeWriter.encodeSuccess(payload, advisory: ProcessAdvisory(events: [], pending: []))
         #expect(try #require(String(data: emptyCase, encoding: .utf8)) == #"{"data":{"platform":"ios","visible":true},"ok":true}"#)
+    }
+
+    @Test("command advisory renderer emits the client-side info line")
+    func commandAdvisoryRenderer() {
+        let advisory = CommandAdvisory(kind: .fullScreenTapTarget, message: "check target")
+        #expect(CommandAdvisoryRenderer.banner(for: advisory) == "[i] check target")
     }
 
     @Test("error envelope without hint omits the hint key entirely")

--- a/Tests/SimUseExecutableCommandDaemonTests.swift
+++ b/Tests/SimUseExecutableCommandDaemonTests.swift
@@ -46,6 +46,25 @@ private struct FakeDaemonCommand: SimUseExecutableCommand {
     }
 }
 
+private struct FakeAdvisoryCommand: SimUseExecutableCommand {
+    static let configuration = CommandConfiguration(commandName: "fake-advisory-cmd")
+
+    @Flag(name: .customLong("json"))
+    var jsonOutput: Bool = false
+
+    func execute() async throws -> FakeResult {
+        FakeResult()
+    }
+
+    func format(_ result: FakeResult) -> CommandOutput { CommandOutput() }
+
+    struct FakeResult: Codable, CommandAdvisoryProviding {
+        var commandAdvisory: CommandAdvisory? {
+            CommandAdvisory(kind: .fullScreenTapTarget, message: "check target")
+        }
+    }
+}
+
 private enum ResolverProbe: LocalizedError {
     case simulated
     var errorDescription: String? { "simulated resolver failure" }
@@ -78,5 +97,13 @@ struct DaemonExecuteOrderTests {
         } catch let error as ResolverProbe {
             #expect(error == .simulated)
         }
+    }
+
+    @Test("daemon response carries command advisory outside data")
+    func commandAdvisoryIsTopLevel() async throws {
+        var cmd = FakeAdvisoryCommand()
+        let data = try await cmd.executeAsDaemonResponse(id: nil)
+        let text = try #require(String(data: data, encoding: .utf8))
+        #expect(text == #"{"advisory":{"kind":"full_screen_tap_target","message":"check target"},"data":{},"ok":true}"#)
     }
 }


### PR DESCRIPTION
## Summary
Split from #24. This reworks the full-screen tap advisory on current `main` so it travels through the structured success envelope instead of daemon stderr.

- emits a top-level `advisory` field in `--json`
- renders the advisory client-side above normal text output
- keeps process-liveness under the existing `process` key
- uses the largest positive-area AX root frame as the display denominator instead of assuming `roots.first` is the screen
- preserves tap behavior; the tap still fires

## Tests
- `swift test --filter FullScreenTapAdvisoryTests`
- `swift test --filter JSONEnvelopeWriterTests`
- `swift test --filter DaemonSuccessResponseTests`
- `swift test --filter DaemonExecuteOrderTests`
- `swift test --filter TapForwarderTests`
- `make build`
- `make test` (680 tests passed after rebasing onto current `main`)

## Live simulator spot check
- Booted simulator: `8B707AC1-3089-4AF6-9BFF-F8CC9465CAA0`
- Temporary app exposed `Button "Full Screen Wrapper" #full-screen-wrapper (0,0 402x874)`
- `tap --label "Full Screen Wrapper"` printed `[i] ...` before the success line, stderr empty
- `tap --label "Full Screen Wrapper" --json` returned top-level `advisory` and `data: {"x":201,"y":437}` without duplicating advisory inside `data`
- Negative checks: `tap -x 201 -y 437 --json` and `tap "@1" --json` returned `data` only, no `advisory`

Signed-off-by: joonyeonglim <lyt970120@gmail.com>

