### PR TITLE
feat: add animated GIF export to record-video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `record-video --format gif` (top-level, `ios record-video`, and `android record-video`): record an animated GIF on both platforms. The format is also inferred from a `.gif` `--output` extension (explicit `--format` wins, with a stderr note on mismatch). Capture still runs through the existing H.264 pipelines into an intermediate MP4; on stop, the recording is transcoded into a looping GIF — sampled at `--fps` (GIF default 10) and scaled at `--scale` (GIF default 0.5), with per-frame delays derived from source timestamps so Android's variable frame rate keeps wall-clock pacing. A failed transcode preserves the intermediate MP4 and reports its path.
+
 ### Fixed
 
 - The `SIM_USE_VERSION` build-time override actually reaches the version stamp now. `VersionPlugin` registered its generator command with an empty environment, so the documented "environment variable first" priority was dead code and every build fell back to `git describe` — release builds happened to be correct only because they build on the tagged commit, while `scripts/dev-install.sh` builds stamped a stale describe string. The override is now resolved in the plugin process and baked into the command's argv, which also makes a changed override invalidate SPM's command cache without requiring a source-file edit.

--- a/README.md
+++ b/README.md
@@ -312,6 +312,11 @@ sim-use stream-video --device emulator-5554 --format h264 | \
 sim-use record-video --device $UDID --output recording.mp4            # 30 fps default
 sim-use record-video --device $UDID --fps 60 --output smooth.mp4      # up to 60 fps
 sim-use record-video --device $UDID --quality 60 --scale 0.5 --output low-bw.mp4
+
+# Record an animated GIF (cross-platform) — auto-plays inline in PRs / issues / chat
+sim-use record-video --device $UDID --output demo.gif                 # format inferred from extension
+sim-use record-video --device $UDID --format gif                      # sim-use-video-<timestamp>.gif
+sim-use record-video --device $UDID --format gif --fps 15 --scale 0.4 --output demo.gif
 ```
 
 `record-video` captures a real H.264 stream and muxes it straight into the
@@ -322,6 +327,18 @@ native variable frame rate (`--fps` ignored, `--quality` → bitrate,
 limit on API < 34 automatically. Rotating the display mid-recording stops
 capture on Android (an MP4 track can't change frame size). Press Ctrl+C to
 stop; sim-use finalises the MP4 before exiting.
+
+`--format gif` (or a `.gif` `--output` extension) records the same H.264
+stream to an intermediate MP4, then transcodes it into a looping GIF once
+recording stops — sampling at `--fps` (GIF default 10, capped at 50 by the
+format's centisecond delay floor) and scaling at `--scale` (GIF default
+0.5), since full-rate full-scale GIFs get enormous. Per-frame delays
+follow the source timestamps, so Android's variable frame rate stays true
+to wall-clock. If the transcode fails, the intermediate MP4 is preserved
+and its path reported, so the footage is never lost. GIF is meant for
+short clips: the encoder holds every frame in memory until the file is
+written, so for sessions beyond a few hundred frames prefer a lower
+`--fps` or `--format mp4`.
 
 ### Accessibility inspection
 

--- a/Sources/AndroidBackend/Verbs/AndroidRecordVideoCommand.swift
+++ b/Sources/AndroidBackend/Verbs/AndroidRecordVideoCommand.swift
@@ -20,7 +20,7 @@ import SimUseVideo
 public struct AndroidRecordVideoCommand: SimUseExecutableCommand {
     public static let configuration = CommandConfiguration(
         commandName: "record-video",
-        abstract: "Record the Android device display to an MP4 file using H.264 encoding"
+        abstract: "Record the Android device display to an MP4 (H.264) or animated GIF file"
     )
 
     public struct ExecutionResult: Codable {
@@ -32,16 +32,19 @@ public struct AndroidRecordVideoCommand: SimUseExecutableCommand {
 
     @OptionGroup public var device: AndroidDeviceOptions
 
-    @Option(help: "Frames per second (1-60). Ignored by native screenrecord capture (records at the device's variable frame rate); paces the screencap fallback (default: 10).")
+    @Option(help: "Frames per second (1-60). Ignored by native screenrecord capture (records at the device's variable frame rate); paces the screencap fallback (default: 10) and samples a GIF (default: 10).")
     public var fps: Int?
 
     @Option(help: "Quality factor (1-100) controlling bitrate (default: 80)")
     public var quality: Int = 80
 
-    @Option(help: "Scale factor (0.1-1.0, default: 1.0)")
-    public var scale: Double = 1.0
+    @Option(help: "Scale factor (0.1-1.0; default: 1.0 for mp4, 0.5 for gif)")
+    public var scale: Double?
 
-    @Option(help: "Output MP4 file path. Defaults to sim-use-video-<timestamp>.mp4 in the current directory.")
+    @Option(help: "Output format: mp4, gif. Defaults to the --output extension when recognized, else mp4.")
+    public var format: RecordingFormat?
+
+    @Option(help: "Output file path. Defaults to sim-use-video-<timestamp>.<format> in the current directory.")
     public var output: String?
 
     @Flag(name: .customLong("json"), help: "Emit the unified `{ok, data: {path}}` envelope on success. Mirrors the cross-platform `record-video --json` shape.")
@@ -75,6 +78,7 @@ public struct AndroidRecordVideoCommand: SimUseExecutableCommand {
         let outputURL = try await Self.record(
             serial: device.resolved,
             output: output,
+            format: format,
             fps: fps,
             quality: quality,
             scale: scale
@@ -92,23 +96,35 @@ public struct AndroidRecordVideoCommand: SimUseExecutableCommand {
     }
 
     /// Reusable Android recording entry point: runs until SIGINT/SIGTERM,
-    /// then finalizes the MP4 and returns its URL. The top-level
-    /// cross-platform `RecordVideo` forwards here for Android UDIDs so
-    /// both `sim-use android record-video` and `sim-use record-video` go
+    /// then finalizes the MP4 (transcoding to GIF when requested) and
+    /// returns the output URL. The top-level cross-platform `RecordVideo`
+    /// forwards here for Android UDIDs so both
+    /// `sim-use android record-video` and `sim-use record-video` go
     /// through one body — symmetric to
     /// `AndroidScreenshotCommand.performScreenshot`.
     public static func record(
         serial: String,
         output: String?,
+        format: RecordingFormat?,
         fps: Int?,
         quality: Int,
-        scale: Double
+        scale: Double?
     ) async throws -> URL {
         let adb = Adb()
         try assertAdbDeviceOnline(adb: adb, serial: serial)
 
-        let outputURL = try VideoOutputFile.prepareOutputURL(output: output)
-        FileHandle.standardError.write(Data("Recording Android device \(serial) to \(outputURL.path)\n".utf8))
+        // GIF is transcoded from a finished MP4 (see GIFTranscoder); the
+        // capture loop itself always writes H.264, to plan.recordTarget.
+        let plan = try RecordingOutputPlan(format: format, output: output, fps: fps, scale: scale)
+        let options = plan.options
+        let recordTarget = plan.recordTarget
+        // Native screenrecord capture is variable-frame-rate either way;
+        // the flag still paces the screencap fallback and GIF sampling,
+        // so only claim it is ignored when neither applies.
+        if fps != nil && options.format == .mp4 {
+            FileHandle.standardError.write(Data("note: --fps is ignored by Android native capture (screenrecord records at its variable frame rate)\n".utf8))
+        }
+        FileHandle.standardError.write(Data("Recording Android device \(serial) to \(plan.outputURL.path)\n".utf8))
         FileHandle.standardError.write(Data("Press Ctrl+C to stop recording\n".utf8))
 
         let cancellationFlag = CancellationFlag()
@@ -123,28 +139,25 @@ public struct AndroidRecordVideoCommand: SimUseExecutableCommand {
             try await recordVideoAndroidStream(
                 adb: adb,
                 serial: serial,
-                outputURL: outputURL,
-                fps: fps,
+                outputURL: recordTarget,
                 quality: quality,
-                scale: scale,
+                scale: options.scale,
                 cancellationFlag: cancellationFlag
             )
             recordingFinished.cancel()
-            return outputURL
         } catch let unavailable as ScreenrecordUnavailableError {
             FileHandle.standardError.write(Data("warning: screenrecord unavailable (\(unavailable.underlying)); falling back to screencap frames\n".utf8))
             do {
                 try await recordVideoAndroidScreencapLegacy(
                     adb: adb,
                     serial: serial,
-                    outputURL: outputURL,
-                    fps: fps ?? 10,
+                    outputURL: recordTarget,
+                    fps: options.fps ?? 10,
                     quality: quality,
-                    scale: scale,
+                    scale: options.scale,
                     cancellationFlag: cancellationFlag
                 )
                 recordingFinished.cancel()
-                return outputURL
             } catch {
                 recordingFinished.cancel()
                 throw CLIError(errorDescription: "Failed to record video: \(error.localizedDescription)")
@@ -153,6 +166,14 @@ public struct AndroidRecordVideoCommand: SimUseExecutableCommand {
             recordingFinished.cancel()
             throw CLIError(errorDescription: "Failed to record video: \(error.localizedDescription)")
         }
+
+        // Tear the observer down before the transcode so Ctrl+C during a
+        // long GIF encode kills the process instead of being swallowed by
+        // a handler that has nothing left to cancel (invalidate is
+        // idempotent; the defer covers the error paths above).
+        signalObserver.invalidate()
+        try await plan.finalizeRecording()
+        return plan.outputURL
     }
 
     static func assertAdbDeviceOnline(adb: Adb, serial: String) throws {
@@ -179,15 +200,10 @@ public struct AndroidRecordVideoCommand: SimUseExecutableCommand {
         adb: Adb,
         serial: String,
         outputURL: URL,
-        fps: Int?,
         quality: Int,
         scale: Double,
         cancellationFlag: CancellationFlag
     ) async throws {
-        if fps != nil {
-            FileHandle.standardError.write(Data("note: --fps is ignored on Android (screenrecord records at native variable frame rate)\n".utf8))
-        }
-
         let sdk = detectSDK(adb: adb, serial: serial)
         // Detect the display size unconditionally so --quality maps to a
         // bitrate even at the default scale — only the --size *argument* is

--- a/Sources/SimUse/Commands/RecordVideo.swift
+++ b/Sources/SimUse/Commands/RecordVideo.swift
@@ -19,21 +19,24 @@ struct RecordVideo: SimUseExecutableCommand {
 
     static let configuration = CommandConfiguration(
         commandName: "record-video",
-        abstract: "Record the simulator display to an MP4 file using H.264 encoding"
+        abstract: "Record the simulator display to an MP4 (H.264) or animated GIF file"
     )
 
     @OptionGroup var device: DeviceOptions
 
-    @Option(help: "Frames per second (1-60, default: 30). Ignored on Android (screenrecord uses the device's native variable frame rate).")
+    @Option(help: "Frames per second (1-60; default: 30 for mp4, 10 for gif). Ignored by Android capture (screenrecord uses the device's native variable frame rate), but still applied when sampling a GIF.")
     var fps: Int?
 
     @Option(help: "Quality factor (1-100) controlling bitrate (default: 80)")
     var quality: Int = 80
 
-    @Option(help: "Scale factor (0.1-1.0, default: 1.0)")
-    var scale: Double = 1.0
+    @Option(help: "Scale factor (0.1-1.0; default: 1.0 for mp4, 0.5 for gif)")
+    var scale: Double?
 
-    @Option(help: "Output MP4 file path. Defaults to sim-use-video-<timestamp>.mp4 in the current directory.")
+    @Option(help: "Output format: mp4, gif. Defaults to the --output extension when recognized, else mp4.")
+    var format: RecordingFormat?
+
+    @Option(help: "Output file path. Defaults to sim-use-video-<timestamp>.<format> in the current directory.")
     var output: String?
 
     @OptionGroup var json: JSONOutputOptions
@@ -82,6 +85,7 @@ struct RecordVideo: SimUseExecutableCommand {
         sub.fps = fps
         sub.quality = quality
         sub.scale = scale
+        sub.format = format
         sub.output = output
         sub.device = device
         sub.json = json
@@ -92,6 +96,7 @@ struct RecordVideo: SimUseExecutableCommand {
         let outputURL = try await AndroidRecordVideoCommand.record(
             serial: device.resolved,
             output: output,
+            format: format,
             fps: fps,
             quality: quality,
             scale: scale

--- a/Sources/SimUseVideo/GIFTranscoder.swift
+++ b/Sources/SimUseVideo/GIFTranscoder.swift
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: Apache-2.0
+import Foundation
+import AVFoundation
+import ImageIO
+import UniformTypeIdentifiers
+import VideoToolbox
+import SimUseCore
+
+public enum GIFTranscoderError: Error, LocalizedError, Equatable {
+    case noVideoTrack
+    case noFrames
+    case cannotCreateDestination(String)
+    case finalizeFailed
+
+    public var errorDescription: String? {
+        switch self {
+        case .noVideoTrack:
+            return "Recording contains no video track"
+        case .noFrames:
+            return "Recording contains no video frames"
+        case .cannotCreateDestination(let path):
+            return "Unable to create GIF file at \(path)"
+        case .finalizeFailed:
+            return "Failed to finalize GIF file"
+        }
+    }
+}
+
+/// Transcodes a finalized MP4 recording into an animated GIF.
+///
+/// GIF is a post-step rather than a fourth capture path on purpose: none
+/// of the capture pipelines (idb's in-process recorder on iOS, `adb
+/// screenrecord` passthrough on Android, the screenshot fallback) expose
+/// decoded frames in-process, and the signal-to-finalise path of the
+/// recording loop is latency-critical — transcoding after the MP4
+/// trailer is on disk keeps that path untouched and covers every capture
+/// mode with a single implementation.
+///
+/// Two passes over the asset bound *decode* memory to one frame:
+///
+///   1. A decoding read collects presentation timestamps (discarding the
+///      pixels), which fixes the sampled frame count —
+///      `CGImageDestination` requires the image count at creation time.
+///      A passthrough (non-decoding) read would be cheaper but its raw
+///      PTS carry B-frame reorder offsets, un-applied edit lists, and
+///      trailer artifacts; only the decoded output's timestamps are the
+///      display timeline.
+///   2. BGRA decode appends only the sampled frames to the destination.
+///
+/// The *encode* side is not bounded: `CGImageDestination` holds every
+/// added frame until finalize (ImageIO has no incremental GIF writer),
+/// so peak memory grows linearly with the sampled frame count — see
+/// `memoryWarningFrameThreshold`.
+///
+/// Sampling at `fps` also normalizes Android's variable-frame-rate
+/// `screenrecord` output; per-frame delays come from the actual sampled
+/// timestamp deltas, so wall-clock pacing survives the resample.
+public enum GIFTranscoder {
+    /// GIF delay resolution is centiseconds; browsers treat delays below
+    /// 2 cs as "as fast as possible", so clamp to keep pacing honest.
+    static let minimumDelay: Double = 0.02
+
+    /// The centisecond delay floor makes 50 the highest frame rate a GIF
+    /// can pace truthfully — sampling faster would clamp every delay up
+    /// and stretch playback past wall clock.
+    static let maximumFPS = 50
+
+    /// Past this many sampled frames the in-memory encode gets heavy
+    /// (roughly 9 MB per half-scale iPhone frame at finalize); warn so
+    /// the user can pick a lower `--fps` or record mp4 for long sessions.
+    static let memoryWarningFrameThreshold = 300
+
+    /// Result of the timestamp-sampling pass.
+    struct SamplingPlan: Equatable {
+        /// Presentation timestamps (seconds, ascending) of the frames to keep.
+        let timestamps: [Double]
+        /// Per-frame GIF delays (seconds), same count as `timestamps`.
+        let delays: [Double]
+    }
+
+    /// Select frames from `presentationTimes` (seconds, any order) by
+    /// walking a target clock in `1/fps` steps — a frame is kept when it
+    /// reaches the next target, and the clock then advances from the kept
+    /// frame. Target accumulation (rather than distance-to-previous)
+    /// keeps the *average* rate at `fps` even when source spacing beats
+    /// against the interval. Each kept frame's display delay is the gap
+    /// to its successor; the last frame holds for the nominal interval.
+    static func plan(presentationTimes: [Double], fps: Int) -> SamplingPlan {
+        let sorted = presentationTimes.sorted()
+        guard !sorted.isEmpty else { return SamplingPlan(timestamps: [], delays: []) }
+
+        let interval = 1.0 / Double(min(fps, Self.maximumFPS))
+        // Quarter-frame tolerance absorbs encoder timestamp jitter when
+        // the source is already at the target rate, without letting a
+        // higher-rate source sneak extra frames through.
+        let epsilon = interval * 0.25
+
+        var kept: [Double] = [sorted[0]]
+        var nextTarget = sorted[0] + interval
+        for pts in sorted.dropFirst() where pts >= nextTarget - epsilon {
+            kept.append(pts)
+            nextTarget = max(nextTarget, pts) + interval
+        }
+
+        var delays: [Double] = []
+        for (index, pts) in kept.enumerated() {
+            let delay = index + 1 < kept.count ? kept[index + 1] - pts : interval
+            delays.append(max(delay, Self.minimumDelay))
+        }
+        return SamplingPlan(timestamps: kept, delays: delays)
+    }
+
+    /// Transcode `mp4URL` into an animated GIF at `gifURL`, sampling at
+    /// `fps` (capped at `maximumFPS`). Returns the number of frames
+    /// actually written.
+    @discardableResult
+    public static func transcode(mp4URL: URL, to gifURL: URL, fps: Int) async throws -> Int {
+        let asset = AVURLAsset(url: mp4URL)
+        guard let track = try await asset.loadTracks(withMediaType: .video).first else {
+            throw GIFTranscoderError.noVideoTrack
+        }
+
+        let plan = Self.plan(presentationTimes: try Self.readPresentationTimes(asset: asset, track: track), fps: fps)
+        guard !plan.timestamps.isEmpty else {
+            throw GIFTranscoderError.noFrames
+        }
+        if plan.timestamps.count > Self.memoryWarningFrameThreshold {
+            FileHandle.standardError.write(Data("warning: GIF has \(plan.timestamps.count) frames; the encoder holds all of them in memory until the file is written — for long sessions prefer a lower --fps or --format mp4\n".utf8))
+        }
+
+        guard let destination = CGImageDestinationCreateWithURL(
+            gifURL as CFURL,
+            UTType.gif.identifier as CFString,
+            plan.timestamps.count,
+            nil
+        ) else {
+            throw GIFTranscoderError.cannotCreateDestination(gifURL.path)
+        }
+
+        let gifProperties: [CFString: Any] = [
+            kCGImagePropertyGIFDictionary: [
+                kCGImagePropertyGIFLoopCount: 0 // loop forever
+            ]
+        ]
+        CGImageDestinationSetProperties(destination, gifProperties as CFDictionary)
+
+        let appended = try Self.appendSampledFrames(asset: asset, track: track, plan: plan, to: destination)
+        guard appended > 0 else {
+            throw GIFTranscoderError.noFrames
+        }
+
+        guard CGImageDestinationFinalize(destination) else {
+            throw GIFTranscoderError.finalizeFailed
+        }
+        return appended
+    }
+
+    /// Convenience wrapper for the record-video post-step: transcodes and
+    /// removes the intermediate MP4 on success; on failure, preserves it
+    /// and says where it is (so a failed transcode never discards the
+    /// captured footage) while removing the partially written GIF, which
+    /// would otherwise read as a successful recording to any
+    /// does-the-file-exist check.
+    public static func transcodeRecording(tempMP4: URL, to gifURL: URL, fps: Int) async throws {
+        FileHandle.standardError.write(Data("Transcoding to GIF...\n".utf8))
+        do {
+            let frames = try await transcode(mp4URL: tempMP4, to: gifURL, fps: fps)
+            try? FileManager.default.removeItem(at: tempMP4)
+            FileHandle.standardError.write(Data("GIF written (\(frames) frames)\n".utf8))
+        } catch {
+            try? FileManager.default.removeItem(at: gifURL)
+            throw CLIError(
+                errorDescription: "Failed to transcode recording to GIF: \(error.localizedDescription); intermediate MP4 preserved at \(tempMP4.path)"
+            )
+        }
+    }
+
+    /// Pass 1 — display-timeline presentation timestamps via a decoding
+    /// read (pixels discarded; decoder-native 4:2:0 halves the bandwidth
+    /// of a BGRA conversion nothing looks at). See the type comment for
+    /// why passthrough PTS can't drive the plan.
+    private static func readPresentationTimes(asset: AVURLAsset, track: AVAssetTrack) throws -> [Double] {
+        let reader = try AVAssetReader(asset: asset)
+        let output = AVAssetReaderTrackOutput(track: track, outputSettings: [
+            kCVPixelBufferPixelFormatTypeKey as String: Int(kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange)
+        ])
+        output.alwaysCopiesSampleData = false
+        reader.add(output)
+        guard reader.startReading() else {
+            throw reader.error ?? GIFTranscoderError.noFrames
+        }
+
+        var times: [Double] = []
+        while let sample = output.copyNextSampleBuffer() {
+            let pts = CMSampleBufferGetPresentationTimeStamp(sample)
+            if pts.isValid {
+                times.append(pts.seconds)
+            }
+        }
+        if reader.status == .failed {
+            throw reader.error ?? GIFTranscoderError.noFrames
+        }
+        return times
+    }
+
+    /// Pass 2 — BGRA decode, appending only the planned frames. Decoded
+    /// output arrives in presentation order, so a single cursor over the
+    /// (ascending) planned timestamps pairs frames without buffering.
+    /// Returns the number of frames actually appended: a frame whose
+    /// pixels can't be converted consumes its plan slot (keeping every
+    /// later frame's delay paired correctly) and is dropped.
+    private static func appendSampledFrames(
+        asset: AVURLAsset,
+        track: AVAssetTrack,
+        plan: SamplingPlan,
+        to destination: CGImageDestination
+    ) throws -> Int {
+        let reader = try AVAssetReader(asset: asset)
+        let output = AVAssetReaderTrackOutput(track: track, outputSettings: [
+            kCVPixelBufferPixelFormatTypeKey as String: Int(kCVPixelFormatType_32BGRA)
+        ])
+        output.alwaysCopiesSampleData = false
+        reader.add(output)
+        guard reader.startReading() else {
+            throw reader.error ?? GIFTranscoderError.noFrames
+        }
+
+        // Timestamps in pass 2 are re-derived from the same samples as
+        // pass 1, so match with a small absolute tolerance rather than
+        // exact float equality.
+        let tolerance = 0.001
+        var cursor = 0
+        var appended = 0
+
+        while cursor < plan.timestamps.count, let sample = output.copyNextSampleBuffer() {
+            let pts = CMSampleBufferGetPresentationTimeStamp(sample)
+            guard pts.isValid, pts.seconds >= plan.timestamps[cursor] - tolerance else { continue }
+            let slot = cursor
+            cursor += 1
+            guard let pixelBuffer = CMSampleBufferGetImageBuffer(sample) else { continue }
+
+            var cgImage: CGImage?
+            VTCreateCGImageFromCVPixelBuffer(pixelBuffer, options: nil, imageOut: &cgImage)
+            guard let cgImage else { continue }
+
+            let frameProperties: [CFString: Any] = [
+                kCGImagePropertyGIFDictionary: [
+                    kCGImagePropertyGIFDelayTime: plan.delays[slot],
+                    kCGImagePropertyGIFUnclampedDelayTime: plan.delays[slot]
+                ]
+            ]
+            CGImageDestinationAddImage(destination, cgImage, frameProperties as CFDictionary)
+            appended += 1
+        }
+        if reader.status == .failed {
+            throw reader.error ?? GIFTranscoderError.noFrames
+        }
+        reader.cancelReading()
+        return appended
+    }
+}

--- a/Sources/SimUseVideo/GIFTranscoder.swift
+++ b/Sources/SimUseVideo/GIFTranscoder.swift
@@ -83,8 +83,15 @@ public enum GIFTranscoder {
     /// reaches the next target, and the clock then advances from the kept
     /// frame. Target accumulation (rather than distance-to-previous)
     /// keeps the *average* rate at `fps` even when source spacing beats
-    /// against the interval. Each kept frame's display delay is the gap
-    /// to its successor; the last frame holds for the nominal interval.
+    /// against the interval.
+    ///
+    /// Timing honesty is enforced in two places so the centisecond floor
+    /// never stretches playback: a frame closer than `minimumDelay` to
+    /// the previous kept frame is not selected at all (clamping it up
+    /// would owe time the GIF can't repay), and each kept frame's delay
+    /// quantizes the *cumulative* timeline to centiseconds, so per-frame
+    /// rounding carries forward instead of accumulating. The last frame
+    /// holds for the nominal interval.
     static func plan(presentationTimes: [Double], fps: Int) -> SamplingPlan {
         let sorted = presentationTimes.sorted()
         guard !sorted.isEmpty else { return SamplingPlan(timestamps: [], delays: []) }
@@ -92,20 +99,27 @@ public enum GIFTranscoder {
         let interval = 1.0 / Double(min(fps, Self.maximumFPS))
         // Quarter-frame tolerance absorbs encoder timestamp jitter when
         // the source is already at the target rate, without letting a
-        // higher-rate source sneak extra frames through.
+        // higher-rate source sneak extra frames through. The gap check
+        // gets a tighter 1 ms allowance for the same jitter.
         let epsilon = interval * 0.25
 
         var kept: [Double] = [sorted[0]]
         var nextTarget = sorted[0] + interval
-        for pts in sorted.dropFirst() where pts >= nextTarget - epsilon {
+        for pts in sorted.dropFirst()
+        where pts >= nextTarget - epsilon && pts - kept[kept.count - 1] >= Self.minimumDelay - 0.001 {
             kept.append(pts)
             nextTarget = max(nextTarget, pts) + interval
         }
 
         var delays: [Double] = []
+        var elapsed = 0.0
+        var quantized = 0.0
         for (index, pts) in kept.enumerated() {
-            let delay = index + 1 < kept.count ? kept[index + 1] - pts : interval
-            delays.append(max(delay, Self.minimumDelay))
+            elapsed += index + 1 < kept.count ? kept[index + 1] - pts : interval
+            let centiseconds = max((elapsed - quantized) * 100.0, Self.minimumDelay * 100.0).rounded()
+            let delay = centiseconds / 100.0
+            quantized += delay
+            delays.append(delay)
         }
         return SamplingPlan(timestamps: kept, delays: delays)
     }

--- a/Sources/SimUseVideo/RecordingFormat.swift
+++ b/Sources/SimUseVideo/RecordingFormat.swift
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+import ArgumentParser
+import Foundation
+
+/// Output container for the `record-video` verb, shared by every
+/// surface (top-level forwarder, `ios record-video`,
+/// `android record-video`) so the contract cannot drift between
+/// platforms.
+public enum RecordingFormat: String, ExpressibleByArgument, Codable, Sendable {
+    case mp4
+    case gif
+
+    /// Infer a format from an explicit `--output` path extension.
+    /// Returns nil when the extension is absent or unrecognized so the
+    /// caller can fall through to the mp4 default.
+    public static func infer(fromOutput output: String?) -> RecordingFormat? {
+        guard let output else { return nil }
+        let ext = (output.trimmingCharacters(in: .whitespacesAndNewlines) as NSString).pathExtension.lowercased()
+        return RecordingFormat(rawValue: ext)
+    }
+
+    /// One stderr note when an explicit `--format` contradicts the
+    /// `--output` extension — explicit always wins, but silently writing
+    /// mp4 bytes into a `.gif` path would read as a bug.
+    public static func warnIfOverridingExtension(explicit: RecordingFormat?, output: String?) {
+        guard let explicit, let inferred = infer(fromOutput: output), inferred != explicit else { return }
+        FileHandle.standardError.write(Data("note: --format \(explicit.rawValue) overrides the --output .\(inferred.rawValue) extension\n".utf8))
+    }
+}
+
+/// Resolve the `--format` / `--fps` / `--scale` interplay in one place
+/// so every surface applies identical semantics. Explicit `--format`
+/// wins over the `--output` extension; GIF gets lower fps/scale
+/// defaults because full-rate, full-scale GIFs are enormous.
+public struct ResolvedRecordingOptions: Equatable, Sendable {
+    public let format: RecordingFormat
+    public let fps: Int?
+    public let scale: Double
+    /// The rate GIF sampling runs at — always resolved, so the default
+    /// lives here and nowhere else.
+    public let gifSampleFPS: Int
+
+    public init(format: RecordingFormat?, output: String?, fps: Int?, scale: Double?) {
+        let resolvedFormat = format ?? RecordingFormat.infer(fromOutput: output) ?? .mp4
+        let sampleFPS = fps ?? 10
+        self.format = resolvedFormat
+        self.gifSampleFPS = sampleFPS
+        self.fps = fps ?? (resolvedFormat == .gif ? sampleFPS : nil)
+        self.scale = scale ?? (resolvedFormat == .gif ? 0.5 : 1.0)
+    }
+
+    /// Where the H.264 capture should land: the final URL for mp4, an
+    /// intermediate sibling for gif (transcoded after stop, removed on
+    /// success, preserved on failure).
+    public func recordTarget(for outputURL: URL) -> URL {
+        format == .gif ? URL(fileURLWithPath: outputURL.path + ".recording.mp4") : outputURL
+    }
+}
+
+/// The per-run output plan every `record-video` surface goes through:
+/// resolve the format/fps/scale interplay, emit the extension-mismatch
+/// note, resolve the output URL, and clear a stale GIF intermediate left
+/// by a failed or killed previous run (the AVAssetWriter-based recorders
+/// refuse to open an existing file, and `prepareOutputURL` only clears
+/// the final path). Owning the whole sequence here keeps the three
+/// surfaces from drifting.
+public struct RecordingOutputPlan {
+    public let options: ResolvedRecordingOptions
+    public let outputURL: URL
+    public let recordTarget: URL
+
+    public init(format: RecordingFormat?, output: String?, fps: Int?, scale: Double?) throws {
+        options = ResolvedRecordingOptions(format: format, output: output, fps: fps, scale: scale)
+        RecordingFormat.warnIfOverridingExtension(explicit: format, output: output)
+        outputURL = try VideoOutputFile.prepareOutputURL(output: output, fileExtension: options.format.rawValue)
+        recordTarget = options.recordTarget(for: outputURL)
+        if recordTarget != outputURL, FileManager.default.fileExists(atPath: recordTarget.path) {
+            try FileManager.default.removeItem(at: recordTarget)
+        }
+    }
+
+    /// GIF post-step; a no-op for mp4. Call after capture has finalized
+    /// `recordTarget` — and after the capture signal observer has been
+    /// invalidated, so a stuck transcode stays interruptible.
+    public func finalizeRecording() async throws {
+        guard options.format == .gif else { return }
+        try await GIFTranscoder.transcodeRecording(tempMP4: recordTarget, to: outputURL, fps: options.gifSampleFPS)
+    }
+}

--- a/Sources/SimUseVideo/VideoOutputFile.swift
+++ b/Sources/SimUseVideo/VideoOutputFile.swift
@@ -6,9 +6,10 @@ import SimUseCore
 /// regardless of platform backend.
 public enum VideoOutputFile {
     /// Resolve the user-supplied `--output` argument into a concrete
-    /// MP4 file URL. Both the iOS backend and the cross-platform
-    /// forwarder's Android branch use the same path semantics.
-    public static func prepareOutputURL(output: String?) throws -> URL {
+    /// output file URL (default naming uses `fileExtension`). Every
+    /// platform backend and the cross-platform forwarder use the same
+    /// path semantics.
+    public static func prepareOutputURL(output: String?, fileExtension: String = "mp4") throws -> URL {
         let fileManager = FileManager.default
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime]
@@ -18,7 +19,7 @@ public enum VideoOutputFile {
         if let providedPath, !providedPath.isEmpty {
             resolvedPath = (providedPath as NSString).expandingTildeInPath
         } else {
-            resolvedPath = "sim-use-video-\(formatter.string(from: Date())).mp4"
+            resolvedPath = "sim-use-video-\(formatter.string(from: Date())).\(fileExtension)"
         }
 
         let baseURL: URL
@@ -30,7 +31,7 @@ public enum VideoOutputFile {
 
         var isDirectory: ObjCBool = false
         if fileManager.fileExists(atPath: baseURL.path, isDirectory: &isDirectory), isDirectory.boolValue {
-            let filename = "sim-use-video-\(formatter.string(from: Date())).mp4"
+            let filename = "sim-use-video-\(formatter.string(from: Date())).\(fileExtension)"
             let directoryURL = baseURL
             if !fileManager.fileExists(atPath: directoryURL.path) {
                 try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true, attributes: nil)

--- a/Sources/SimUseVideo/VideoRecordingOptions.swift
+++ b/Sources/SimUseVideo/VideoRecordingOptions.swift
@@ -6,7 +6,10 @@ import ArgumentParser
 /// `android record-video`) so the contract cannot drift between
 /// platforms.
 public enum VideoRecordingOptions {
-    public static func validate(fps: Int?, quality: Int, scale: Double) throws {
+    /// `scale` is optional because its default is format-dependent
+    /// (1.0 for mp4, 0.5 for gif — see `ResolvedRecordingOptions`);
+    /// nil means "not user-supplied" and needs no range check.
+    public static func validate(fps: Int?, quality: Int, scale: Double?) throws {
         if let fps {
             guard fps >= 1 && fps <= 60 else {
                 throw ValidationError("FPS must be between 1 and 60")
@@ -15,7 +18,7 @@ public enum VideoRecordingOptions {
         guard quality >= 1 && quality <= 100 else {
             throw ValidationError("Quality must be between 1 and 100")
         }
-        guard scale >= 0.1 && scale <= 1.0 else {
+        guard scale.map({ $0 >= 0.1 && $0 <= 1.0 }) ?? true else {
             throw ValidationError("Scale must be between 0.1 and 1.0")
         }
     }

--- a/Sources/iOSSimBackend/Verbs/IOSSimRecordVideoCommand.swift
+++ b/Sources/iOSSimBackend/Verbs/IOSSimRecordVideoCommand.swift
@@ -19,7 +19,7 @@ import SimUseVideo
 public struct IOSSimRecordVideoCommand: SimUseExecutableCommand {
     public static let configuration = CommandConfiguration(
         commandName: "record-video",
-        abstract: "Record the iOS Simulator display to an MP4 file using H.264 encoding"
+        abstract: "Record the iOS Simulator display to an MP4 (H.264) or animated GIF file"
     )
 
     public struct ExecutionResult: Codable {
@@ -38,16 +38,19 @@ public struct IOSSimRecordVideoCommand: SimUseExecutableCommand {
 
     @OptionGroup public var device: DeviceOptions
 
-    @Option(help: "Frames per second (1-60, default: 30).")
+    @Option(help: "Frames per second (1-60; default: 30 for mp4, 10 for gif).")
     public var fps: Int?
 
     @Option(help: "Quality factor (1-100) controlling bitrate (default: 80)")
     public var quality: Int = 80
 
-    @Option(help: "Scale factor (0.1-1.0, default: 1.0)")
-    public var scale: Double = 1.0
+    @Option(help: "Scale factor (0.1-1.0; default: 1.0 for mp4, 0.5 for gif)")
+    public var scale: Double?
 
-    @Option(help: "Output MP4 file path. Defaults to sim-use-video-<timestamp>.mp4 in the current directory.")
+    @Option(help: "Output format: mp4, gif. Defaults to the --output extension when recognized, else mp4.")
+    public var format: RecordingFormat?
+
+    @Option(help: "Output file path. Defaults to sim-use-video-<timestamp>.<format> in the current directory.")
     public var output: String?
 
     @OptionGroup public var json: JSONOutputOptions
@@ -95,8 +98,12 @@ public struct IOSSimRecordVideoCommand: SimUseExecutableCommand {
             throw CLIError(errorDescription: "Simulator \(trimmedUDID) is not booted. Current state: \(stateDescription)")
         }
 
-        let outputURL = try VideoOutputFile.prepareOutputURL(output: output)
-        FileHandle.standardError.write(Data("Recording simulator \(targetSimulator.udid) to \(outputURL.path)\n".utf8))
+        // GIF is transcoded from a finished MP4 (see GIFTranscoder); the
+        // capture loop itself always writes H.264, to plan.recordTarget.
+        let plan = try RecordingOutputPlan(format: format, output: output, fps: fps, scale: scale)
+        let options = plan.options
+        let recordTarget = plan.recordTarget
+        FileHandle.standardError.write(Data("Recording simulator \(targetSimulator.udid) to \(plan.outputURL.path)\n".utf8))
         FileHandle.standardError.write(Data("Press Ctrl+C to stop recording\n".utf8))
 
         let cancellationFlag = CancellationFlag()
@@ -110,27 +117,25 @@ public struct IOSSimRecordVideoCommand: SimUseExecutableCommand {
         do {
             try await recordVideoViaNativeRecording(
                 simulator: targetSimulator,
-                outputURL: outputURL,
-                fps: fps ?? 30,
+                outputURL: recordTarget,
+                fps: options.fps ?? 30,
                 quality: quality,
-                scale: scale,
+                scale: options.scale,
                 cancellationFlag: cancellationFlag
             )
             recordingFinished.cancel()
-            return ExecutionResult(path: outputURL.path)
         } catch let unavailable as RecordingUnavailableError {
             FileHandle.standardError.write(Data("warning: native H.264 recording unavailable (\(unavailable.underlying)); falling back to screenshot capture\n".utf8))
             do {
                 try await recordVideoViaScreenshots(
                     simulator: targetSimulator,
-                    outputURL: outputURL,
-                    fps: fps ?? 10,
+                    outputURL: recordTarget,
+                    fps: options.fps ?? 10,
                     quality: quality,
-                    scale: scale,
+                    scale: options.scale,
                     cancellationFlag: cancellationFlag
                 )
                 recordingFinished.cancel()
-                return ExecutionResult(path: outputURL.path)
             } catch {
                 recordingFinished.cancel()
                 throw CLIError(errorDescription: "Failed to record video: \(error.localizedDescription)")
@@ -139,6 +144,14 @@ public struct IOSSimRecordVideoCommand: SimUseExecutableCommand {
             recordingFinished.cancel()
             throw CLIError(errorDescription: "Failed to record video: \(error.localizedDescription)")
         }
+
+        // Tear the observer down before the transcode so Ctrl+C during a
+        // long GIF encode kills the process instead of being swallowed by
+        // a handler that has nothing left to cancel (invalidate is
+        // idempotent; the defer covers the error paths above).
+        signalObserver.invalidate()
+        try await plan.finalizeRecording()
+        return ExecutionResult(path: plan.outputURL.path)
     }
 
     // MARK: - H.264 native recording

--- a/Tests/GIFTranscoderTests.swift
+++ b/Tests/GIFTranscoderTests.swift
@@ -61,7 +61,21 @@ struct GIFTranscoderTests {
         #expect(capped == GIFTranscoder.plan(presentationTimes: times, fps: GIFTranscoder.maximumFPS))
         // Total GIF duration stays close to the 1 s of source footage.
         let duration = capped.delays.reduce(0, +)
-        #expect(abs(duration - 1.0) < 0.1)
+        #expect(abs(duration - 1.0) <= 0.02)
+    }
+
+    @Test("High-rate sources keep wall-clock duration to centisecond tolerance", arguments: [60, 120])
+    func planPreservesWallClockAtHighSourceRates(sourceFPS: Int) {
+        // 10 s of source footage — long enough for per-frame rounding to
+        // accumulate visibly if selection or quantization loses debt
+        // (independent 2 cs clamping used to stretch this to ~10.65 s
+        // for a 60 fps source and ~10.8 s for 120 fps).
+        let times = (0..<(10 * sourceFPS)).map { Double($0) / Double(sourceFPS) }
+        let plan = GIFTranscoder.plan(presentationTimes: times, fps: 60)
+
+        #expect(plan.delays.allSatisfy { $0 >= GIFTranscoder.minimumDelay })
+        let duration = plan.delays.reduce(0, +)
+        #expect(abs(duration - 10.0) <= 0.02)
     }
 
     @Test("Empty input yields an empty plan")

--- a/Tests/GIFTranscoderTests.swift
+++ b/Tests/GIFTranscoderTests.swift
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: Apache-2.0
+import Testing
+import Foundation
+import AVFoundation
+import CoreMedia
+import ImageIO
+import UniformTypeIdentifiers
+@testable import SimUseVideo
+
+@Suite("GIFTranscoder")
+struct GIFTranscoderTests {
+    // MARK: - Sampling plan (pure logic)
+
+    @Test("Constant-rate input at the target fps keeps every frame")
+    func planKeepsAllFramesAtTargetRate() {
+        let times = (0..<20).map { Double($0) * 0.1 } // 10 fps source
+        let plan = GIFTranscoder.plan(presentationTimes: times, fps: 10)
+        #expect(plan.timestamps == times)
+        #expect(plan.delays.count == times.count)
+        #expect(plan.delays.dropLast().allSatisfy { abs($0 - 0.1) < 0.0001 })
+        #expect(abs(plan.delays.last! - 0.1) < 0.0001) // last frame holds one interval
+    }
+
+    @Test("High-rate input is downsampled to the target fps")
+    func planDownsamplesHighRateInput() {
+        let times = (0..<60).map { Double($0) / 30.0 } // 2 s of 30 fps
+        let plan = GIFTranscoder.plan(presentationTimes: times, fps: 10)
+        // ~10 fps over 2 s → about 20 frames, never the full 60.
+        #expect(plan.timestamps.count >= 15 && plan.timestamps.count <= 25)
+        for (index, pts) in plan.timestamps.enumerated().dropFirst() {
+            #expect(pts - plan.timestamps[index - 1] >= 0.1 - 0.05)
+        }
+    }
+
+    @Test("Variable-frame-rate input derives delays from actual gaps")
+    func planHandlesVariableFrameRate() {
+        let times = [0.0, 0.1, 0.5, 0.6, 2.0] // Android screenrecord-style VFR
+        let plan = GIFTranscoder.plan(presentationTimes: times, fps: 10)
+        #expect(plan.timestamps == times)
+        #expect(abs(plan.delays[1] - 0.4) < 0.0001) // gap 0.1 → 0.5
+        #expect(abs(plan.delays[3] - 1.4) < 0.0001) // gap 0.6 → 2.0
+    }
+
+    @Test("Unsorted timestamps are ordered before sampling")
+    func planSortsTimestamps() {
+        let plan = GIFTranscoder.plan(presentationTimes: [0.2, 0.0, 0.1], fps: 10)
+        #expect(plan.timestamps == [0.0, 0.1, 0.2])
+    }
+
+    @Test("Delays are clamped to the 2-centisecond GIF floor")
+    func planClampsTinyDelays() {
+        let times = (0..<10).map { Double($0) / 60.0 }
+        let plan = GIFTranscoder.plan(presentationTimes: times, fps: 60)
+        #expect(plan.delays.allSatisfy { $0 >= GIFTranscoder.minimumDelay })
+    }
+
+    @Test("Sampling caps at 50 fps so clamped delays cannot stretch playback")
+    func planCapsSamplingRate() {
+        let times = (0..<120).map { Double($0) / 120.0 } // 1 s of 120 fps
+        let capped = GIFTranscoder.plan(presentationTimes: times, fps: 60)
+        #expect(capped == GIFTranscoder.plan(presentationTimes: times, fps: GIFTranscoder.maximumFPS))
+        // Total GIF duration stays close to the 1 s of source footage.
+        let duration = capped.delays.reduce(0, +)
+        #expect(abs(duration - 1.0) < 0.1)
+    }
+
+    @Test("Empty input yields an empty plan")
+    func planEmptyInput() {
+        let plan = GIFTranscoder.plan(presentationTimes: [], fps: 10)
+        #expect(plan.timestamps.isEmpty)
+        #expect(plan.delays.isEmpty)
+    }
+
+    // MARK: - Format resolution
+
+    @Test("Format is inferred from the --output extension")
+    func formatInference() {
+        #expect(RecordingFormat.infer(fromOutput: "demo.gif") == .gif)
+        #expect(RecordingFormat.infer(fromOutput: "/tmp/x/demo.GIF") == .gif)
+        #expect(RecordingFormat.infer(fromOutput: "demo.mp4") == .mp4)
+        #expect(RecordingFormat.infer(fromOutput: "demo.mov") == nil)
+        #expect(RecordingFormat.infer(fromOutput: "demo") == nil)
+        #expect(RecordingFormat.infer(fromOutput: nil) == nil)
+    }
+
+    @Test("GIF gets lower fps/scale defaults; explicit flags win")
+    func resolvedOptionsDefaults() {
+        typealias Options = ResolvedRecordingOptions
+
+        let mp4 = Options(format: nil, output: nil, fps: nil, scale: nil)
+        #expect(mp4.format == .mp4)
+        #expect(mp4.fps == nil) // capture-path default (30 native / 10 fallback)
+        #expect(mp4.scale == 1.0)
+
+        let gif = Options(format: .gif, output: nil, fps: nil, scale: nil)
+        #expect(gif.format == .gif)
+        #expect(gif.fps == 10)
+        #expect(gif.gifSampleFPS == 10)
+        #expect(gif.scale == 0.5)
+
+        let inferred = Options(format: nil, output: "demo.gif", fps: nil, scale: nil)
+        #expect(inferred.format == .gif)
+
+        let explicit = Options(format: .mp4, output: "demo.gif", fps: 24, scale: 0.8)
+        #expect(explicit.format == .mp4) // explicit --format beats the extension
+        #expect(explicit.fps == 24)
+        #expect(explicit.gifSampleFPS == 24)
+        #expect(explicit.scale == 0.8)
+    }
+
+    @Test("RecordingOutputPlan clears a stale GIF intermediate from a previous failed run")
+    func outputPlanClearsStaleIntermediate() throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gif-plan-test-\(UUID().uuidString).gif")
+        defer {
+            try? FileManager.default.removeItem(at: base)
+            try? FileManager.default.removeItem(at: URL(fileURLWithPath: base.path + ".recording.mp4"))
+        }
+        let stale = URL(fileURLWithPath: base.path + ".recording.mp4")
+        try Data([0x00]).write(to: stale)
+
+        let plan = try RecordingOutputPlan(format: nil, output: base.path, fps: nil, scale: nil)
+        #expect(plan.options.format == .gif)
+        #expect(plan.recordTarget == stale)
+        #expect(!FileManager.default.fileExists(atPath: stale.path))
+    }
+
+    @Test("RecordingOutputPlan records mp4 straight to the output path")
+    func outputPlanMP4Passthrough() throws {
+        let base = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gif-plan-test-\(UUID().uuidString).mp4")
+        defer { try? FileManager.default.removeItem(at: base) }
+        let plan = try RecordingOutputPlan(format: nil, output: base.path, fps: nil, scale: nil)
+        #expect(plan.recordTarget == plan.outputURL)
+    }
+
+    @Test("Default output filename uses the resolved format's extension")
+    func prepareOutputURLExtension() throws {
+        let gifURL = try VideoOutputFile.prepareOutputURL(output: nil, fileExtension: "gif")
+        #expect(gifURL.pathExtension == "gif")
+        let mp4URL = try VideoOutputFile.prepareOutputURL(output: nil)
+        #expect(mp4URL.pathExtension == "mp4")
+    }
+
+    // MARK: - Real transcode round-trip
+
+    /// Write `frameCount` solid-color frames through the H.264 recorder
+    /// so the transcoder has a real MP4 to chew on — no simulator needed.
+    private func makeSyntheticMP4(frameCount: Int, fps: Int, width: Int = 64, height: Int = 64) async throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gif-transcoder-test-\(UUID().uuidString).mp4")
+        let recorder = try H264StreamRecorder(outputURL: url, width: width, height: height, fps: fps, quality: 80)
+
+        for frame in 0..<frameCount {
+            let image = try #require(Self.makeFrame(width: width, height: height, hue: Double(frame) / Double(frameCount)))
+            let pts = CMTime(seconds: Double(frame) / Double(fps), preferredTimescale: 600)
+            try recorder.append(image: image, presentationTime: pts)
+        }
+        try await recorder.finish()
+        return url
+    }
+
+    private static func makeFrame(width: Int, height: Int, hue: Double) -> CGImage? {
+        let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue
+        )
+        guard let context else { return nil }
+        context.setFillColor(CGColor(red: hue, green: 1.0 - hue, blue: 0.5, alpha: 1.0))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        // A moving square so the encoder emits more than one distinct frame.
+        context.setFillColor(CGColor(red: 0, green: 0, blue: 0, alpha: 1.0))
+        context.fill(CGRect(x: Int(hue * Double(width - 8)), y: 8, width: 8, height: 8))
+        return context.makeImage()
+    }
+
+    @Test("MP4 round-trip produces a looping GIF with the sampled frame count")
+    func transcodeRoundTrip() async throws {
+        let mp4URL = try await makeSyntheticMP4(frameCount: 20, fps: 10)
+        defer { try? FileManager.default.removeItem(at: mp4URL) }
+        let gifURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gif-transcoder-test-\(UUID().uuidString).gif")
+        defer { try? FileManager.default.removeItem(at: gifURL) }
+
+        let written = try await GIFTranscoder.transcode(mp4URL: mp4URL, to: gifURL, fps: 10)
+
+        let source = try #require(CGImageSourceCreateWithURL(gifURL as CFURL, nil))
+        let type = try #require(CGImageSourceGetType(source) as String?)
+        #expect(UTType(type)?.conforms(to: .gif) == true)
+
+        let frameCount = CGImageSourceGetCount(source)
+        #expect(frameCount == written)
+        // Encoder may drop nothing here: 10 fps source sampled at 10 fps.
+        #expect(frameCount >= 18 && frameCount <= 20)
+
+        let containerProps = try #require(CGImageSourceCopyProperties(source, nil) as? [CFString: Any])
+        let gifDict = try #require(containerProps[kCGImagePropertyGIFDictionary] as? [CFString: Any])
+        #expect(gifDict[kCGImagePropertyGIFLoopCount] as? Int == 0)
+
+        let frameProps = try #require(CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any])
+        let frameGIF = try #require(frameProps[kCGImagePropertyGIFDictionary] as? [CFString: Any])
+        let delay = try #require(frameGIF[kCGImagePropertyGIFUnclampedDelayTime] as? Double)
+        #expect(abs(delay - 0.1) < 0.02)
+
+        let width = try #require(frameProps[kCGImagePropertyPixelWidth] as? Int)
+        #expect(width == 64)
+    }
+
+    @Test("30 fps MP4 sampled at 10 fps drops about two thirds of the frames")
+    func transcodeDownsamples() async throws {
+        let mp4URL = try await makeSyntheticMP4(frameCount: 30, fps: 30)
+        defer { try? FileManager.default.removeItem(at: mp4URL) }
+        let gifURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gif-transcoder-test-\(UUID().uuidString).gif")
+        defer { try? FileManager.default.removeItem(at: gifURL) }
+
+        let written = try await GIFTranscoder.transcode(mp4URL: mp4URL, to: gifURL, fps: 10)
+        #expect(written >= 8 && written <= 12)
+        #expect(CGImageSourceGetCount(try #require(CGImageSourceCreateWithURL(gifURL as CFURL, nil))) == written)
+    }
+
+    @Test("A file with no video track throws noVideoTrack")
+    func transcodeRejectsNonVideo() async throws {
+        let bogusURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gif-transcoder-test-\(UUID().uuidString).mp4")
+        try Data([0x00, 0x01, 0x02, 0x03]).write(to: bogusURL)
+        defer { try? FileManager.default.removeItem(at: bogusURL) }
+        let gifURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gif-transcoder-test-\(UUID().uuidString).gif")
+
+        await #expect(throws: (any Error).self) {
+            try await GIFTranscoder.transcode(mp4URL: bogusURL, to: gifURL, fps: 10)
+        }
+    }
+
+    @Test("A failed transcode preserves the intermediate MP4 and removes the partial GIF")
+    func transcodeRecordingFailureCleansGIF() async throws {
+        let bogusURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gif-transcoder-test-\(UUID().uuidString).mp4")
+        try Data([0x00, 0x01, 0x02, 0x03]).write(to: bogusURL)
+        defer { try? FileManager.default.removeItem(at: bogusURL) }
+        let gifURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gif-transcoder-test-\(UUID().uuidString).gif")
+        try Data([0x47, 0x49, 0x46]).write(to: gifURL) // partial/garbage GIF on disk
+
+        await #expect(throws: (any Error).self) {
+            try await GIFTranscoder.transcodeRecording(tempMP4: bogusURL, to: gifURL, fps: 10)
+        }
+        #expect(FileManager.default.fileExists(atPath: bogusURL.path)) // footage preserved
+        #expect(!FileManager.default.fileExists(atPath: gifURL.path)) // garbage removed
+    }
+}

--- a/skills/sim-use/SKILL.md
+++ b/skills/sim-use/SKILL.md
@@ -82,6 +82,7 @@ Every byte of command output you read costs context. Defaults that keep the loop
 | Swipe | `sim-use swipe --from 50,500 --to 350,500 --device <UDID>` |
 | Pinch zoom in | `sim-use gesture pinch-out --device <UDID>` (two-finger spread) |
 | Rotate | `sim-use gesture rotate-cw --angle 90 --device <UDID>` |
+| Record evidence GIF | `sim-use record-video --output demo.gif --device <UDID>` — stop with SIGINT/SIGTERM (never SIGKILL); transcodes after stop; auto-plays inline in PRs |
 
 ## 2. Pitfalls
 

--- a/skills/sim-use/references/cheatsheet.md
+++ b/skills/sim-use/references/cheatsheet.md
@@ -124,6 +124,7 @@ sim-use touch -x 150 -y 250 --down --up --delay 1.0  # long press
 sim-use screenshot --output shot.png
 sim-use record-video --output recording.mp4             # H.264, 30 fps default; Ctrl+C to stop
 sim-use record-video --output smooth.mp4 --fps 60       # iOS: constant rate up to 60 fps (Android ignores --fps, native rate)
+sim-use record-video --output demo.gif                  # animated GIF (inferred from extension, or --format gif); 10 fps + 0.5 scale defaults; transcoded after Ctrl+C
 sim-use stream-video --fps 10 --format mjpeg > out.mjpeg  # live JPEG stream (both platforms)
 sim-use stream-video --format h264 | ffplay -f h264 -      # Android only: native H.264 passthrough (VFR)
 ```


### PR DESCRIPTION
## What

`record-video` gains `--format mp4|gif` on all three surfaces (top-level, `ios record-video`, `android record-video`).
The format is also inferred from a `.gif` `--output` extension; an explicit `--format` wins, with a stderr note on mismatch.

```bash
sim-use record-video --output demo.gif            # inferred; 10 fps / 0.5 scale GIF defaults
sim-use record-video --format gif --fps 15 --scale 0.4
```

## Why

Animated GIFs auto-play inline in PRs / issues / chat, which makes them the most convenient evidence format for short agent-driven verification flows — today producing one requires an out-of-band ffmpeg conversion.

## Design

GIF is a **post-stop transcode**, not a fourth capture path: none of the capture pipelines (idb's in-process recorder on iOS, `adb screenrecord` passthrough on Android, the screenshot/screencap fallbacks) expose decoded frames in-process, and the signal-to-finalise path is latency-critical. Capture lands in an intermediate MP4; on stop, `GIFTranscoder` (in `SimUseVideo`) decodes it with `AVAssetReader` and encodes a looping GIF via `CGImageDestination`.

- **Two decoding passes** bound decode memory to one frame: pass 1 collects display-timeline PTS (CGImageDestination needs the frame count up front; passthrough PTS carry B-frame reorder offsets and un-applied edit lists, so a non-decoding read can't drive the plan), pass 2 appends only the sampled frames.
- **Sampling** walks a 1/fps target clock (capped at 50 fps — the GIF centisecond delay floor makes faster pacing dishonest), normalizing Android's VFR capture; per-frame delays follow source timestamp gaps.
- **Shared orchestration**: `RecordingOutputPlan` owns resolve → warn → prepare → stale-intermediate cleanup → transcode for every surface, so the flag contract can't drift between platforms (same posture as `VideoRecordingOptions`).
- **Failure safety**: a failed transcode preserves the intermediate MP4 (and says where), removes the partially written GIF, and a stale intermediate from a previous failed/killed run is cleared before capture. The capture signal observer is torn down before the transcode so Ctrl+C during a long encode stays effective. Encodes past ~300 frames print a memory warning (ImageIO holds all frames until finalize; documented in the README).

## Base

Started from `50bc5a0` and rebased onto `da63f16` (post-v0.12.0), relocating the code into the `SimUseVideo` module introduced by #79 — which is also what made the `android record-video` surface come along for free (as discussed on Slack).

## Testing

- `make test` fully green (834 unit tests), including 16 new `GIFTranscoderTests` — sampling-plan properties, format/option resolution, output-plan lifecycle, and a real MP4→GIF round-trip synthesized through `H264StreamRecorder` (no simulator needed).
- Live-verified on an iPhone 17 simulator (iOS 26) against LINE Dev: multiple end-to-end repro GIFs recorded with a single command each (see Demo).

## Demo

Each recorded against LINE Dev on an iPhone 17 simulator with a single `record-video --output <name>.gif` invocation (touch points enabled in the app):

| Open the camera from the LINE AI screen<br>(83 frames, 905 KB) | Change the app font and apply<br>(68 frames, 626 KB) |
| --- | --- |
| <img src="https://raw.githubusercontent.com/kws0210/sim-use/assets/line-ai-camera-repro.gif" width="260" alt="line-ai-camera-repro"> | <img src="https://raw.githubusercontent.com/kws0210/sim-use/assets/line-font-change-repro.gif" width="260" alt="line-font-change-repro"> |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


