### PR TITLE
fix: drain simctl stdout/stderr to avoid waitUntilExit deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `sim-use devices` no longer hangs forever on machines with enough simulators installed to push `simctl list devices -j` past the ~64 KB kernel pipe buffer. `SimctlDeviceLister.runSimctl` now drains stdout/stderr concurrently with the child (the same `readabilityHandler` drain `Adb.run` uses on the Android path) instead of reading only after `waitUntilExit()`, which deadlocked once the child blocked on `write(2)`.
 - The root `sim-use --help` abstract no longer claims the tool is iOS-Simulator-only; it now mentions Android emulators/devices as well.
 - `android swipe` invoked directly now enforces the same coordinate rules as the other surfaces: negative coordinates and identical start/end points are rejected at validate time instead of being forwarded to the bridge.
 - Swipe coordinates are validated as finite and ≤ 100000 on all surfaces, so values like `inf`, `nan`, or `1e19` fail with a clean validation error instead of trapping the daemon in the Double→Int conversion.

--- a/Sources/iOSSimBackend/Sim/SimctlDeviceLister.swift
+++ b/Sources/iOSSimBackend/Sim/SimctlDeviceLister.swift
@@ -30,15 +30,34 @@ public enum SimctlDeviceLister {
 
     // MARK: - Internals
 
-    private static func runSimctl(args: [String]) throws -> Data {
+    // `internal` + injectable `executablePath` so tests can drive the drain
+    // against `/bin/sh`; production uses the default `xcrun`.
+    static func runSimctl(executablePath: String = "/usr/bin/xcrun", args: [String]) throws -> Data {
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/xcrun")
+        process.executableURL = URL(fileURLWithPath: executablePath)
         process.arguments = args
 
         let stdout = Pipe()
         let stderr = Pipe()
         process.standardOutput = stdout
         process.standardError = stderr
+
+        // Drain both pipes while the child runs. Once `simctl list devices -j`
+        // outgrows the ~64 KB pipe buffer the child blocks on `write(2)` and
+        // never exits, hanging `waitUntilExit()`. Same drain as `Adb.run`.
+        let bufferLock = NSLock()
+        var outBuffer = Data()
+        var errBuffer = Data()
+        stdout.fileHandleForReading.readabilityHandler = { handle in
+            let chunk = handle.availableData
+            guard !chunk.isEmpty else { return }
+            bufferLock.lock(); outBuffer.append(chunk); bufferLock.unlock()
+        }
+        stderr.fileHandleForReading.readabilityHandler = { handle in
+            let chunk = handle.availableData
+            guard !chunk.isEmpty else { return }
+            bufferLock.lock(); errBuffer.append(chunk); bufferLock.unlock()
+        }
 
         do {
             try process.run()
@@ -47,13 +66,21 @@ public enum SimctlDeviceLister {
         }
         process.waitUntilExit()
 
+        // Detach handlers and collect anything left after exit.
+        stdout.fileHandleForReading.readabilityHandler = nil
+        stderr.fileHandleForReading.readabilityHandler = nil
+        bufferLock.lock()
+        outBuffer.append(stdout.fileHandleForReading.readDataToEndOfFile())
+        errBuffer.append(stderr.fileHandleForReading.readDataToEndOfFile())
+        bufferLock.unlock()
+
         guard process.terminationStatus == 0 else {
-            let err = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            let err = String(data: errBuffer, encoding: .utf8) ?? ""
             throw ListerError.simctlFailed(
                 message: "xcrun simctl exited \(process.terminationStatus): \(err.trimmingCharacters(in: .whitespacesAndNewlines))"
             )
         }
-        return stdout.fileHandleForReading.readDataToEndOfFile()
+        return outBuffer
     }
 
     /// Parses simctl's JSON:

--- a/Tests/SimctlDeviceListerTests.swift
+++ b/Tests/SimctlDeviceListerTests.swift
@@ -4,9 +4,10 @@
 import SimUseCore
 import XCTest
 
-/// Unit tests for `SimctlDeviceLister.parse` (the parser path) and the
-/// runtime-identifier translator. We don't shell out to `xcrun simctl`
-/// here; those paths get covered by manual + smoke verification.
+/// Unit tests for `SimctlDeviceLister`: the `parse` path, the
+/// runtime-identifier translator, and the `runSimctl` pipe-drain
+/// contract. The drain tests spawn `/bin/sh` (never a real
+/// `xcrun simctl`) so they run in CI without a simulator.
 final class SimctlDeviceListerTests: XCTestCase {
 
     // MARK: - parse()
@@ -131,5 +132,36 @@ final class SimctlDeviceListerTests: XCTestCase {
             SimctlDeviceLister.friendlyRuntime("unknown.format"),
             "unknown.format"
         )
+    }
+
+    // MARK: - runSimctl()
+
+    /// 200 KB of stdout overflows the ~64 KB pipe buffer; without the drain
+    /// the child blocks on `write(2)` and `waitUntilExit()` never returns.
+    /// Mirrors `AdbRunnerTests.testRunDoesNotDeadlockOnLargeStdout`.
+    func testRunSimctlDoesNotDeadlockOnLargeStdout() throws {
+        let data = try SimctlDeviceLister.runSimctl(
+            executablePath: "/bin/sh",
+            args: ["-c", "head -c 200000 /dev/zero | tr '\\0' 'a'"]
+        )
+        XCTAssertEqual(
+            data.count,
+            200_000,
+            "all 200 KB of stdout must reach the caller — pipe drain is the contract"
+        )
+    }
+
+    /// Stderr must drain the same way; the failure path (non-zero exit)
+    /// must not wedge on a chatty child either.
+    func testRunSimctlDoesNotDeadlockOnLargeStderr() {
+        XCTAssertThrowsError(try SimctlDeviceLister.runSimctl(
+            executablePath: "/bin/sh",
+            args: ["-c", "head -c 200000 /dev/zero | tr '\\0' 'b' 1>&2; exit 7"]
+        )) { error in
+            guard case SimctlDeviceLister.ListerError.simctlFailed(let message) = error else {
+                return XCTFail("expected ListerError.simctlFailed, got \(error)")
+            }
+            XCTAssertTrue(message.contains("exited 7"), "error should surface the non-zero exit code; got: \(message)")
+        }
     }
 }


### PR DESCRIPTION
## Summary

`sim-use devices` hangs indefinitely on machines with enough simulators that
`xcrun simctl list devices -j` exceeds the ~64 KB kernel pipe buffer.
`SimctlDeviceLister.runSimctl` reads the pipes only after `waitUntilExit()`, so
once simctl's output overflows the buffer the child blocks on `write(2)` and
never exits — the parent waits on it forever.

This drains stdout/stderr concurrently while the child runs (the same
`readabilityHandler` drain `Adb.run` already uses on the Android path), so the
buffer never fills and simctl always completes, regardless of output size.

Fixes #37

## Changes

- `runSimctl` drains both pipes via `readabilityHandler` while the child runs,
  collecting any remainder after exit. `waitUntilExit()` is kept.
- `runSimctl` made `internal` + injectable `executablePath` so the runner tests
  can drive the drain against `/bin/sh` (no live `xcrun simctl` needed).
- Two regression tests mirroring `AdbRunnerTests` (200 KB stdout / stderr):
  without the drain they deadlock; with it they pass in ~0.07 s.

## Scope / notes

- **Timeout not introduced.** `Adb.run` pairs its drain with a
  `terminationHandler` + semaphore timeout; I kept `waitUntilExit()` here to stay
  surgical, since `runSimctl` has no timeout semantics today. Happy to add
  semaphore+timeout parity if you'd prefer — note the regression tests would then
  fail red instead of hanging until the CI job timeout.
- **Sibling site left alone.** `DeviceResolver.simctlBootedListProvider` has the
  same wait-before-drain shape but runs `simctl list devices booted -j`
  (booted-only, small output), so it's very unlikely to cross 64 KB in practice.
  Left out to keep this PR minimal and focused — happy to follow up separately.

## Testing

- `make test` — full unit suite green (692 tests).
- Real repro: on a machine with 117 simulators (~66 KB `simctl` output), the
  released 0.9.0 `sim-use devices --all` hangs indefinitely; the patched build
  returns in ~0.9 s.
