### PR TITLE
Full-screen tap advisory through the success envelope, with review hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions CI (`.github/workflows/tests.yml`): Swift unit tests on macOS hosted runners (idb-derived FB XCFrameworks cached between runs), bridge Kotlin JVM unit tests on ubuntu, and a bridge protocol parity check — all for every push and pull request targeting `main`.
 - `make build` / `make test` condense swift output via [xcsift](https://github.com/ldomaradzki/xcsift) (TOON summary; test coverage report) when it is installed — strictly optional, plain swift output otherwise; `SIM_USE_XCSIFT=0` forces plain output.
 - `swipe` now accepts `--from x,y --to x,y` and positional `x,y x,y` coordinates on top-level, iOS, Android, and iOS batch surfaces while keeping the existing four coordinate flags.
-- `tap`/`long-press` now surface a structured advisory when a label/value selector resolves to a near-full-screen element, so daemon-routed calls show the warning in terminal output and `--json` instead of burying it in the daemon log.
+- `tap`/`long-press` — and `ios batch` tap steps — now surface a structured advisory when a label/value selector resolves to a near-full-screen element (measured against the Application root frame), so daemon-routed calls show the warning in terminal output and `--json` instead of burying it in the daemon log.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub Actions CI (`.github/workflows/tests.yml`): Swift unit tests on macOS hosted runners (idb-derived FB XCFrameworks cached between runs), bridge Kotlin JVM unit tests on ubuntu, and a bridge protocol parity check — all for every push and pull request targeting `main`.
 - `make build` / `make test` condense swift output via [xcsift](https://github.com/ldomaradzki/xcsift) (TOON summary; test coverage report) when it is installed — strictly optional, plain swift output otherwise; `SIM_USE_XCSIFT=0` forces plain output.
 - `swipe` now accepts `--from x,y --to x,y` and positional `x,y x,y` coordinates on top-level, iOS, Android, and iOS batch surfaces while keeping the existing four coordinate flags.
+- `tap`/`long-press` now surface a structured advisory when a label/value selector resolves to a near-full-screen element, so daemon-routed calls show the warning in terminal output and `--json` instead of burying it in the daemon log.
 
 ### Changed
 

--- a/Sources/SimUseCore/CommandAdvisory.swift
+++ b/Sources/SimUseCore/CommandAdvisory.swift
@@ -32,6 +32,18 @@ public struct CommandAdvisory: Codable, Equatable, Sendable {
     }
 }
 
+/// Adopted by `ExecutionResult` types that can carry a per-command
+/// advisory. Both envelope layers hoist `commandAdvisory` to the
+/// top-level `advisory` key: `executeAsDaemonResponse` on the daemon
+/// side and `resolveExecutionResult` on the in-process side.
+///
+/// Contract: the advisory must NOT appear in the conformer's own
+/// encoded output — the envelope carries it, so a synthesized Codable
+/// that includes the stored property would silently duplicate it
+/// inside `data`. Exclude it with a `CodingKeys` enum that omits the
+/// property (give the property a default value so decode synthesis
+/// keeps working), and register the conformer in
+/// `CommandAdvisoryContractTests`, which pins exactly this.
 public protocol CommandAdvisoryProviding {
     var commandAdvisory: CommandAdvisory? { get }
 }

--- a/Sources/SimUseCore/CommandAdvisory.swift
+++ b/Sources/SimUseCore/CommandAdvisory.swift
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+import Foundation
+
+/// Per-command informational advisory carried in the success envelope under
+/// `advisory`. Unlike `ProcessAdvisory` (`process`), this describes the
+/// command result itself and is rendered client-side so daemon stderr never
+/// swallows it.
+public struct CommandAdvisory: Codable, Equatable, Sendable {
+    public enum Kind: String, Codable, Equatable, Sendable {
+        case fullScreenTapTarget = "full_screen_tap_target"
+    }
+
+    public let kind: Kind
+    public let message: String
+
+    public init(kind: Kind, message: String) {
+        self.kind = kind
+        self.message = message
+    }
+}
+
+public protocol CommandAdvisoryProviding {
+    var commandAdvisory: CommandAdvisory? { get }
+}
+
+public enum CommandAdvisoryRenderer {
+    public static func banner(for advisory: CommandAdvisory) -> String {
+        "[i] \(advisory.message)"
+    }
+}

--- a/Sources/SimUseCore/CommandAdvisory.swift
+++ b/Sources/SimUseCore/CommandAdvisory.swift
@@ -17,6 +17,19 @@ public struct CommandAdvisory: Codable, Equatable, Sendable {
         self.kind = kind
         self.message = message
     }
+
+    /// Collapse several advisories into the single `advisory` slot the
+    /// success envelope carries. Multi-step surfaces (batch) join their
+    /// per-step messages line by line under the first advisory's kind;
+    /// the renderer prefixes each line so the text output stays scannable.
+    public static func merged(_ advisories: [CommandAdvisory]) -> CommandAdvisory? {
+        guard let first = advisories.first else { return nil }
+        guard advisories.count > 1 else { return first }
+        return CommandAdvisory(
+            kind: first.kind,
+            message: advisories.map(\.message).joined(separator: "\n")
+        )
+    }
 }
 
 public protocol CommandAdvisoryProviding {
@@ -25,6 +38,9 @@ public protocol CommandAdvisoryProviding {
 
 public enum CommandAdvisoryRenderer {
     public static func banner(for advisory: CommandAdvisory) -> String {
-        "[i] \(advisory.message)"
+        advisory.message
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map { "[i] \($0)" }
+            .joined(separator: "\n")
     }
 }

--- a/Sources/SimUseCore/Daemon/DaemonDispatch.swift
+++ b/Sources/SimUseCore/Daemon/DaemonDispatch.swift
@@ -164,7 +164,7 @@ public enum DaemonDispatch {
 
         let advisory = processAdvisory(for: executable)
         do {
-            let data = try await executable.executeAsDaemonResponse(id: request.id, advisory: advisory)
+            let data = try await executable.executeAsDaemonResponse(id: request.id, processAdvisory: advisory)
             return Outcome(responseData: data, shouldStopDaemon: false)
         } catch {
             let kind = DaemonErrorKind.classify(error)

--- a/Sources/SimUseCore/Daemon/DaemonProtocol.swift
+++ b/Sources/SimUseCore/Daemon/DaemonProtocol.swift
@@ -52,21 +52,23 @@ public struct DaemonSuccessResponse<Data: Encodable>: Encodable {
     public let data: Data
     /// Optional process-liveness advisory (issue #81). Additive and
     /// backward-compatible: omitted from the wire when nil, so older
-    /// clients simply don't see it.
-    public let advisory: ProcessAdvisory?
-    public let commandAdvisory: CommandAdvisory?
+    /// clients simply don't see it. Encodes under the `process` key.
+    public let processAdvisory: ProcessAdvisory?
+    /// Per-command advisory hoisted out of the result (see
+    /// `CommandAdvisoryProviding`). Encodes under the `advisory` key.
+    public let advisory: CommandAdvisory?
 
     public init(
         id: String? = nil,
         data: Data,
-        advisory: ProcessAdvisory? = nil,
-        commandAdvisory: CommandAdvisory? = nil
+        processAdvisory: ProcessAdvisory? = nil,
+        advisory: CommandAdvisory? = nil
     ) {
         self.id = id
         self.ok = true
         self.data = data
+        self.processAdvisory = processAdvisory
         self.advisory = advisory
-        self.commandAdvisory = commandAdvisory
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -74,8 +76,8 @@ public struct DaemonSuccessResponse<Data: Encodable>: Encodable {
         if let id { try container.encode(id, forKey: .id) }
         try container.encode(ok, forKey: .ok)
         try container.encode(data, forKey: .data)
-        if let commandAdvisory { try container.encode(commandAdvisory, forKey: .advisory) }
-        if let advisory, !advisory.isEmpty { try container.encode(advisory, forKey: .process) }
+        if let advisory { try container.encode(advisory, forKey: .advisory) }
+        if let processAdvisory, !processAdvisory.isEmpty { try container.encode(processAdvisory, forKey: .process) }
     }
 
     private enum CodingKeys: String, CodingKey { case id, ok, data, advisory, process }

--- a/Sources/SimUseCore/Daemon/DaemonProtocol.swift
+++ b/Sources/SimUseCore/Daemon/DaemonProtocol.swift
@@ -54,12 +54,19 @@ public struct DaemonSuccessResponse<Data: Encodable>: Encodable {
     /// backward-compatible: omitted from the wire when nil, so older
     /// clients simply don't see it.
     public let advisory: ProcessAdvisory?
+    public let commandAdvisory: CommandAdvisory?
 
-    public init(id: String? = nil, data: Data, advisory: ProcessAdvisory? = nil) {
+    public init(
+        id: String? = nil,
+        data: Data,
+        advisory: ProcessAdvisory? = nil,
+        commandAdvisory: CommandAdvisory? = nil
+    ) {
         self.id = id
         self.ok = true
         self.data = data
         self.advisory = advisory
+        self.commandAdvisory = commandAdvisory
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -67,10 +74,11 @@ public struct DaemonSuccessResponse<Data: Encodable>: Encodable {
         if let id { try container.encode(id, forKey: .id) }
         try container.encode(ok, forKey: .ok)
         try container.encode(data, forKey: .data)
+        if let commandAdvisory { try container.encode(commandAdvisory, forKey: .advisory) }
         if let advisory, !advisory.isEmpty { try container.encode(advisory, forKey: .process) }
     }
 
-    private enum CodingKeys: String, CodingKey { case id, ok, data, process }
+    private enum CodingKeys: String, CodingKey { case id, ok, data, advisory, process }
 }
 
 public struct DaemonErrorResponse: Encodable {

--- a/Sources/SimUseCore/JSONEnvelopeWriter.swift
+++ b/Sources/SimUseCore/JSONEnvelopeWriter.swift
@@ -20,9 +20,14 @@ public enum JSONEnvelopeWriter {
     public static func writeSuccess<T: Encodable>(
         _ data: T,
         advisory: ProcessAdvisory? = nil,
+        commandAdvisory: CommandAdvisory? = nil,
         to handle: FileHandle = .standardOutput
     ) throws {
-        let encoded = try makeEncoder().encode(SuccessEnvelope(data: data, process: nonEmpty(advisory)))
+        let encoded = try makeEncoder().encode(SuccessEnvelope(
+            data: data,
+            advisory: commandAdvisory,
+            process: nonEmpty(advisory)
+        ))
         handle.write(encoded)
         handle.write(Data([0x0A]))
     }
@@ -49,8 +54,16 @@ public enum JSONEnvelopeWriter {
     /// Direct access for callers that need the encoded bytes without
     /// writing to a `FileHandle` (used by tests to snapshot the wire
     /// shape).
-    public static func encodeSuccess<T: Encodable>(_ data: T, advisory: ProcessAdvisory? = nil) throws -> Data {
-        try makeEncoder().encode(SuccessEnvelope(data: data, process: nonEmpty(advisory)))
+    public static func encodeSuccess<T: Encodable>(
+        _ data: T,
+        advisory: ProcessAdvisory? = nil,
+        commandAdvisory: CommandAdvisory? = nil
+    ) throws -> Data {
+        try makeEncoder().encode(SuccessEnvelope(
+            data: data,
+            advisory: commandAdvisory,
+            process: nonEmpty(advisory)
+        ))
     }
 
     /// Drop an empty advisory so the `process` key never appears with no
@@ -79,16 +92,18 @@ public enum JSONEnvelopeWriter {
 private struct SuccessEnvelope<T: Encodable>: Encodable {
     let ok: Bool = true
     let data: T
+    let advisory: CommandAdvisory?
     let process: ProcessAdvisory?
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(ok, forKey: .ok)
         try container.encode(data, forKey: .data)
+        if let advisory { try container.encode(advisory, forKey: .advisory) }
         if let process { try container.encode(process, forKey: .process) }
     }
 
-    private enum CodingKeys: String, CodingKey { case ok, data, process }
+    private enum CodingKeys: String, CodingKey { case ok, data, advisory, process }
 }
 
 private struct ErrorEnvelope: Encodable {

--- a/Sources/SimUseCore/JSONEnvelopeWriter.swift
+++ b/Sources/SimUseCore/JSONEnvelopeWriter.swift
@@ -14,19 +14,21 @@ import Foundation
 /// this writer directly from their own `run()`.
 public enum JSONEnvelopeWriter {
     /// Emit `{ok: true, data: <payload>}` followed by a single LF.
-    /// When `advisory` carries process-liveness events it nests under
-    /// the `process` key (issue #81); a nil / empty advisory is omitted
-    /// so the baseline envelope shape is unchanged.
+    /// When `processAdvisory` carries process-liveness events it nests
+    /// under the `process` key (issue #81); a per-command `advisory`
+    /// nests under the `advisory` key. Nil (or, for process, empty)
+    /// advisories are omitted so the baseline envelope shape is
+    /// unchanged.
     public static func writeSuccess<T: Encodable>(
         _ data: T,
-        advisory: ProcessAdvisory? = nil,
-        commandAdvisory: CommandAdvisory? = nil,
+        processAdvisory: ProcessAdvisory? = nil,
+        advisory: CommandAdvisory? = nil,
         to handle: FileHandle = .standardOutput
     ) throws {
         let encoded = try makeEncoder().encode(SuccessEnvelope(
             data: data,
-            advisory: commandAdvisory,
-            process: nonEmpty(advisory)
+            advisory: advisory,
+            process: nonEmpty(processAdvisory)
         ))
         handle.write(encoded)
         handle.write(Data([0x0A]))
@@ -56,13 +58,13 @@ public enum JSONEnvelopeWriter {
     /// shape).
     public static func encodeSuccess<T: Encodable>(
         _ data: T,
-        advisory: ProcessAdvisory? = nil,
-        commandAdvisory: CommandAdvisory? = nil
+        processAdvisory: ProcessAdvisory? = nil,
+        advisory: CommandAdvisory? = nil
     ) throws -> Data {
         try makeEncoder().encode(SuccessEnvelope(
             data: data,
-            advisory: commandAdvisory,
-            process: nonEmpty(advisory)
+            advisory: advisory,
+            process: nonEmpty(processAdvisory)
         ))
     }
 

--- a/Sources/SimUseCore/Types/SimUseExecutableCommand+Daemon.swift
+++ b/Sources/SimUseCore/Types/SimUseExecutableCommand+Daemon.swift
@@ -17,7 +17,12 @@ extension SimUseExecutableCommand {
     public mutating func executeAsDaemonResponse(id: String?, advisory: ProcessAdvisory? = nil) async throws -> Data {
         try resolveDeferredArguments()
         let result = try await execute()
-        let envelope = DaemonSuccessResponse(id: id, data: result, advisory: advisory)
+        let envelope = DaemonSuccessResponse(
+            id: id,
+            data: result,
+            advisory: advisory,
+            commandAdvisory: (result as? CommandAdvisoryProviding)?.commandAdvisory
+        )
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
         return try encoder.encode(envelope)

--- a/Sources/SimUseCore/Types/SimUseExecutableCommand+Daemon.swift
+++ b/Sources/SimUseCore/Types/SimUseExecutableCommand+Daemon.swift
@@ -14,14 +14,14 @@ extension SimUseExecutableCommand {
     /// is idempotent for explicit `--udid` invocations and necessary
     /// when the daemon happens to dispatch a command that came in
     /// without the resolved value baked in.
-    public mutating func executeAsDaemonResponse(id: String?, advisory: ProcessAdvisory? = nil) async throws -> Data {
+    public mutating func executeAsDaemonResponse(id: String?, processAdvisory: ProcessAdvisory? = nil) async throws -> Data {
         try resolveDeferredArguments()
         let result = try await execute()
         let envelope = DaemonSuccessResponse(
             id: id,
             data: result,
-            advisory: advisory,
-            commandAdvisory: (result as? CommandAdvisoryProviding)?.commandAdvisory
+            processAdvisory: processAdvisory,
+            advisory: (result as? CommandAdvisoryProviding)?.commandAdvisory
         )
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]

--- a/Sources/SimUseCore/Types/SimUseExecutableCommand.swift
+++ b/Sources/SimUseCore/Types/SimUseExecutableCommand.swift
@@ -80,7 +80,11 @@ extension SimUseExecutableCommand {
                 try resolveDeferredArguments()
                 await clientPreflight()
                 let resolved = try await resolveExecutionResult()
-                try emitJSONSuccess(resolved.result, advisory: resolved.advisory)
+                try emitJSONSuccess(
+                    resolved.result,
+                    advisory: resolved.advisory,
+                    commandAdvisory: resolved.commandAdvisory
+                )
             } catch {
                 emitJSONError(error)
                 Darwin.exit(1)
@@ -99,6 +103,9 @@ extension SimUseExecutableCommand {
                 if let advisory = resolved.advisory,
                    let banner = ProcessAdvisoryRenderer.banner(for: advisory) {
                     FileHandle.standardOutput.write(Data((banner + "\n").utf8))
+                }
+                if let commandAdvisory = resolved.commandAdvisory {
+                    FileHandle.standardOutput.write(Data((CommandAdvisoryRenderer.banner(for: commandAdvisory) + "\n").utf8))
                 }
                 let output = format(result)
                 let tFormatted = DispatchTime.now()
@@ -137,11 +144,16 @@ extension SimUseExecutableCommand {
     /// Failures inside the daemon path are *not* retried in-process:
     /// they are surfaced verbatim so the user sees the same error the
     /// daemon would have produced.
-    private func resolveExecutionResult() async throws -> (result: ExecutionResult, advisory: ProcessAdvisory?) {
+    private func resolveExecutionResult() async throws -> (
+        result: ExecutionResult,
+        advisory: ProcessAdvisory?,
+        commandAdvisory: CommandAdvisory?
+    ) {
         guard shouldUseDaemon, let udid = simulatorUDIDForDaemon else {
             // In-process (standalone) path has no persistent tracker, so
             // it carries no cross-command process advisory.
-            return (try await execute(), nil)
+            let result = try await execute()
+            return (result, nil, (result as? CommandAdvisoryProviding)?.commandAdvisory)
         }
 
         let perf = ProcessInfo.processInfo.environment["SIM_USE_CLIENT_PERF"] == "1"
@@ -174,10 +186,12 @@ extension SimUseExecutableCommand {
 
         let result: ExecutionResult
         let advisory: ProcessAdvisory?
+        let commandAdvisory: CommandAdvisory?
         do {
             let payload = try JSONDecoder().decode(DaemonClientSuccessPayload<ExecutionResult>.self, from: responseData)
             result = payload.data
             advisory = payload.advisory
+            commandAdvisory = payload.commandAdvisory
         } catch {
             throw DaemonClientError.malformedResponse(underlying: error)
         }
@@ -192,7 +206,7 @@ extension SimUseExecutableCommand {
             ))
         }
 
-        return (result, advisory)
+        return (result, advisory, commandAdvisory)
     }
 
     /// Is this command eligible for daemon dispatch *right now*?
@@ -232,8 +246,16 @@ extension SimUseExecutableCommand {
         return result
     }
 
-    private func emitJSONSuccess(_ result: ExecutionResult, advisory: ProcessAdvisory?) throws {
-        try JSONEnvelopeWriter.writeSuccess(result, advisory: advisory)
+    private func emitJSONSuccess(
+        _ result: ExecutionResult,
+        advisory: ProcessAdvisory?,
+        commandAdvisory: CommandAdvisory?
+    ) throws {
+        try JSONEnvelopeWriter.writeSuccess(
+            result,
+            advisory: advisory,
+            commandAdvisory: commandAdvisory
+        )
     }
 
     private func emitJSONError(_ error: Error) {
@@ -251,12 +273,14 @@ public struct DaemonClientSuccessPayload<T: Decodable>: Decodable {
     /// the daemon attached one (issue #81). Absent on responses that
     /// predate the field or carry no event.
     public let advisory: ProcessAdvisory?
+    public let commandAdvisory: CommandAdvisory?
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.data = try container.decode(T.self, forKey: .data)
         self.advisory = try container.decodeIfPresent(ProcessAdvisory.self, forKey: .process)
+        self.commandAdvisory = try container.decodeIfPresent(CommandAdvisory.self, forKey: .advisory)
     }
 
-    private enum CodingKeys: String, CodingKey { case data, process }
+    private enum CodingKeys: String, CodingKey { case data, process, advisory }
 }

--- a/Sources/SimUseCore/Types/SimUseExecutableCommand.swift
+++ b/Sources/SimUseCore/Types/SimUseExecutableCommand.swift
@@ -280,7 +280,14 @@ public struct DaemonClientSuccessPayload<T: Decodable>: Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.data = try container.decode(T.self, forKey: .data)
         self.processAdvisory = try container.decodeIfPresent(ProcessAdvisory.self, forKey: .process)
-        self.advisory = try container.decodeIfPresent(CommandAdvisory.self, forKey: .advisory)
+        // A malformed advisory must never fail the whole payload: the
+        // command has already executed and the advisory is purely
+        // informational. A newer daemon can emit a CommandAdvisory.Kind
+        // this client's closed enum doesn't know (version probe failure
+        // or SIM_USE_DAEMON_VERSION_CHECK=0 skips the restart gate);
+        // decode it tolerantly instead of surfacing malformedResponse
+        // for a command that succeeded.
+        self.advisory = (try? container.decodeIfPresent(CommandAdvisory.self, forKey: .advisory)) ?? nil
     }
 
     private enum CodingKeys: String, CodingKey { case data, process, advisory }

--- a/Sources/SimUseCore/Types/SimUseExecutableCommand.swift
+++ b/Sources/SimUseCore/Types/SimUseExecutableCommand.swift
@@ -82,8 +82,8 @@ extension SimUseExecutableCommand {
                 let resolved = try await resolveExecutionResult()
                 try emitJSONSuccess(
                     resolved.result,
-                    advisory: resolved.advisory,
-                    commandAdvisory: resolved.commandAdvisory
+                    processAdvisory: resolved.processAdvisory,
+                    advisory: resolved.advisory
                 )
             } catch {
                 emitJSONError(error)
@@ -100,12 +100,12 @@ extension SimUseExecutableCommand {
                 // command output (e.g. the describe-ui App header) so an
                 // agent driving via the default text surface can't miss a
                 // crash signal (issue #81).
-                if let advisory = resolved.advisory,
-                   let banner = ProcessAdvisoryRenderer.banner(for: advisory) {
+                if let processAdvisory = resolved.processAdvisory,
+                   let banner = ProcessAdvisoryRenderer.banner(for: processAdvisory) {
                     FileHandle.standardOutput.write(Data((banner + "\n").utf8))
                 }
-                if let commandAdvisory = resolved.commandAdvisory {
-                    FileHandle.standardOutput.write(Data((CommandAdvisoryRenderer.banner(for: commandAdvisory) + "\n").utf8))
+                if let advisory = resolved.advisory {
+                    FileHandle.standardOutput.write(Data((CommandAdvisoryRenderer.banner(for: advisory) + "\n").utf8))
                 }
                 let output = format(result)
                 let tFormatted = DispatchTime.now()
@@ -146,8 +146,8 @@ extension SimUseExecutableCommand {
     /// daemon would have produced.
     private func resolveExecutionResult() async throws -> (
         result: ExecutionResult,
-        advisory: ProcessAdvisory?,
-        commandAdvisory: CommandAdvisory?
+        processAdvisory: ProcessAdvisory?,
+        advisory: CommandAdvisory?
     ) {
         guard shouldUseDaemon, let udid = simulatorUDIDForDaemon else {
             // In-process (standalone) path has no persistent tracker, so
@@ -185,13 +185,13 @@ extension SimUseExecutableCommand {
         let t1 = DispatchTime.now()
 
         let result: ExecutionResult
-        let advisory: ProcessAdvisory?
-        let commandAdvisory: CommandAdvisory?
+        let processAdvisory: ProcessAdvisory?
+        let advisory: CommandAdvisory?
         do {
             let payload = try JSONDecoder().decode(DaemonClientSuccessPayload<ExecutionResult>.self, from: responseData)
             result = payload.data
+            processAdvisory = payload.processAdvisory
             advisory = payload.advisory
-            commandAdvisory = payload.commandAdvisory
         } catch {
             throw DaemonClientError.malformedResponse(underlying: error)
         }
@@ -206,7 +206,7 @@ extension SimUseExecutableCommand {
             ))
         }
 
-        return (result, advisory, commandAdvisory)
+        return (result, processAdvisory, advisory)
     }
 
     /// Is this command eligible for daemon dispatch *right now*?
@@ -248,13 +248,13 @@ extension SimUseExecutableCommand {
 
     private func emitJSONSuccess(
         _ result: ExecutionResult,
-        advisory: ProcessAdvisory?,
-        commandAdvisory: CommandAdvisory?
+        processAdvisory: ProcessAdvisory?,
+        advisory: CommandAdvisory?
     ) throws {
         try JSONEnvelopeWriter.writeSuccess(
             result,
-            advisory: advisory,
-            commandAdvisory: commandAdvisory
+            processAdvisory: processAdvisory,
+            advisory: advisory
         )
     }
 
@@ -272,14 +272,15 @@ public struct DaemonClientSuccessPayload<T: Decodable>: Decodable {
     /// Process-liveness advisory carried under the `process` key, when
     /// the daemon attached one (issue #81). Absent on responses that
     /// predate the field or carry no event.
-    public let advisory: ProcessAdvisory?
-    public let commandAdvisory: CommandAdvisory?
+    public let processAdvisory: ProcessAdvisory?
+    /// Per-command advisory carried under the `advisory` key.
+    public let advisory: CommandAdvisory?
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.data = try container.decode(T.self, forKey: .data)
-        self.advisory = try container.decodeIfPresent(ProcessAdvisory.self, forKey: .process)
-        self.commandAdvisory = try container.decodeIfPresent(CommandAdvisory.self, forKey: .advisory)
+        self.processAdvisory = try container.decodeIfPresent(ProcessAdvisory.self, forKey: .process)
+        self.advisory = try container.decodeIfPresent(CommandAdvisory.self, forKey: .advisory)
     }
 
     private enum CodingKeys: String, CodingKey { case data, process, advisory }

--- a/Sources/iOSSimBackend/A11y/AXDisplayFrame.swift
+++ b/Sources/iOSSimBackend/A11y/AXDisplayFrame.swift
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+import Foundation
+
+/// Single definition of "the screen" for code that measures against
+/// display bounds derived from an AX snapshot (the full-screen tap
+/// advisory denominator, `--frame` relative-bound resolution).
+///
+/// Application-typed roots are the candidate set — the same rule
+/// `OutlineFormatter.pickRoot` applies when `describe-ui` renders the
+/// `(WxH)` screen header — and the largest positive-area frame among
+/// them wins, because root order is not guaranteed (keyboard / alert
+/// windows can precede the app). Trees without a usable
+/// Application-typed frame fall back to the largest positive-area
+/// root of any type rather than trusting `roots.first`.
+public enum AXDisplayFrame {
+    public static func frame(in roots: [AccessibilityElement]) -> AccessibilityElement.Frame? {
+        let usable = roots.compactMap { root -> (isApplication: Bool, frame: AccessibilityElement.Frame)? in
+            guard let frame = root.frame, frame.width > 0, frame.height > 0 else { return nil }
+            return (root.type == "Application", frame)
+        }
+        let applications = usable.filter(\.isApplication)
+        let pool = applications.isEmpty ? usable : applications
+        return pool.max { area($0.frame) < area($1.frame) }?.frame
+    }
+
+    private static func area(_ frame: AccessibilityElement.Frame) -> Double {
+        frame.width * frame.height
+    }
+}

--- a/Sources/iOSSimBackend/A11y/AccessibilityPoller.swift
+++ b/Sources/iOSSimBackend/A11y/AccessibilityPoller.swift
@@ -18,6 +18,29 @@ public struct AccessibilityPoller {
         rootsProvider: RootsProvider? = nil,
         logger: SimUseLogger
     ) async throws -> (x: Double, y: Double) {
+        let target = try await resolveWithPollingTarget(
+            query: query,
+            simulatorUDID: simulatorUDID,
+            waitTimeout: waitTimeout,
+            pollInterval: pollInterval,
+            elementType: elementType,
+            frameFilter: frameFilter,
+            rootsProvider: rootsProvider,
+            logger: logger
+        )
+        return (x: target.x, y: target.y)
+    }
+
+    public static func resolveWithPollingTarget(
+        query: AccessibilityQuery,
+        simulatorUDID: String,
+        waitTimeout: TimeInterval,
+        pollInterval: TimeInterval,
+        elementType: String? = nil,
+        frameFilter: AccessibilityTargetResolver.FrameFilter? = nil,
+        rootsProvider: RootsProvider? = nil,
+        logger: SimUseLogger
+    ) async throws -> AccessibilityTargetResolver.ResolvedTarget {
         // Non-batch callers pass no provider and keep the historical
         // fetch-every-time behaviour; batch passes the BatchContext cache.
         let fetchRoots: RootsProvider = rootsProvider ?? { _ in
@@ -26,7 +49,7 @@ public struct AccessibilityPoller {
 
         let roots = try await fetchRoots(false)
         do {
-            return try AccessibilityTargetResolver.resolveCenterPoint(roots: roots, query: query, elementType: elementType, frameFilter: frameFilter)
+            return try AccessibilityTargetResolver.resolveTarget(roots: roots, query: query, elementType: elementType, frameFilter: frameFilter)
         } catch let error as ElementResolutionError where error.isRetryableDuringWait && waitTimeout > 0 {
             let clock = ContinuousClock()
             let deadline = clock.now + .seconds(waitTimeout)
@@ -38,7 +61,7 @@ public struct AccessibilityPoller {
 
                 let freshRoots = try await fetchRoots(true)
                 do {
-                    return try AccessibilityTargetResolver.resolveCenterPoint(roots: freshRoots, query: query, elementType: elementType, frameFilter: frameFilter)
+                    return try AccessibilityTargetResolver.resolveTarget(roots: freshRoots, query: query, elementType: elementType, frameFilter: frameFilter)
                 } catch let retryError as ElementResolutionError where retryError.isRetryableDuringWait {
                     lastError = retryError
                     continue

--- a/Sources/iOSSimBackend/A11y/AccessibilityTargetResolver.swift
+++ b/Sources/iOSSimBackend/A11y/AccessibilityTargetResolver.swift
@@ -302,8 +302,8 @@ public struct AccessibilityTargetResolver {
         if let frameFilter, !frameFilter.isEmpty {
             let effective: FrameFilter
             if frameFilter.hasRelativeBounds {
-                guard let screen = roots.first?.frame else {
-                    throw ElementResolutionError.invalidFrame(reason: "--frame uses relative bounds but the AX root has no frame to resolve against.")
+                guard let screen = AXDisplayFrame.frame(in: roots) else {
+                    throw ElementResolutionError.invalidFrame(reason: "--frame uses relative bounds but no AX root has a usable frame to resolve against.")
                 }
                 effective = frameFilter.resolved(screen: screen)
             } else {

--- a/Sources/iOSSimBackend/A11y/AccessibilityTargetResolver.swift
+++ b/Sources/iOSSimBackend/A11y/AccessibilityTargetResolver.swift
@@ -8,6 +8,15 @@ public enum AccessibilityQuery {
     case value(String)
     case labelContains(String)
     case labelRegex(pattern: String)
+
+    public var tapAdvisoryQuery: String? {
+        switch self {
+        case .label(let value), .value(let value), .labelContains(let value):
+            return value
+        case .id, .labelRegex:
+            return nil
+        }
+    }
 }
 
 public enum ElementResolutionError: LocalizedError, HintProviding {
@@ -263,6 +272,27 @@ public struct AccessibilityTargetResolver {
         elementType: String? = nil,
         frameFilter: FrameFilter? = nil
     ) throws -> (x: Double, y: Double) {
+        let target = try resolveTarget(
+            roots: roots,
+            query: query,
+            elementType: elementType,
+            frameFilter: frameFilter
+        )
+        return (x: target.x, y: target.y)
+    }
+
+    public struct ResolvedTarget {
+        public let x: Double
+        public let y: Double
+        public let advisory: CommandAdvisory?
+    }
+
+    public static func resolveTarget(
+        roots: [AccessibilityElement],
+        query: AccessibilityQuery,
+        elementType: String? = nil,
+        frameFilter: FrameFilter? = nil
+    ) throws -> ResolvedTarget {
         var allElements = roots.flatMap { $0.flattened() }
 
         if let elementType {
@@ -293,7 +323,10 @@ public struct AccessibilityTargetResolver {
 
         let centerX = frame.x + (frame.width / 2.0)
         let centerY = frame.y + (frame.height / 2.0)
-        return (x: centerX, y: centerY)
+        let advisory = query.tapAdvisoryQuery.flatMap {
+            FullScreenTapAdvisory.advisory(matched: frame, roots: roots, query: $0)
+        }
+        return ResolvedTarget(x: centerX, y: centerY, advisory: advisory)
     }
 
     private static func matchElement(

--- a/Sources/iOSSimBackend/A11y/FullScreenTapAdvisory.swift
+++ b/Sources/iOSSimBackend/A11y/FullScreenTapAdvisory.swift
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+import Foundation
+import SimUseCore
+
+/// Warns when a selector resolves to a near-display-sized element. Canvas
+/// frameworks can expose a full-screen wrapper whose center is not the control
+/// the user meant to tap.
+public enum FullScreenTapAdvisory {
+    public static let threshold = 0.9
+
+    public static func advisory(
+        matched: AccessibilityElement.Frame,
+        roots: [AccessibilityElement],
+        query: String
+    ) -> CommandAdvisory? {
+        guard let screen = displayFrame(in: roots),
+              let message = message(matched: matched, screen: screen, query: query)
+        else { return nil }
+        return CommandAdvisory(kind: .fullScreenTapTarget, message: message)
+    }
+
+    public static func message(
+        matched: AccessibilityElement.Frame,
+        screen: AccessibilityElement.Frame,
+        query: String
+    ) -> String? {
+        guard screen.width > 0, screen.height > 0 else { return nil }
+        guard matched.width > 0, matched.height > 0 else { return nil }
+        let fraction = (matched.width * matched.height) / (screen.width * screen.height)
+        guard fraction >= threshold else { return nil }
+        let pct = Int((min(fraction, 1.0) * 100).rounded())
+        return "The element matching '\(query)' covers ~\(pct)% of the screen; " +
+            "tapping its center may hit a full-screen wrapper rather than the intended control. " +
+            "Use a positional @N/#N alias or explicit -x/-y coordinates."
+    }
+
+    private static func displayFrame(in roots: [AccessibilityElement]) -> AccessibilityElement.Frame? {
+        roots.compactMap(\.frame)
+            .filter { $0.width > 0 && $0.height > 0 }
+            .max { ($0.width * $0.height) < ($1.width * $1.height) }
+    }
+}

--- a/Sources/iOSSimBackend/A11y/FullScreenTapAdvisory.swift
+++ b/Sources/iOSSimBackend/A11y/FullScreenTapAdvisory.swift
@@ -13,7 +13,7 @@ public enum FullScreenTapAdvisory {
         roots: [AccessibilityElement],
         query: String
     ) -> CommandAdvisory? {
-        guard let screen = displayFrame(in: roots),
+        guard let screen = AXDisplayFrame.frame(in: roots),
               let message = message(matched: matched, screen: screen, query: query)
         else { return nil }
         return CommandAdvisory(kind: .fullScreenTapTarget, message: message)
@@ -32,11 +32,5 @@ public enum FullScreenTapAdvisory {
         return "The element matching '\(query)' covers ~\(pct)% of the screen; " +
             "tapping its center may hit a full-screen wrapper rather than the intended control. " +
             "Use a positional @N/#N alias or explicit -x/-y coordinates."
-    }
-
-    private static func displayFrame(in roots: [AccessibilityElement]) -> AccessibilityElement.Frame? {
-        roots.compactMap(\.frame)
-            .filter { $0.width > 0 && $0.height > 0 }
-            .max { ($0.width * $0.height) < ($1.width * $1.height) }
     }
 }

--- a/Sources/iOSSimBackend/Batch/BatchContext.swift
+++ b/Sources/iOSSimBackend/Batch/BatchContext.swift
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import ArgumentParser
 import Foundation
+import SimUseCore
 
 public enum AXCachePolicy: String, CaseIterable, ExpressibleByArgument, Sendable {
     case perBatch
@@ -28,6 +29,15 @@ public final class BatchContext {
 
     private let fetchElements: ElementFetcher
     private var cachedRoots: [AccessibilityElement]?
+    /// 1-based step number, advanced by `beginStep()`. Used to prefix
+    /// recorded advisories so a multi-step run says which step warned
+    /// (matching the "Step N failed" convention of the error path).
+    private var currentStepNumber = 0
+    /// Command advisories recorded while converting steps (e.g. a tap
+    /// selector resolving to a near-full-screen element). Collected here
+    /// because `BatchPrimitive`s carry only HID work — the batch command
+    /// merges these into its `ExecutionResult` after the run.
+    public private(set) var commandAdvisories: [CommandAdvisory] = []
 
     public init(
         simulatorUDID: String,
@@ -53,9 +63,19 @@ public final class BatchContext {
     /// next selector resolution refetches; `.perBatch` keeps the snapshot
     /// for the whole run and `.none` never caches in the first place.
     public func beginStep() {
+        currentStepNumber += 1
         if axCachePolicy == .perStep {
             cachedRoots = nil
         }
+    }
+
+    /// Record a per-command advisory raised while converting the current
+    /// step, prefixed with the step number when the run has entered one.
+    public func recordAdvisory(_ advisory: CommandAdvisory) {
+        let message = currentStepNumber > 0
+            ? "Step \(currentStepNumber): \(advisory.message)"
+            : advisory.message
+        commandAdvisories.append(CommandAdvisory(kind: advisory.kind, message: message))
     }
 
     /// Returns the AX roots honouring the cache policy. `forceRefresh`

--- a/Sources/iOSSimBackend/Batch/Command+BatchConvertible.swift
+++ b/Sources/iOSSimBackend/Batch/Command+BatchConvertible.swift
@@ -55,7 +55,7 @@ extension IOSSimTapCommand: BatchConvertible {
                 throw CLIError(errorDescription: "Unexpected state: no coordinates and no element query.")
             }
 
-            resolvedPoint = try await AccessibilityPoller.resolveWithPolling(
+            let target = try await AccessibilityPoller.resolveWithPollingTarget(
                 query: query,
                 simulatorUDID: context.simulatorUDID,
                 waitTimeout: context.waitTimeout,
@@ -67,6 +67,13 @@ extension IOSSimTapCommand: BatchConvertible {
                 },
                 logger: logger
             )
+            resolvedPoint = (target.x, target.y)
+            // Same full-screen-wrapper warning the standalone tap emits;
+            // batch has no per-step envelope, so it rides the context to
+            // the batch ExecutionResult.
+            if let advisory = target.advisory {
+                context.recordAdvisory(advisory)
+            }
         }
 
         if let duration, duration > 0 {

--- a/Sources/iOSSimBackend/Verbs/IOSSimBatchCommand.swift
+++ b/Sources/iOSSimBackend/Verbs/IOSSimBatchCommand.swift
@@ -10,11 +10,21 @@ import SimUseCore
 /// session plumbing has no Android equivalent. Reach via
 /// `sim-use ios batch` only.
 public struct IOSSimBatchCommand: SimUseExecutableCommand {
-    public struct ExecutionResult: Codable {
+    public struct ExecutionResult: Codable, CommandAdvisoryProviding {
         public let stepsExecuted: Int
-        public init(stepsExecuted: Int) {
+        /// Merged advisories recorded while resolving selector-based
+        /// steps (see `BatchContext.recordAdvisory`). Hoisted to the
+        /// envelope's top-level `advisory` key; excluded from the
+        /// encoded `data` payload via `CodingKeys` per the
+        /// `CommandAdvisoryProviding` contract.
+        public var commandAdvisory: CommandAdvisory? = nil
+
+        public init(stepsExecuted: Int, commandAdvisory: CommandAdvisory? = nil) {
             self.stepsExecuted = stepsExecuted
+            self.commandAdvisory = commandAdvisory
         }
+
+        private enum CodingKeys: String, CodingKey { case stepsExecuted }
     }
 
     public static let configuration = CommandConfiguration(
@@ -222,7 +232,11 @@ public struct IOSSimBatchCommand: SimUseExecutableCommand {
             throw CLIError(errorDescription: "Batch completed with \(failures.count) failure(s):\n\(failureMessage)")
         }
 
-        return ExecutionResult(stepsExecuted: stepLines.count)
+        let advisories = await MainActor.run { context.commandAdvisories }
+        return ExecutionResult(
+            stepsExecuted: stepLines.count,
+            commandAdvisory: CommandAdvisory.merged(advisories)
+        )
     }
 
     public func format(_ result: ExecutionResult) -> CommandOutput {

--- a/Sources/iOSSimBackend/Verbs/IOSSimTapCommand.swift
+++ b/Sources/iOSSimBackend/Verbs/IOSSimTapCommand.swift
@@ -101,34 +101,21 @@ public struct IOSSimTapCommand: SimUseExecutableCommand {
     public struct ExecutionResult: Codable, CommandAdvisoryProviding {
         public let x: Double
         public let y: Double
-        public let advisory: CommandAdvisory?
+        /// Excluded from the encoded `data` payload via `CodingKeys`
+        /// (the default value keeps decode synthesis working) — the
+        /// envelope hoists it to the top-level `advisory` key. See
+        /// `CommandAdvisoryProviding` for the contract.
+        public var commandAdvisory: CommandAdvisory? = nil
 
-        public init(x: Double, y: Double, advisory: CommandAdvisory? = nil) {
+        public init(x: Double, y: Double, commandAdvisory: CommandAdvisory? = nil) {
             self.x = x
             self.y = y
-            self.advisory = advisory
-        }
-
-        public var commandAdvisory: CommandAdvisory? {
-            advisory
+            self.commandAdvisory = commandAdvisory
         }
 
         private enum CodingKeys: String, CodingKey {
             case x
             case y
-        }
-
-        public init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.x = try container.decode(Double.self, forKey: .x)
-            self.y = try container.decode(Double.self, forKey: .y)
-            self.advisory = nil
-        }
-
-        public func encode(to encoder: Encoder) throws {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try container.encode(x, forKey: .x)
-            try container.encode(y, forKey: .y)
         }
     }
 
@@ -434,7 +421,7 @@ public struct IOSSimTapCommand: SimUseExecutableCommand {
         }
 
         logger.info().log("Tap completed successfully")
-        return ExecutionResult(x: resolvedPoint.x, y: resolvedPoint.y, advisory: resolvedAdvisory)
+        return ExecutionResult(x: resolvedPoint.x, y: resolvedPoint.y, commandAdvisory: resolvedAdvisory)
     }
 
     public func format(_ result: ExecutionResult) -> CommandOutput {

--- a/Sources/iOSSimBackend/Verbs/IOSSimTapCommand.swift
+++ b/Sources/iOSSimBackend/Verbs/IOSSimTapCommand.swift
@@ -98,13 +98,37 @@ public struct IOSSimTapCommand: SimUseExecutableCommand {
         return filter.isEmpty ? nil : filter
     }
 
-    public struct ExecutionResult: Codable {
+    public struct ExecutionResult: Codable, CommandAdvisoryProviding {
         public let x: Double
         public let y: Double
+        public let advisory: CommandAdvisory?
 
-        public init(x: Double, y: Double) {
+        public init(x: Double, y: Double, advisory: CommandAdvisory? = nil) {
             self.x = x
             self.y = y
+            self.advisory = advisory
+        }
+
+        public var commandAdvisory: CommandAdvisory? {
+            advisory
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case x
+            case y
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.x = try container.decode(Double.self, forKey: .x)
+            self.y = try container.decode(Double.self, forKey: .y)
+            self.advisory = nil
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(x, forKey: .x)
+            try container.encode(y, forKey: .y)
         }
     }
 
@@ -254,6 +278,7 @@ public struct IOSSimTapCommand: SimUseExecutableCommand {
 
         let resolvedPoint: (x: Double, y: Double)
         let resolvedDescription: String
+        let resolvedAdvisory: CommandAdvisory?
 
         if let alias {
             switch OutlineAliasResolver.parse(alias) {
@@ -262,6 +287,7 @@ public struct IOSSimTapCommand: SimUseExecutableCommand {
                     let resolved = try OutlineAliasResolver.resolve(alias, udid: device.resolved)
                     resolvedPoint = resolved.point
                     resolvedDescription = resolved.humanDescription
+                    resolvedAdvisory = nil
                 } catch {
                     if !jsonOutput {
                         print("Warning: \(error.localizedDescription) No tap performed.", to: &standardError)
@@ -274,7 +300,7 @@ public struct IOSSimTapCommand: SimUseExecutableCommand {
                 // handling. No alias cache read — the selector is
                 // self-contained and works across multiple snapshots.
                 do {
-                    resolvedPoint = try await AccessibilityPoller.resolveWithPolling(
+                    let target = try await AccessibilityPoller.resolveWithPollingTarget(
                         query: .id(uniqueId),
                         simulatorUDID: device.resolved,
                         waitTimeout: waitTimeout,
@@ -283,6 +309,8 @@ public struct IOSSimTapCommand: SimUseExecutableCommand {
                         frameFilter: frameFilter,
                         logger: logger
                     )
+                    resolvedPoint = (x: target.x, y: target.y)
+                    resolvedAdvisory = target.advisory
                     resolvedDescription = "#\(uniqueId) (AXUniqueId) at (\(resolvedPoint.x), \(resolvedPoint.y))"
                 } catch let error as ElementResolutionError {
                     if !jsonOutput {
@@ -296,6 +324,7 @@ public struct IOSSimTapCommand: SimUseExecutableCommand {
         } else if let pointX, let pointY {
             resolvedPoint = (x: pointX, y: pointY)
             resolvedDescription = "(\(pointX), \(pointY))"
+            resolvedAdvisory = nil
         } else {
             let query: AccessibilityQuery
             if let elementID {
@@ -313,7 +342,7 @@ public struct IOSSimTapCommand: SimUseExecutableCommand {
             }
 
             do {
-                resolvedPoint = try await AccessibilityPoller.resolveWithPolling(
+                let target = try await AccessibilityPoller.resolveWithPollingTarget(
                     query: query,
                     simulatorUDID: device.resolved,
                     waitTimeout: waitTimeout,
@@ -322,6 +351,8 @@ public struct IOSSimTapCommand: SimUseExecutableCommand {
                     frameFilter: frameFilter,
                     logger: logger
                 )
+                resolvedPoint = (x: target.x, y: target.y)
+                resolvedAdvisory = target.advisory
             } catch let error as ElementResolutionError {
                 if !jsonOutput {
                     print("Warning: \(error.localizedDescription) No tap performed.", to: &standardError)
@@ -403,7 +434,7 @@ public struct IOSSimTapCommand: SimUseExecutableCommand {
         }
 
         logger.info().log("Tap completed successfully")
-        return ExecutionResult(x: resolvedPoint.x, y: resolvedPoint.y)
+        return ExecutionResult(x: resolvedPoint.x, y: resolvedPoint.y, advisory: resolvedAdvisory)
     }
 
     public func format(_ result: ExecutionResult) -> CommandOutput {

--- a/Tests/AccessibilityTargetResolverTests.swift
+++ b/Tests/AccessibilityTargetResolverTests.swift
@@ -305,6 +305,36 @@ struct FrameFilterIntegrationTests {
         }
     }
 
+    @Test("relative frame filter uses the Application root when a non-app root comes first")
+    func relFrameSkipsLeadingNonAppRoot() throws {
+        // A keyboard-style window precedes the app root; 0.7r must
+        // resolve against the app's 800-tall frame (y >= 560), not the
+        // keyboard's 300-tall one (y >= 710, which would reject the
+        // y=700 cell and fail the resolution).
+        let json: [[String: Any]] = [
+            [
+                "type": "Window",
+                "AXLabel": "Keyboard",
+                "frame": ["x": 0, "y": 500, "width": 400, "height": 300],
+            ],
+            [
+                "type": "Application",
+                "AXLabel": "App",
+                "frame": ["x": 0, "y": 0, "width": 400, "height": 800],
+                "children": [
+                    cellJSON(label: "Header", x: 0, y: 50),
+                    cellJSON(label: "Header", x: 0, y: 700),
+                ],
+            ],
+        ]
+        let roots = try decodeRoots(json)
+        let filter = try AccessibilityTargetResolver.FrameFilter(specs: ["minY=0.7r"])
+        let point = try AccessibilityTargetResolver.resolveCenterPoint(
+            roots: roots, query: .label("Header"), frameFilter: filter
+        )
+        #expect(point.y == 720)
+    }
+
     @Test("relative frame filter without an AX root frame surfaces invalidFrame")
     func relWithoutScreenFrame() throws {
         // Build a tree where the first root has no frame at all.

--- a/Tests/BatchAdvisoryTests.swift
+++ b/Tests/BatchAdvisoryTests.swift
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+@testable import iOSSimBackend
+import Foundation
+import SimUseCore
+import Testing
+
+// The full-screen tap advisory must survive the batch path: selector
+// steps resolve inside `toBatchPrimitives` (never the standalone tap
+// command), so the advisory rides `BatchContext` into the batch
+// `ExecutionResult` instead of the per-command envelope hoist. These
+// tests pin that plumbing with an injected fetcher (no simulator).
+
+/// One Application root: a wrapper covering the whole 400x800 screen
+/// plus a small normal button.
+private func makeAdvisoryTree() throws -> [AccessibilityElement] {
+    let json = """
+    [{"type": "Application", "AXLabel": "App", "frame": {"x": 0, "y": 0, "width": 400, "height": 800}, "children": [
+        {"type": "Other", "AXLabel": "Flutter wrapper", "frame": {"x": 0, "y": 0, "width": 400, "height": 800}},
+        {"type": "Button", "AXLabel": "Small", "frame": {"x": 10, "y": 700, "width": 100, "height": 40}, "enabled": true}
+    ]}]
+    """
+    return try JSONDecoder().decode([AccessibilityElement].self, from: Data(json.utf8))
+}
+
+@MainActor
+private func makeContext(tree: [AccessibilityElement]) -> BatchContext {
+    BatchContext(
+        simulatorUDID: "FAKE-UDID",
+        axCachePolicy: .perBatch,
+        typeSubmissionMode: .chunked,
+        typeChunkSize: 200,
+        fetchElements: { _, _ in tree }
+    )
+}
+
+private let quietLogger = SimUseLogger(writeToStdErr: false)
+
+@Suite("Batch — full-screen tap advisory")
+@MainActor
+struct BatchAdvisoryTests {
+    private func parseStep(_ tokens: [String], context: BatchContext) async throws -> [BatchPrimitive] {
+        context.beginStep()
+        return try await BatchStepParser.parseStepTokens(
+            tokens,
+            globalUDID: "FAKE-UDID",
+            context: context,
+            logger: quietLogger
+        )
+    }
+
+    @Test("tap-by-label on a full-screen wrapper records a step-prefixed advisory")
+    func recordsAdvisoryForFullScreenTap() async throws {
+        let context = makeContext(tree: try makeAdvisoryTree())
+
+        _ = try await parseStep(["tap", "--label", "Small"], context: context)
+        _ = try await parseStep(["tap", "--label", "Flutter wrapper"], context: context)
+
+        #expect(context.commandAdvisories.count == 1)
+        let advisory = try #require(context.commandAdvisories.first)
+        #expect(advisory.kind == .fullScreenTapTarget)
+        #expect(advisory.message.hasPrefix("Step 2: "))
+        #expect(advisory.message.contains("Flutter wrapper"))
+    }
+
+    @Test("coordinate and normal-selector steps record nothing")
+    func noAdvisoryForNormalSteps() async throws {
+        let context = makeContext(tree: try makeAdvisoryTree())
+
+        _ = try await parseStep(["tap", "-x", "10", "-y", "10"], context: context)
+        _ = try await parseStep(["tap", "--label", "Small"], context: context)
+
+        #expect(context.commandAdvisories.isEmpty)
+    }
+}

--- a/Tests/CommandAdvisoryContractTests.swift
+++ b/Tests/CommandAdvisoryContractTests.swift
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+@testable import iOSSimBackend
+import Foundation
+import SimUseCore
+import Testing
+
+// Pins the CommandAdvisoryProviding exclude-from-data contract for every
+// conformer: the envelope hoists `commandAdvisory` to the top-level
+// `advisory` key, so a result type that also encoded the advisory inside
+// its own payload would silently duplicate it on the wire (and leak an
+// object no client schema expects). Nothing enforces the exclusion at
+// compile time — new conformers must register here.
+
+private let contractAdvisory = CommandAdvisory(kind: .fullScreenTapTarget, message: "check target")
+
+private func encodedJSON<T: Encodable>(_ value: T) throws -> String {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+    return String(decoding: try encoder.encode(value), as: UTF8.self)
+}
+
+@Suite("CommandAdvisoryProviding — exclude-from-data contract")
+struct CommandAdvisoryContractTests {
+    @Test("tap result encodes without the advisory and decodes it as nil")
+    func tapResult() throws {
+        let result = IOSSimTapCommand.ExecutionResult(x: 10, y: 20, commandAdvisory: contractAdvisory)
+        #expect(result.commandAdvisory == contractAdvisory)
+
+        let json = try encodedJSON(result)
+        #expect(json == #"{"x":10,"y":20}"#)
+
+        let decoded = try JSONDecoder().decode(IOSSimTapCommand.ExecutionResult.self, from: Data(json.utf8))
+        #expect(decoded.commandAdvisory == nil)
+        #expect(decoded.x == 10)
+        #expect(decoded.y == 20)
+    }
+
+    @Test("batch result encodes without the advisory and decodes it as nil")
+    func batchResult() throws {
+        let result = IOSSimBatchCommand.ExecutionResult(stepsExecuted: 3, commandAdvisory: contractAdvisory)
+        #expect(result.commandAdvisory == contractAdvisory)
+
+        let json = try encodedJSON(result)
+        #expect(json == #"{"stepsExecuted":3}"#)
+
+        let decoded = try JSONDecoder().decode(IOSSimBatchCommand.ExecutionResult.self, from: Data(json.utf8))
+        #expect(decoded.commandAdvisory == nil)
+        #expect(decoded.stepsExecuted == 3)
+    }
+}

--- a/Tests/DaemonProtocolTests.swift
+++ b/Tests/DaemonProtocolTests.swift
@@ -109,7 +109,7 @@ struct DaemonSuccessResponseTests {
 
     @Test("Advisory is omitted from the envelope when nil")
     func advisoryOmittedWhenNil() throws {
-        let resp = DaemonSuccessResponse(data: Payload(foo: "bar", count: 3), advisory: nil)
+        let resp = DaemonSuccessResponse(data: Payload(foo: "bar", count: 3), processAdvisory: nil)
         let text = jsonString(try encoderStable().encode(resp))
         #expect(text == #"{"data":{"count":3,"foo":"bar"},"ok":true}"#)
     }
@@ -119,7 +119,7 @@ struct DaemonSuccessResponseTests {
         let event = ProcessEvent(kind: .disappeared, bundleId: "com.x", pid: 100, confidence: .high)
         let resp = DaemonSuccessResponse(
             data: Payload(foo: "bar", count: 3),
-            advisory: ProcessAdvisory(events: [event], pending: [])
+            processAdvisory: ProcessAdvisory(events: [event], pending: [])
         )
         let text = jsonString(try encoderStable().encode(resp))
         #expect(text == #"{"data":{"count":3,"foo":"bar"},"ok":true,"process":{"events":[{"bundleId":"com.x","confidence":"high","kind":"disappeared","pid":100}],"pending":[]}}"#)
@@ -129,7 +129,7 @@ struct DaemonSuccessResponseTests {
     func commandAdvisoryNestsUnderAdvisory() throws {
         let resp = DaemonSuccessResponse(
             data: Payload(foo: "bar", count: 3),
-            commandAdvisory: CommandAdvisory(kind: .fullScreenTapTarget, message: "check target")
+            advisory: CommandAdvisory(kind: .fullScreenTapTarget, message: "check target")
         )
         let text = jsonString(try encoderStable().encode(resp))
         #expect(text == #"{"advisory":{"kind":"full_screen_tap_target","message":"check target"},"data":{"count":3,"foo":"bar"},"ok":true}"#)

--- a/Tests/DaemonProtocolTests.swift
+++ b/Tests/DaemonProtocolTests.swift
@@ -124,6 +124,16 @@ struct DaemonSuccessResponseTests {
         let text = jsonString(try encoderStable().encode(resp))
         #expect(text == #"{"data":{"count":3,"foo":"bar"},"ok":true,"process":{"events":[{"bundleId":"com.x","confidence":"high","kind":"disappeared","pid":100}],"pending":[]}}"#)
     }
+
+    @Test("Command advisory nests under the advisory key when present")
+    func commandAdvisoryNestsUnderAdvisory() throws {
+        let resp = DaemonSuccessResponse(
+            data: Payload(foo: "bar", count: 3),
+            commandAdvisory: CommandAdvisory(kind: .fullScreenTapTarget, message: "check target")
+        )
+        let text = jsonString(try encoderStable().encode(resp))
+        #expect(text == #"{"advisory":{"kind":"full_screen_tap_target","message":"check target"},"data":{"count":3,"foo":"bar"},"ok":true}"#)
+    }
 }
 
 // MARK: - DaemonPingData

--- a/Tests/DaemonProtocolTests.swift
+++ b/Tests/DaemonProtocolTests.swift
@@ -136,6 +136,39 @@ struct DaemonSuccessResponseTests {
     }
 }
 
+// MARK: - DaemonClientSuccessPayload
+
+@Suite("DaemonClientSuccessPayload decoding")
+struct DaemonClientSuccessPayloadTests {
+    private struct Payload: Decodable, Equatable {
+        let foo: String
+    }
+
+    @Test("Decodes data plus a known command advisory")
+    func decodesKnownAdvisory() throws {
+        let wire = Data(#"{"advisory":{"kind":"full_screen_tap_target","message":"m"},"data":{"foo":"bar"},"ok":true}"#.utf8)
+        let payload = try JSONDecoder().decode(DaemonClientSuccessPayload<Payload>.self, from: wire)
+        #expect(payload.data == Payload(foo: "bar"))
+        #expect(payload.advisory == CommandAdvisory(kind: .fullScreenTapTarget, message: "m"))
+    }
+
+    @Test("An unknown advisory kind from a newer daemon is dropped, not fatal")
+    func unknownAdvisoryKindIsDropped() throws {
+        let wire = Data(#"{"advisory":{"kind":"from_the_future","message":"m"},"data":{"foo":"bar"},"ok":true}"#.utf8)
+        let payload = try JSONDecoder().decode(DaemonClientSuccessPayload<Payload>.self, from: wire)
+        #expect(payload.data == Payload(foo: "bar"))
+        #expect(payload.advisory == nil)
+    }
+
+    @Test("Absent advisory decodes as nil")
+    func absentAdvisoryIsNil() throws {
+        let wire = Data(#"{"data":{"foo":"bar"},"ok":true}"#.utf8)
+        let payload = try JSONDecoder().decode(DaemonClientSuccessPayload<Payload>.self, from: wire)
+        #expect(payload.advisory == nil)
+        #expect(payload.processAdvisory == nil)
+    }
+}
+
 // MARK: - DaemonPingData
 
 @Suite("DaemonPingData codable round-trip")

--- a/Tests/FullScreenTapAdvisoryTests.swift
+++ b/Tests/FullScreenTapAdvisoryTests.swift
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+@testable import iOSSimBackend
+import Foundation
+import SimUseCore
+import Testing
+
+private func advisoryFrame(_ x: Double, _ y: Double, _ w: Double, _ h: Double) -> AccessibilityElement.Frame {
+    let dict: [String: Any] = ["x": x, "y": y, "width": w, "height": h]
+    let data = try! JSONSerialization.data(withJSONObject: dict)
+    return try! JSONDecoder().decode(AccessibilityElement.Frame.self, from: data)
+}
+
+private func advisoryElement(
+    type: String = "Application",
+    label: String = "App",
+    frame: AccessibilityElement.Frame,
+    children: [[String: Any]] = []
+) throws -> AccessibilityElement {
+    var dict: [String: Any] = [
+        "type": type,
+        "AXLabel": label,
+        "frame": ["x": frame.x, "y": frame.y, "width": frame.width, "height": frame.height],
+    ]
+    if !children.isEmpty {
+        dict["children"] = children
+    }
+    let data = try JSONSerialization.data(withJSONObject: dict)
+    return try JSONDecoder().decode(AccessibilityElement.self, from: data)
+}
+
+@Suite("FullScreenTapAdvisory")
+struct FullScreenTapAdvisoryTests {
+    private let screen = advisoryFrame(0, 0, 400, 800)
+
+    @Test("warns when matched element covers the display")
+    func warnsOnFullScreenMatch() {
+        let message = FullScreenTapAdvisory.message(
+            matched: advisoryFrame(0, 0, 400, 800),
+            screen: screen,
+            query: "Flutter wrapper"
+        )
+        #expect(message?.contains("100%") == true)
+        #expect(message?.contains("Flutter wrapper") == true)
+    }
+
+    @Test("warns at the 90% threshold")
+    func warnsAtThreshold() {
+        let message = FullScreenTapAdvisory.message(
+            matched: advisoryFrame(0, 0, 400, 720),
+            screen: screen,
+            query: "x"
+        )
+        #expect(message != nil)
+    }
+
+    @Test("stays silent for normal controls")
+    func silentForNormalControl() {
+        let message = FullScreenTapAdvisory.message(
+            matched: advisoryFrame(10, 700, 80, 40),
+            screen: screen,
+            query: "x"
+        )
+        #expect(message == nil)
+    }
+
+    @Test("uses the largest root frame as display denominator")
+    func usesLargestRootFrame() throws {
+        let keyboardRoot = try advisoryElement(
+            label: "Keyboard",
+            frame: advisoryFrame(0, 500, 400, 300)
+        )
+        let appRoot = try advisoryElement(
+            label: "App",
+            frame: screen,
+            children: [[
+                "type": "Button",
+                "AXLabel": "Submit",
+                "frame": ["x": 0, "y": 0, "width": 400, "height": 300],
+            ]]
+        )
+
+        let target = try AccessibilityTargetResolver.resolveTarget(
+            roots: [keyboardRoot, appRoot],
+            query: .label("Submit")
+        )
+
+        #expect(target.x == 200)
+        #expect(target.y == 150)
+        #expect(target.advisory == nil)
+    }
+
+    @Test("tap execution result keeps advisory out of data payload")
+    func tapResultDoesNotEncodeAdvisoryInData() throws {
+        let result = IOSSimTapCommand.ExecutionResult(
+            x: 10,
+            y: 20,
+            advisory: CommandAdvisory(kind: .fullScreenTapTarget, message: "check target")
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        let text = String(data: try encoder.encode(result), encoding: .utf8)
+        #expect(text == #"{"x":10,"y":20}"#)
+    }
+}

--- a/Tests/FullScreenTapAdvisoryTests.swift
+++ b/Tests/FullScreenTapAdvisoryTests.swift
@@ -89,6 +89,43 @@ struct FullScreenTapAdvisoryTests {
         #expect(target.advisory == nil)
     }
 
+    @Test("prefers the Application root over a larger non-Application root")
+    func prefersApplicationRootOverLargerWindow() throws {
+        // A scroll-canvas window taller than the display must not
+        // deflate the coverage fraction: the wrapper is 97.5% of the
+        // Application root but only 26% of the canvas window.
+        let canvasRoot = try advisoryElement(
+            type: "Window",
+            label: "Canvas",
+            frame: advisoryFrame(0, 0, 400, 3000)
+        )
+        let appRoot = try advisoryElement(
+            label: "App",
+            frame: screen,
+            children: [[
+                "type": "Other",
+                "AXLabel": "Full Screen Wrapper",
+                "frame": ["x": 0, "y": 10, "width": 400, "height": 780],
+            ]]
+        )
+
+        let target = try AccessibilityTargetResolver.resolveTarget(
+            roots: [canvasRoot, appRoot],
+            query: .label("Full Screen Wrapper")
+        )
+
+        #expect(target.advisory != nil)
+    }
+
+    @Test("display frame falls back to the largest root when no Application root has a frame")
+    func fallsBackToLargestRootWithoutApplication() throws {
+        let smallWindow = try advisoryElement(type: "Window", label: "Overlay", frame: advisoryFrame(0, 0, 100, 100))
+        let bigWindow = try advisoryElement(type: "Window", label: "Main", frame: advisoryFrame(0, 0, 400, 800))
+        let frame = try #require(AXDisplayFrame.frame(in: [smallWindow, bigWindow]))
+        #expect(frame.width == 400)
+        #expect(frame.height == 800)
+    }
+
     @Test("tap execution result keeps advisory out of data payload")
     func tapResultDoesNotEncodeAdvisoryInData() throws {
         let result = IOSSimTapCommand.ExecutionResult(

--- a/Tests/FullScreenTapAdvisoryTests.swift
+++ b/Tests/FullScreenTapAdvisoryTests.swift
@@ -125,17 +125,8 @@ struct FullScreenTapAdvisoryTests {
         #expect(frame.width == 400)
         #expect(frame.height == 800)
     }
-
-    @Test("tap execution result keeps advisory out of data payload")
-    func tapResultDoesNotEncodeAdvisoryInData() throws {
-        let result = IOSSimTapCommand.ExecutionResult(
-            x: 10,
-            y: 20,
-            advisory: CommandAdvisory(kind: .fullScreenTapTarget, message: "check target")
-        )
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
-        let text = String(data: try encoder.encode(result), encoding: .utf8)
-        #expect(text == #"{"x":10,"y":20}"#)
-    }
 }
+
+// The exclude-from-data assertion for the tap ExecutionResult moved to
+// CommandAdvisoryContractTests, the single home that pins the contract
+// for every CommandAdvisoryProviding conformer.

--- a/Tests/SimUseCoreTests/JSONEnvelopeWriterTests.swift
+++ b/Tests/SimUseCoreTests/JSONEnvelopeWriterTests.swift
@@ -57,6 +57,15 @@ struct JSONEnvelopeWriterTests {
         #expect(json == #"{"data":{"platform":"ios","visible":true},"ok":true,"process":{"events":[{"bundleId":"com.x","confidence":"high","kind":"disappeared","pid":100}],"pending":[]}}"#)
     }
 
+    @Test("success envelope carries command advisory under `advisory` when present")
+    func successEnvelopeWithCommandAdvisory() throws {
+        let payload = SamplePayload(platform: "ios", visible: true, imePackage: nil)
+        let advisory = CommandAdvisory(kind: .fullScreenTapTarget, message: "check target")
+        let bytes = try JSONEnvelopeWriter.encodeSuccess(payload, commandAdvisory: advisory)
+        let json = try #require(String(data: bytes, encoding: .utf8))
+        #expect(json == #"{"advisory":{"kind":"full_screen_tap_target","message":"check target"},"data":{"platform":"ios","visible":true},"ok":true}"#)
+    }
+
     @Test("success envelope omits `process` when advisory is nil or empty")
     func successEnvelopeAdvisoryOmitted() throws {
         let payload = SamplePayload(platform: "ios", visible: true, imePackage: nil)
@@ -64,6 +73,12 @@ struct JSONEnvelopeWriterTests {
         #expect(try #require(String(data: nilCase, encoding: .utf8)) == #"{"data":{"platform":"ios","visible":true},"ok":true}"#)
         let emptyCase = try JSONEnvelopeWriter.encodeSuccess(payload, advisory: ProcessAdvisory(events: [], pending: []))
         #expect(try #require(String(data: emptyCase, encoding: .utf8)) == #"{"data":{"platform":"ios","visible":true},"ok":true}"#)
+    }
+
+    @Test("command advisory renderer emits the client-side info line")
+    func commandAdvisoryRenderer() {
+        let advisory = CommandAdvisory(kind: .fullScreenTapTarget, message: "check target")
+        #expect(CommandAdvisoryRenderer.banner(for: advisory) == "[i] check target")
     }
 
     @Test("error envelope without hint omits the hint key entirely")

--- a/Tests/SimUseCoreTests/JSONEnvelopeWriterTests.swift
+++ b/Tests/SimUseCoreTests/JSONEnvelopeWriterTests.swift
@@ -81,6 +81,22 @@ struct JSONEnvelopeWriterTests {
         #expect(CommandAdvisoryRenderer.banner(for: advisory) == "[i] check target")
     }
 
+    @Test("command advisory renderer prefixes every line of a multi-line message")
+    func commandAdvisoryRendererMultiLine() {
+        let advisory = CommandAdvisory(kind: .fullScreenTapTarget, message: "Step 1: a\nStep 3: b")
+        #expect(CommandAdvisoryRenderer.banner(for: advisory) == "[i] Step 1: a\n[i] Step 3: b")
+    }
+
+    @Test("merged advisories collapse into one line-joined advisory")
+    func mergedAdvisories() {
+        #expect(CommandAdvisory.merged([]) == nil)
+        let single = CommandAdvisory(kind: .fullScreenTapTarget, message: "only")
+        #expect(CommandAdvisory.merged([single]) == single)
+        let other = CommandAdvisory(kind: .fullScreenTapTarget, message: "second")
+        #expect(CommandAdvisory.merged([single, other])
+            == CommandAdvisory(kind: .fullScreenTapTarget, message: "only\nsecond"))
+    }
+
     @Test("error envelope without hint omits the hint key entirely")
     func errorEnvelopeWithoutHint() throws {
         struct PlainError: Error, LocalizedError {

--- a/Tests/SimUseCoreTests/JSONEnvelopeWriterTests.swift
+++ b/Tests/SimUseCoreTests/JSONEnvelopeWriterTests.swift
@@ -52,7 +52,7 @@ struct JSONEnvelopeWriterTests {
             events: [ProcessEvent(kind: .disappeared, bundleId: "com.x", pid: 100, confidence: .high)],
             pending: []
         )
-        let bytes = try JSONEnvelopeWriter.encodeSuccess(payload, advisory: advisory)
+        let bytes = try JSONEnvelopeWriter.encodeSuccess(payload, processAdvisory: advisory)
         let json = try #require(String(data: bytes, encoding: .utf8))
         #expect(json == #"{"data":{"platform":"ios","visible":true},"ok":true,"process":{"events":[{"bundleId":"com.x","confidence":"high","kind":"disappeared","pid":100}],"pending":[]}}"#)
     }
@@ -61,7 +61,7 @@ struct JSONEnvelopeWriterTests {
     func successEnvelopeWithCommandAdvisory() throws {
         let payload = SamplePayload(platform: "ios", visible: true, imePackage: nil)
         let advisory = CommandAdvisory(kind: .fullScreenTapTarget, message: "check target")
-        let bytes = try JSONEnvelopeWriter.encodeSuccess(payload, commandAdvisory: advisory)
+        let bytes = try JSONEnvelopeWriter.encodeSuccess(payload, advisory: advisory)
         let json = try #require(String(data: bytes, encoding: .utf8))
         #expect(json == #"{"advisory":{"kind":"full_screen_tap_target","message":"check target"},"data":{"platform":"ios","visible":true},"ok":true}"#)
     }
@@ -69,9 +69,9 @@ struct JSONEnvelopeWriterTests {
     @Test("success envelope omits `process` when advisory is nil or empty")
     func successEnvelopeAdvisoryOmitted() throws {
         let payload = SamplePayload(platform: "ios", visible: true, imePackage: nil)
-        let nilCase = try JSONEnvelopeWriter.encodeSuccess(payload, advisory: nil)
+        let nilCase = try JSONEnvelopeWriter.encodeSuccess(payload, processAdvisory: nil)
         #expect(try #require(String(data: nilCase, encoding: .utf8)) == #"{"data":{"platform":"ios","visible":true},"ok":true}"#)
-        let emptyCase = try JSONEnvelopeWriter.encodeSuccess(payload, advisory: ProcessAdvisory(events: [], pending: []))
+        let emptyCase = try JSONEnvelopeWriter.encodeSuccess(payload, processAdvisory: ProcessAdvisory(events: [], pending: []))
         #expect(try #require(String(data: emptyCase, encoding: .utf8)) == #"{"data":{"platform":"ios","visible":true},"ok":true}"#)
     }
 

--- a/Tests/SimUseExecutableCommandDaemonTests.swift
+++ b/Tests/SimUseExecutableCommandDaemonTests.swift
@@ -46,6 +46,25 @@ private struct FakeDaemonCommand: SimUseExecutableCommand {
     }
 }
 
+private struct FakeAdvisoryCommand: SimUseExecutableCommand {
+    static let configuration = CommandConfiguration(commandName: "fake-advisory-cmd")
+
+    @Flag(name: .customLong("json"))
+    var jsonOutput: Bool = false
+
+    func execute() async throws -> FakeResult {
+        FakeResult()
+    }
+
+    func format(_ result: FakeResult) -> CommandOutput { CommandOutput() }
+
+    struct FakeResult: Codable, CommandAdvisoryProviding {
+        var commandAdvisory: CommandAdvisory? {
+            CommandAdvisory(kind: .fullScreenTapTarget, message: "check target")
+        }
+    }
+}
+
 private enum ResolverProbe: LocalizedError {
     case simulated
     var errorDescription: String? { "simulated resolver failure" }
@@ -78,5 +97,13 @@ struct DaemonExecuteOrderTests {
         } catch let error as ResolverProbe {
             #expect(error == .simulated)
         }
+    }
+
+    @Test("daemon response carries command advisory outside data")
+    func commandAdvisoryIsTopLevel() async throws {
+        var cmd = FakeAdvisoryCommand()
+        let data = try await cmd.executeAsDaemonResponse(id: nil)
+        let text = try #require(String(data: data, encoding: .utf8))
+        #expect(text == #"{"advisory":{"kind":"full_screen_tap_target","message":"check target"},"data":{},"ok":true}"#)
     }
 }

--- a/skills/sim-use/SKILL.md
+++ b/skills/sim-use/SKILL.md
@@ -86,6 +86,7 @@ Quick symptom index — see `references/pitfalls.md` for detailed recipes.
 | iOS: `paste` drops text | Soft keyboard only; HID Cmd+V is ignored | Use `paste --via-menu --target-id <id>` |
 | Android: `paste` denied | Background clipboard access blocked | Use `type` instead |
 | Outline shows `U+FFFC` in label | iOS icon placeholder character | Match with `--label-regex` excluding the prefix |
+| `[i] … covers ~N% of the screen` warning (text output, or `--json` top-level `advisory` key) | The selector resolved to a near-full-screen wrapper (common on Flutter/canvas UIs) and the tap hit its center, likely missing the intended control | Re-run `ui` and target the control via `@N`/`#<id>`, or pass explicit `-x/-y` |
 
 ## 3. Crash awareness
 


### PR DESCRIPTION
## Summary

Builds on #29 by @joonyeonglim (the first commit is theirs, unchanged) and layers on the fixes from our review of that PR. #29's envelope transport is sound and follows the direction requested in #24 — this branch closes the gaps review found rather than reworking the design.

## What's added on top of #29

1. **Batch coverage** — batch tap steps resolved selectors through the point-only `resolveWithPolling` wrapper, so a step `tap --label X` hitting a near-full-screen wrapper warned nowhere while the identical standalone tap warned. Steps now record the advisory on `BatchContext` (prefixed `Step N:`), and the batch `ExecutionResult` merges them into the envelope's `advisory` slot. The renderer prefixes each line of a multi-line message with `[i] `.

2. **One definition of "the screen"** — `resolveTarget` resolved `--frame` relative bounds against `roots.first?.frame` while the advisory measured against the largest-area root, and `describe-ui` uses the Application-typed root. New `AXDisplayFrame` (largest positive-area Application-typed root, falling back to largest root of any type) now backs both the advisory denominator and relative `--frame` resolution, so a keyboard/alert window preceding the app root can no longer skew either.

3. **Exclude-from-data contract, documented and pinned** — the envelope hoists `commandAdvisory` out of the result, so a conformer relying on synthesized Codable would silently duplicate the advisory inside `data`. The contract is now spelled out on `CommandAdvisoryProviding` and pinned in `CommandAdvisoryContractTests` for every conformer. The tap `ExecutionResult` drops its hand-written `init(from:)`/`encode` for default-value + `CodingKeys` synthesis.

4. **Field names aligned with wire keys** — `DaemonSuccessResponse`/`JSONEnvelopeWriter`/`DaemonClientSuccessPayload` had a field named `advisory` (ProcessAdvisory) encoding under `process` next to `commandAdvisory` encoding under `advisory`. Renamed to `processAdvisory`/`advisory` so each matches its key; wire shape unchanged, pinned by the exact-JSON envelope tests.

5. **Forward-compatible advisory decode** — an unknown `CommandAdvisory.Kind` from a newer daemon (version probe failure, `SIM_USE_DAEMON_VERSION_CHECK=0`) failed the whole payload decode and reported `malformedResponse` for a command that had already executed. The client now drops a malformed/future advisory and keeps the data payload.

Plus a SKILL.md pitfalls row so agents know how to react to the `[i]` warning, and the CHANGELOG entry extended to cover batch.

## Tests

- `make build` clean
- `make test` — 994 tests pass, including new coverage: batch advisory recording/step-prefixing, Application-root display-frame preference and frame-filter behavior with a leading non-app root, the exclude-from-data contract for both conformers, multi-line renderer/merge, and unknown-kind tolerant decode.

Supersedes #29 (its commit is included verbatim). Refs #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
