### PR TITLE
Fix `android tap` crashing on ArgumentParser direct-init trap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ios stream-video` with the BGRA pixel format no longer exits 0 when the underlying stream fails to start or dies mid-stream; startup and mid-stream errors now terminate the streaming loop and surface as a non-zero exit instead of a stderr-only message.
 - `record-video`'s stop watchdog no longer exits 0 when video finalization overruns its grace window, which could report success for a truncated/unplayable MP4. It now warns on stderr and exits 70 (`EX_SOFTWARE`), and the grace window is 3 s (was 1.5 s).
 - Viewer API no longer reports success when the underlying sim-use invocation exits non-zero without a parseable JSON envelope; the subprocess's stderr is now surfaced in the error response instead of a generic JSON-parse failure.
+- `sim-use android tap` no longer crashes on every invocation with ArgumentParser's "can't read a value from a parsable argument definition" fatal. `performTap`'s default `MultiTouchOptions()` was a directly-initialized `ParsableArguments` value, and the first `.fingers` read trapped before anything was dispatched; the parameter is now optional with `nil` meaning single-touch. The top-level `sim-use tap` routed to Android was unaffected (it passes its parsed options through).
 
 ### Removed
 

--- a/Sources/AndroidBackend/Verbs/AndroidTapCommand.swift
+++ b/Sources/AndroidBackend/Verbs/AndroidTapCommand.swift
@@ -135,10 +135,15 @@ public struct AndroidTapCommand: SimUseExecutableCommand {
     /// reused on the iOS side.
     ///
     /// `multiTouch` carries `--fingers` / `--x2` / `--y2` /
-    /// `--finger-distance`. When `fingers == 2`, the dispatch becomes
-    /// a two-stroke `/gesture` with both strokes starting at the
-    /// resolved target / explicit second-finger placement; otherwise
-    /// the original single-stroke path is unchanged.
+    /// `--finger-distance` from the top-level forwarder. When
+    /// `fingers == 2`, the dispatch becomes a two-stroke `/gesture`
+    /// with both strokes starting at the resolved target / explicit
+    /// second-finger placement; otherwise the original single-stroke
+    /// path is unchanged. `nil` means single-touch — the parameter is
+    /// optional (not a `MultiTouchOptions()` default) because a
+    /// directly-initialized `ParsableArguments` value traps on first
+    /// property read ("can't read a value from a parsable argument
+    /// definition"), which crashed every `sim-use android tap`.
     public static func performTap(
         udid: String,
         alias: String?,
@@ -146,7 +151,7 @@ public struct AndroidTapCommand: SimUseExecutableCommand {
         y: Int?,
         selector: AndroidSelector,
         duration: Double? = nil,
-        multiTouch: MultiTouchOptions = MultiTouchOptions(),
+        multiTouch: MultiTouchOptions? = nil,
         controller: AndroidDeviceController = AndroidDeviceController()
     ) throws -> (x: Int, y: Int, description: String) {
         let target = try AndroidTargetResolver.resolve(
@@ -157,7 +162,7 @@ public struct AndroidTapCommand: SimUseExecutableCommand {
             controller: controller
         )
         let client = controller.bridge(serial: udid)
-        if multiTouch.fingers == 2 {
+        if let multiTouch, multiTouch.fingers == 2 {
             let finger1 = (x: Double(target.x), y: Double(target.y))
             let finger2 = multiTouch.fingerTwoPoint(forFinger1: finger1)
             let display = try client.displayInfo()

--- a/Tests/TapForwarderTests.swift
+++ b/Tests/TapForwarderTests.swift
@@ -184,7 +184,7 @@ struct TapForwarderTests {
             Int?, Int?,
             AndroidSelector,
             Double?,
-            MultiTouchOptions,
+            MultiTouchOptions?,
             AndroidDeviceController
         ) throws -> (x: Int, y: Int, description: String) = AndroidTapCommand.performTap
 
@@ -203,6 +203,38 @@ struct TapForwarderTests {
             elementType: nil,
             frame: nil
         )
+    }
+
+    @Test("performTap without multiTouch throws instead of trapping")
+    func androidTapDefaultMultiTouchDoesNotTrap() {
+        // Regression for the `sim-use android tap` crash: the old
+        // `multiTouch: MultiTouchOptions = MultiTouchOptions()` default
+        // was a directly-initialized ParsableArguments value, and the
+        // first `.fingers` read inside performTap hit ArgumentParser's
+        // "can't read a value from a parsable argument definition"
+        // fatal — before the bridge was ever dialled. With the optional
+        // default the unreachable device must surface as a thrown
+        // BridgeError (adb missing or device not found, depending on
+        // the host), never a process trap.
+        #expect(throws: (any Error).self) {
+            _ = try AndroidTapCommand.performTap(
+                udid: "nonexistent-serial-0000",
+                alias: nil,
+                x: 100, y: 200,
+                selector: AndroidSelector(
+                    id: nil,
+                    label: nil,
+                    labelContains: nil,
+                    labelRegex: nil,
+                    value: nil,
+                    valueContains: nil,
+                    valueRegex: nil,
+                    elementType: nil,
+                    frame: nil
+                ),
+                duration: nil
+            )
+        }
     }
 
     @Test("ArgumentParser parses both top-level Tap and IOSSimTapCommand with same flags")


### PR DESCRIPTION
## Summary

Every `sim-use android tap` invocation crashes at runtime — on released 0.9.0 as well as main — with ArgumentParser's fatal:

```
ArgumentParser/Option.swift:84: Fatal error:
Can't read a value from a parsable argument definition.
```

`AndroidTapCommand.performTap` defaulted its `multiTouch` parameter to a directly-initialized `MultiTouchOptions()`. A `ParsableArguments` value that never went through `parse` keeps its property wrappers in definition state, and the first read (`multiTouch.fingers` at the two-finger check) traps — before the bridge is ever dialled, so the crash reproduces with no device attached and would equally hit a fully working setup.

Found while spot-checking #40 on the android surface.

## Changes

- `performTap`'s `multiTouch` parameter is now `MultiTouchOptions?` defaulting to `nil` (single-touch). The two-finger branch unwraps it; nothing else changes.
- Regression test: `performTap` without `multiTouch` against an unreachable serial must **throw** (adb missing / device not found, depending on host) instead of trapping. Plus the signature pin in the forwarder contract test updated to the optional type.
- CHANGELOG `Fixed` entry.

## Blast radius audit

- The top-level `sim-use tap` routed to an Android UDID was never affected — `Tap.executeAndroid` / `LongPress.executeAndroid` pass their **parsed** option group through.
- **iOS is not affected**: swept the codebase for directly-initialized `ParsableArguments` reads — this was the only `= SomeOptions()` default parameter. The iOS forwarders all use the construct-then-assign-every-property pattern (values come from a parsed top-level command), and `InitOptions` / `RendererOptions` are plain structs, not `ParsableArguments`.

## Testing

- `make test` — 1031 tests green (baseline 1030 + the new regression test).
- Live before/after: `.build/debug/sim-use android tap -x 100 -y 200 --udid emulator-5554` previously printed the fatal above; now exits 1 with `Error: adb command failed (…): adb: device 'emulator-5554' not found`. iOS sanity check on a booted simulator (`tap -x 200 -y 400`) unaffected.

## Notes

- Touches the same `Fixed` CHANGELOG section as #40 — whichever merges second will need a trivial conflict resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
