### PR TITLE
Fix Retina JPEG scaling for stream-video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- JPEG frame scaling now produces the requested pixel dimensions on Retina displays instead of multiplying the result by the screen backing scale (#83).
 - The `SIM_USE_VERSION` build-time override actually reaches the version stamp now. `VersionPlugin` registered its generator command with an empty environment, so the documented "environment variable first" priority was dead code and every build fell back to `git describe` — release builds happened to be correct only because they build on the tagged commit, while `scripts/dev-install.sh` builds stamped a stale describe string. The override is now resolved in the plugin process and baked into the command's argv, which also makes a changed override invalidate SPM's command cache without requiring a source-file edit.
 
 ## [0.12.0] - 2026-07-29

--- a/Sources/SimUseVideo/VideoCommandSupport.swift
+++ b/Sources/SimUseVideo/VideoCommandSupport.swift
@@ -3,10 +3,7 @@ import Foundation
 import AVFoundation
 import ImageIO
 import os
-#if os(macOS)
-import AppKit
 import SimUseCore
-#endif
 
 /// Stop-path watchdog for the `record-video` command.
 ///
@@ -44,6 +41,7 @@ public enum RecordingFinishWatchdog {
 public enum VideoProcessingError: Error {
     case emptyScreenshot
     case failedToDecodeImage
+    case failedToEncodeImage
     case failedToAllocatePixelBuffer
 }
 
@@ -88,47 +86,71 @@ public struct VideoFrameUtilities {
         return (max(evenWidth, 2), max(evenHeight, 2))
     }
 
+    private static func encodeJPEG(_ image: CGImage, quality: Int) throws -> Data {
+        guard let data = CFDataCreateMutable(nil, 0),
+              let destination = CGImageDestinationCreateWithData(
+                  data,
+                  "public.jpeg" as CFString,
+                  1,
+                  nil
+              ) else {
+            throw VideoProcessingError.failedToEncodeImage
+        }
+
+        let properties = [
+            kCGImageDestinationLossyCompressionQuality: Double(quality) / 100.0
+        ] as CFDictionary
+        CGImageDestinationAddImage(destination, image, properties)
+
+        guard CGImageDestinationFinalize(destination) else {
+            throw VideoProcessingError.failedToEncodeImage
+        }
+
+        return data as Data
+    }
+
     private static func scaleJPEGData(_ data: Data, scale: Double, quality: Int) async throws -> Data {
-        #if os(macOS)
-        guard let image = NSImage(data: data) else {
+        guard let image = makeCGImage(from: data) else {
             throw VideoProcessingError.failedToDecodeImage
         }
 
-        let newSize = NSSize(
-            width: image.size.width * scale,
-            height: image.size.height * scale
+        let dimensions = computeDimensions(for: image, scale: scale)
+        guard let context = CGContext(
+            data: nil,
+            width: dimensions.width,
+            height: dimensions.height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            throw VideoProcessingError.failedToAllocatePixelBuffer
+        }
+
+        context.interpolationQuality = .high
+        context.draw(
+            image,
+            in: CGRect(
+                x: 0,
+                y: 0,
+                width: CGFloat(dimensions.width),
+                height: CGFloat(dimensions.height)
+            )
         )
 
-        let newImage = NSImage(size: newSize)
-        newImage.lockFocus()
-        image.draw(in: NSRect(origin: .zero, size: newSize))
-        newImage.unlockFocus()
-
-        guard let tiffData = newImage.tiffRepresentation,
-              let bitmap = NSBitmapImageRep(data: tiffData),
-              let jpegData = bitmap.representation(using: .jpeg, properties: [NSBitmapImageRep.PropertyKey.compressionFactor: Double(quality) / 100.0]) else {
-            throw VideoProcessingError.failedToDecodeImage
+        guard let scaledImage = context.makeImage() else {
+            throw VideoProcessingError.failedToEncodeImage
         }
 
-        return jpegData
-        #else
-        return data
-        #endif
+        return try encodeJPEG(scaledImage, quality: quality)
     }
 
     private static func reencodeJPEGData(_ data: Data, quality: Int) async throws -> Data {
-        #if os(macOS)
-        guard let image = NSImage(data: data),
-              let tiffData = image.tiffRepresentation,
-              let bitmap = NSBitmapImageRep(data: tiffData),
-              let jpegData = bitmap.representation(using: .jpeg, properties: [NSBitmapImageRep.PropertyKey.compressionFactor: Double(quality) / 100.0]) else {
+        guard let image = makeCGImage(from: data) else {
             throw VideoProcessingError.failedToDecodeImage
         }
 
-        return jpegData
-        #else
-        return data
-        #endif
+        return try encodeJPEG(image, quality: quality)
     }
 }
 

--- a/Tests/VideoFrameProcessingTests.swift
+++ b/Tests/VideoFrameProcessingTests.swift
@@ -29,6 +29,32 @@ struct VideoFrameProcessingTests {
         return try #require(rep.representation(using: .png, properties: [:]))
     }
 
+    private func makePatternPNG(width: Int, height: Int) throws -> Data {
+        let context = try #require(CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ))
+
+        for y in 0..<height {
+            for x in 0..<width {
+                let red = CGFloat((x * 17 + y * 3) % 256) / 255.0
+                let green = CGFloat((x * 5 + y * 11) % 256) / 255.0
+                let blue = CGFloat((x * 13 + y * 7) % 256) / 255.0
+                context.setFillColor(CGColor(red: red, green: green, blue: blue, alpha: 1))
+                context.fill(CGRect(x: x, y: y, width: 1, height: 1))
+            }
+        }
+
+        let image = try #require(context.makeImage())
+        let rep = NSBitmapImageRep(cgImage: image)
+        return try #require(rep.representation(using: .png, properties: [:]))
+    }
+
     @Test("makeCGImage decodes PNG data and rejects garbage")
     func makeCGImage() throws {
         let png = try makePNG(width: 64, height: 48)
@@ -77,22 +103,30 @@ struct VideoFrameProcessingTests {
         let png = try makePNG(width: 64, height: 64)
         let out = try await VideoFrameUtilities.processJPEGData(png, scale: 1.0, quality: 50)
         #expect(out != png)
-        // JPEG SOI marker.
         #expect(out.prefix(2) == Data([0xFF, 0xD8]))
+        let reencoded = try #require(VideoFrameUtilities.makeCGImage(from: out))
+        #expect(reencoded.width == 64)
+        #expect(reencoded.height == 64)
     }
 
-    @Test("scaling re-encodes to JPEG and preserves the aspect ratio")
+    @Test("JPEG quality changes encoded output size")
+    func processAppliesQuality() async throws {
+        let png = try makePatternPNG(width: 128, height: 96)
+        let low = try await VideoFrameUtilities.processJPEGData(png, scale: 1.0, quality: 20)
+        let high = try await VideoFrameUtilities.processJPEGData(png, scale: 1.0, quality: 90)
+
+        #expect(low != high)
+        #expect(low.count < high.count)
+    }
+
+    @Test("scaling re-encodes to JPEG at the requested pixel dimensions")
     func processScales() async throws {
         let png = try makePNG(width: 100, height: 60)
         let out = try await VideoFrameUtilities.processJPEGData(png, scale: 0.5, quality: 80)
         #expect(out.prefix(2) == Data([0xFF, 0xD8]))
-        // The scale path draws through NSImage.lockFocus, which renders
-        // at the host's backing scale factor — absolute pixel dimensions
-        // are environment-dependent (1x headless vs 2x Retina), so pin
-        // the re-encode and the aspect ratio, not exact sizes.
         let scaled = try #require(VideoFrameUtilities.makeCGImage(from: out))
-        let aspect = Double(scaled.width) / Double(scaled.height)
-        #expect(abs(aspect - 100.0 / 60.0) < 0.15, "aspect drifted: \(scaled.width)x\(scaled.height)")
+        #expect(scaled.width == 50)
+        #expect(scaled.height == 30)
     }
 
     @Test("estimateBitrate clamps to its floor and ceiling and grows with quality")


### PR DESCRIPTION
## Summary

Fixes #83.

This updates JPEG frame scaling to produce the requested output pixel dimensions regardless of the host display backing scale. Previously, the macOS `NSImage.lockFocus()` path could render through the Retina backing scale, so `--scale 0.5` could still emit frames at the original Retina-sized dimensions.

The new path decodes to `CGImage`, computes exact scaled dimensions, draws into an explicitly sized `CGContext`, and encodes the result with `CGImageDestination`.

## Changes

- Replace the AppKit-based JPEG scale/re-encode path with ImageIO/CoreGraphics encoding.
- Add an explicit JPEG encode failure error.
- Add tests that assert scaled JPEG output has exact pixel dimensions.
- Add coverage that quality-only re-encoding preserves dimensions and changes output size.

## Validation

- `make build`
- `swift test --filter VideoFrameProcessingTests`
- `git diff --check`
- Live simulator verification:
  - `--scale 1.0`: `1206x2622`
  - `--scale 0.5`: `602x1310`