### PR TITLE
Fix root --help abstract to mention Android support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The root `sim-use --help` abstract no longer claims the tool is iOS-Simulator-only; it now mentions Android emulators/devices as well.
 - `android swipe` invoked directly now enforces the same coordinate rules as the other surfaces: negative coordinates and identical start/end points are rejected at validate time instead of being forwarded to the bridge.
 - Swipe coordinates are validated as finite and ≤ 100000 on all surfaces, so values like `inf`, `nan`, or `1e19` fail with a clean validation error instead of trapping the daemon in the Double→Int conversion.
 - The top-level `swipe` and `android swipe` no longer disagree on fractional Android coordinates (truncation vs rounding); both round half away from zero via shared accessors.

--- a/Sources/SimUse/main.swift
+++ b/Sources/SimUse/main.swift
@@ -71,7 +71,7 @@ struct SimUse: AsyncParsableCommand {
     static let simUseLogger = SimUseLogger()
 
     static let configuration = CommandConfiguration(
-        abstract: "A utility to interact with iOS Simulators and extract accessibility information.",
+        abstract: "A utility to interact with iOS Simulators and Android emulators/devices and extract accessibility information.",
         version: VERSION,
         subcommands: [
             // Cross-platform verbs (top-level routes by UDID shape).


### PR DESCRIPTION
## Summary

The root `sim-use --help` abstract still described the tool as iOS-Simulator-only ("A utility to interact with iOS Simulators and extract accessibility information."), predating the Android backend. This was the last remaining pre-cross-platform wording — README, `devices`, and the `ios` / `android` namespaces already describe both platforms.

- `Sources/SimUse/main.swift`: abstract now reads "A utility to interact with iOS Simulators and Android emulators/devices and extract accessibility information."
- `CHANGELOG.md`: entry added under `[Unreleased]` → `### Fixed`.

## Testing

- `make build` passes.
- Verified `.build/debug/sim-use --help` shows the updated OVERVIEW line.

Text-only change; no command surface or behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
