### PR TITLE
feat: drive physical iOS devices over the accessibility audit daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `sim-use ios-device` (experimental): drive a **physical** iPhone or iPad. `devices` lists attached devices, `ui` prints an outline of the foreground app's accessibility tree, and `tap --text` activates a matching element. The device is reached through its accessibility audit daemon over usbmux lockdown, so nothing is installed on it, nothing is code signed, and no Developer Disk Image is needed — but the device must be unlocked. This channel exposes no element geometry, so there is no coordinate tap, swipe or gesture: interaction goes through accessibility actions, and the outline is ordered by the accessibility reading order rather than by screen position.
+
 ## [0.13.0] - 2026-08-06
 
 ### Added

--- a/Package.swift
+++ b/Package.swift
@@ -48,7 +48,7 @@ let privateModuleMapFlags: [String] = ["-Xcc", "-I\(privateHeadersDir)"] + [
 }
 
 let fbLinkerFlags: [String] = [
-    "FBControlCore", "FBSimulatorControl", "XCTestBootstrap",
+    "FBControlCore", "FBSimulatorControl", "XCTestBootstrap", "FBDeviceControl",
 ].flatMap {
     [
         "-Xlinker", "-force_load",
@@ -86,6 +86,10 @@ let package = Package(
         .library(
             name: "iOSSimBackend",
             targets: ["iOSSimBackend"]
+        ),
+        .library(
+            name: "iOSDeviceBackend",
+            targets: ["iOSDeviceBackend"]
         ),
     ],
     dependencies: [
@@ -133,6 +137,20 @@ let package = Package(
             ],
             plugins: ["VersionPlugin"]
         ),
+        // Physical iOS devices, driven over the accessibility audit daemon
+        // (usbmux lockdown -> DTX). No XCUITest runner, so no code signing and
+        // no Developer Disk Image — but also no element geometry, which is why
+        // this target does not share iOSSimBackend's frame-based machinery.
+        .target(
+            name: "iOSDeviceBackend",
+            dependencies: [
+                "SimUseCore",
+                "FBDeviceControl",
+                "FBControlCore",
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ],
+            path: "Sources/iOSDeviceBackend"
+        ),
         .target(
             name: "AndroidBackend",
             dependencies: [
@@ -159,9 +177,11 @@ let package = Package(
                 "SimUseVideo",
                 "AndroidBackend",
                 "iOSSimBackend",
+                "iOSDeviceBackend",
                 "FBSimulatorControl",
                 "FBControlCore",
                 "XCTestBootstrap",
+                "FBDeviceControl",
                 "CompanionUtilities"
             ],
             path: "Sources/SimUse",
@@ -188,7 +208,7 @@ let package = Package(
         ),
         .testTarget(
             name: "SimUseTests",
-            dependencies: ["SimUse", "iOSSimBackend", "SimUseCore", "SimUseVideo"],
+            dependencies: ["SimUse", "iOSSimBackend", "iOSDeviceBackend", "SimUseCore", "SimUseVideo"],
             path: "Tests",
             // `Tests/` is the umbrella path; the sub-target test
             // directories below sit under it as separate testTargets.
@@ -245,6 +265,10 @@ let package = Package(
         .binaryTarget(
             name: "CompanionUtilities",
             path: "build_products/XCFrameworks/CompanionUtilities.xcframework"
+        ),
+        .binaryTarget(
+            name: "FBDeviceControl",
+            path: "build_products/XCFrameworks/FBDeviceControl.xcframework"
         ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Plan, code, **verify**, ship — teach this CLI to your agent and close the last
 - [Install](#install)
 - [Platforms](#platforms)
 - [Commands](#commands)
+- [Physical iOS devices](#physical-ios-devices)
 - [Architecture](#architecture)
 - [Viewer](#viewer)
 - [Contributing](#contributing)
@@ -145,6 +146,8 @@ sim-use drives both **iOS Simulators** and **Android devices / emulators** throu
 
 For Android, run `sim-use android init --device <serial>` once to install the bridge APK. See `AGENTS.md` for Android toolchain setup.
 
+**Physical iPhones and iPads** are reachable too, under a separate `sim-use ios-device` surface — nothing is installed on the device, nothing is code signed and no Developer Disk Image is needed, but the device must be unlocked. That channel exposes no element geometry, so it trades coordinate taps, swipes and gestures for accessibility actions. See [Physical iOS devices](#physical-ios-devices).
+
 
 ## Commands
 
@@ -153,6 +156,7 @@ All device-scoped commands accept `--device <ID>` (optional when only one simula
   * **Top-level** — cross-platform verbs: `ui`, `tap`, `long-press`, `swipe`, `touch`, `multi-touch`, `type`, `paste`, `button`, `gesture`, `keyboard-state`, `screenshot`, `record-video`, `stream-video`, `app-state`. Same flags on iOS and Android.
   * **`sim-use ios <verb>`** — iOS-only: `key`, `key-combo`, `key-sequence`, `batch`.
   * **`sim-use android <verb>`** — Android-only: `init`, `devices`, `ping`, `scroll`.
+  * **`sim-use ios-device <verb>`** — physical iOS devices (experimental): `devices`, `ui`, `tap`. Separate from the top-level verbs because the capabilities differ — see [Physical iOS devices](#physical-ios-devices).
 
 Run `sim-use --help` or `sim-use <command> --help` for the full flag set.
 
@@ -381,9 +385,37 @@ SIM_USE_NO_DAEMON=1 sim-use ui --device $UDID
 Daemons self-exit after 600 s of idle and log to `/tmp/sim-use-<uid>/<UDID>.log`. Streaming commands (`screenshot`, `record-video`, `stream-video`) always run in-process regardless.
 
 
+## Physical iOS devices
+
+**Experimental.** A connected iPhone or iPad is driven through its accessibility audit daemon over usbmux lockdown — no XCUITest runner is installed, nothing is code signed, and no Developer Disk Image is mounted. The device must be **unlocked**; a locked screen accepts the connection and then reports no elements.
+
+```bash
+sim-use ios-device devices
+# 00008140-000210603A40801C  My iPhone  iOS 27.0  Booted
+
+sim-use ios-device ui
+# @4   Button  "Chats Button, Selected"
+# @5   Button  "Friends"
+# ...
+# 117 elements (316 nodes) in 6647 ms
+
+sim-use ios-device tap --text "Friends"
+# ✓ Activated Friends Button
+```
+
+A device is addressed by UDID or ECID, and `--device` is optional when only one is attached.
+
+This channel behaves differently from the simulator one, in ways that shape how you drive it:
+
+  * **No element geometry.** iOS serves no frames here — Xcode's own Accessibility Inspector shows no Frame row for a physical device either. So there is no coordinate tap, `swipe`, `gesture` or `multi-touch`; interaction is by accessibility action instead. Scrolling and app-defined swipe actions (a chat row's *Pin* or *Mute*, say) are reachable that way without any gesture.
+  * **No `@N` aliases across processes.** Element handles encode a live pointer and die with the connection, so `tap` resolves its target by `--text` inside a single session rather than reusing an alias from a previous `ui`.
+  * **Slower.** The daemon serialises requests, so a full tree costs a few seconds. `--fast` stops descending at labelled elements — roughly 40% quicker for about a quarter fewer elements.
+  * **Reading order, not screen order.** With no frames to sort by, the outline follows the accessibility tree's nesting and reading order.
+
+
 ## Architecture
 
-sim-use drives iOS Simulators through the lower-level XCFrameworks of Facebook's [idb](https://github.com/facebook/idb) (statically linked), Apple's Accessibility APIs, and the simulator HID pipeline. Android devices are driven through an on-device bridge APK that exposes the AccessibilityService tree and input injection over HTTP, tunnelled via `adb forward`. Everything ships as a single binary; every command supports `--json` for machine consumption.
+sim-use drives iOS Simulators through the lower-level XCFrameworks of Facebook's [idb](https://github.com/facebook/idb) (statically linked), Apple's Accessibility APIs, and the simulator HID pipeline. Android devices are driven through an on-device bridge APK that exposes the AccessibilityService tree and input injection over HTTP, tunnelled via `adb forward`. Physical iOS devices go through a third path: idb's `FBDeviceControl` opens a lockdown service connection, over which sim-use speaks Apple's DTX message protocol to the accessibility audit daemon. Everything ships as a single binary; every command supports `--json` for machine consumption.
 
 
 ## Viewer

--- a/Sources/SimUse/main.swift
+++ b/Sources/SimUse/main.swift
@@ -7,6 +7,7 @@ import Darwin
 import SimUseCore
 import AndroidBackend
 import iOSSimBackend
+import iOSDeviceBackend
 
 // MARK: - Main Entry Point
 //
@@ -101,6 +102,7 @@ struct SimUse: AsyncParsableCommand {
             // `IOSSimCommand` only — the top-level surface only carries
             // verbs that work on both platforms.
             IOSSimCommand.self,
+            IOSDeviceCommand.self,
             AndroidCommand.self,
         ]
     )

--- a/Sources/iOSDeviceBackend/AXAudit/AXAuditAttribute.swift
+++ b/Sources/iOSDeviceBackend/AXAudit/AXAuditAttribute.swift
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+import Foundation
+
+/// A request descriptor for `deviceElement:valueForAttribute:` and
+/// `deviceElement:performAction:withValue:`.
+///
+/// The daemon advertises the attributes it supports per inspector section, but
+/// the advertised list is not exhaustive — `Traits` is absent from it yet reads
+/// back fine — so the names below are the ones measured to work rather than the
+/// ones announced. `Frame` is deliberately missing: iOS serves no geometry on
+/// this channel at all (Xcode's own Accessibility Inspector shows no Frame row
+/// for a physical device either).
+public struct AXAuditAttribute: Equatable, Sendable {
+    public let name: String
+    public let humanReadableName: String
+    public let performsAction: Bool
+    public let isSettable: Bool
+    public let valueType: Int
+
+    public init(
+        name: String,
+        humanReadableName: String? = nil,
+        performsAction: Bool = false,
+        isSettable: Bool = false,
+        valueType: Int = 0
+    ) {
+        self.name = name
+        self.humanReadableName = humanReadableName ?? name
+        self.performsAction = performsAction
+        self.isSettable = isSettable
+        self.valueType = valueType
+    }
+
+    public var encoded: AXAuditValue {
+        .object(tag: "AXAuditElementAttribute_v1", fields: [
+            "AttributeNameValue_v1": .scalar(name),
+            "HumanReadableNameValue_v1": .scalar(humanReadableName),
+            "DisplayAsTree_v1": .scalar(0),
+            "IsInternal_v1": .scalar(0),
+            "PerformsActionValue_v1": .scalar(performsAction ? 1 : 0),
+            "SettableValue_v1": .scalar(isSettable ? 1 : 0),
+            "ValueTypeValue_v1": .scalar(valueType),
+        ])
+    }
+}
+
+// MARK: - Readable attributes
+
+public extension AXAuditAttribute {
+    static let label = AXAuditAttribute(name: "Label")
+    static let value = AXAuditAttribute(name: "Value")
+    static let hint = AXAuditAttribute(name: "Hint")
+    static let identifier = AXAuditAttribute(name: "Identifier")
+    static let traits = AXAuditAttribute(name: "Traits")
+    static let traitsHumanReadable = AXAuditAttribute(name: "TraitsHumanReadable")
+    static let className = AXAuditAttribute(name: "ElementClassName")
+    static let hierarchy = AXAuditAttribute(name: "_AXHierarchyElementsAttribute")
+}
+
+// MARK: - Actions
+
+public extension AXAuditAttribute {
+    /// Tapping. The numeric codes are the daemon's own action identifiers,
+    /// read back from the Actions section of a focus event.
+    static let activate = action(code: 2010, humanReadableName: "Activate")
+    static let scrollDown = action(code: 2006, humanReadableName: "Scroll down")
+    static let scrollUp = action(code: 2007, humanReadableName: "Scroll up")
+
+    static func action(code: Int, humanReadableName: String) -> AXAuditAttribute {
+        AXAuditAttribute(
+            name: "AXAction-\(code)",
+            humanReadableName: humanReadableName,
+            performsAction: true,
+            valueType: 1
+        )
+    }
+
+    /// App-defined actions (LINE's `Pin chat`, `Delete`, …). Their names embed a
+    /// live pointer, so they are only valid for the session that reported them.
+    static func custom(name: String, humanReadableName: String) -> AXAuditAttribute {
+        AXAuditAttribute(name: name, humanReadableName: humanReadableName, performsAction: true, valueType: 1)
+    }
+
+    var isScrollAction: Bool { self == .scrollDown || self == .scrollUp }
+}

--- a/Sources/iOSDeviceBackend/AXAudit/AXAuditClient.swift
+++ b/Sources/iOSDeviceBackend/AXAudit/AXAuditClient.swift
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+import Foundation
+
+/// Sends one DTX selector and resolves its reply. Kept abstract so the
+/// selector layer can be exercised without a device attached.
+public protocol DTXInvoking: Sendable {
+    func invoke(_ selector: String, arguments: [AXAuditValue], expectsReply: Bool) async throws -> AXAuditValue
+}
+
+public extension DTXInvoking {
+    func invoke(_ selector: String, _ arguments: AXAuditValue...) async throws -> AXAuditValue {
+        try await invoke(selector, arguments: arguments, expectsReply: true)
+    }
+
+    func send(_ selector: String, _ arguments: AXAuditValue...) async throws {
+        _ = try await invoke(selector, arguments: arguments, expectsReply: false)
+    }
+}
+
+public enum AXAuditError: Error, LocalizedError, CustomStringConvertible {
+    case noRootElement
+    case unsupportedSelector(String)
+    case malformedReply(selector: String)
+
+    public var errorDescription: String? { description }
+
+    public var description: String {
+        switch self {
+        case .noRootElement:
+            return "the foreground app exposed no root accessibility element — unlock the device and try again"
+        case let .unsupportedSelector(selector):
+            return "the device does not support '\(selector)'"
+        case let .malformedReply(selector):
+            return "the device did not answer '\(selector)' as expected — this is what a locked screen looks like; unlock it and try again"
+        }
+    }
+}
+
+/// Selector-level API for `com.apple.accessibility.axAuditDaemon.remoteserver`.
+///
+/// Reachable over plain usbmux lockdown: no runner app, no code signing and no
+/// Developer Disk Image. Element geometry is not available on this channel at
+/// any iOS version measured, so there is intentionally no frame accessor.
+public struct AXAuditClient: Sendable {
+    private let transport: any DTXInvoking
+
+    public init(transport: any DTXInvoking) {
+        self.transport = transport
+    }
+
+    /// Must run before anything else: without it the daemon answers element
+    /// queries with nil even though the connection is healthy.
+    public func prepare() async throws {
+        try await transport.send("deviceInspectorEnable:", .bool(true))
+        try await transport.send("deviceSetAppMonitoringEnabled:", .bool(true))
+        try await transport.send("deviceInspectorShowVisuals:", .bool(false))
+    }
+
+    /// Releases the daemon's inspector state. Skipping this leaves the device
+    /// wedged: later sessions connect and answer, but every element query comes
+    /// back empty until something calls it. Abruptly dropping several sessions
+    /// at once is enough to trigger that.
+    public func finish() async {
+        try? await transport.send("deviceInspectorEnable:", .bool(false))
+        try? await transport.send("deviceSetAppMonitoringEnabled:", .bool(false))
+        try? await transport.send("devicePerformFinalCleanup")
+    }
+
+    public func capabilities() async throws -> [String] {
+        let reply = try await transport.invoke("deviceCapabilities")
+        guard case let .list(values) = reply.unwrapped else {
+            throw AXAuditError.malformedReply(selector: "deviceCapabilities")
+        }
+        return values.compactMap(\.stringValue)
+    }
+
+    public func apiVersion() async throws -> Int? {
+        try await transport.invoke("deviceApiVersion").intValue
+    }
+
+    public func rootElement() async throws -> AXAuditElement {
+        let reply = try await transport.invoke("deviceFetchSpecialElement:", .int(0))
+        guard let element = AXAuditElement(payload: reply) else { throw AXAuditError.noRootElement }
+        return element
+    }
+
+    public func value(of attribute: AXAuditAttribute, for element: AXAuditElement) async throws -> AXAuditValue {
+        try await transport.invoke("deviceElement:valueForAttribute:", element.encoded, attribute.encoded)
+    }
+
+    public func string(_ attribute: AXAuditAttribute, for element: AXAuditElement) async throws -> String? {
+        try await value(of: attribute, for: element).stringValue
+    }
+
+    /// Direct children of `element`, already carrying their label and role so a
+    /// tree walk needs one round trip per node rather than one per attribute.
+    public func children(of element: AXAuditElement) async throws -> [AXAuditNode] {
+        let reply = try await value(of: .hierarchy, for: element)
+        return reply.descendants(taggedWith: "AXAuditNode_v1").compactMap { node in
+            guard let child = node["AuditElementValue_v1"].flatMap(AXAuditElement.init(payload:)) else { return nil }
+            return AXAuditNode(
+                element: child,
+                summary: node["HumanReadableDescriptionValue_v1"]?.stringValue ?? "",
+                role: node["HumanReadableRoleDescriptionValue_v1"]?.stringValue ?? "",
+                isIgnored: node["IsIgnoredValue_v1"]?.boolValue ?? false
+            )
+        }
+    }
+
+    public func perform(_ action: AXAuditAttribute, on element: AXAuditElement) async throws {
+        try await transport.send("deviceElement:performAction:withValue:", element.encoded, action.encoded, .int(0))
+    }
+
+    public func captureScreenshot() async throws -> DeviceScreenshot {
+        let reply = try await transport.invoke("deviceCaptureScreenshot")
+        guard let screenshot = DeviceScreenshot(payload: reply) else {
+            throw AXAuditError.malformedReply(selector: "deviceCaptureScreenshot")
+        }
+        return screenshot
+    }
+}
+
+/// A screenshot plus the display metadata the daemon returns alongside it —
+/// the only geometry this channel offers.
+public struct DeviceScreenshot: Sendable {
+    public let pngData: Data
+    public let nativeScale: Int?
+    public let rotationRadians: Int?
+
+    init?(payload: AXAuditValue) {
+        guard let data = payload["imageData"]?.dataValue, data.starts(with: Self.pngMagic) else { return nil }
+        pngData = data
+        nativeScale = payload["displayNativeScale"]?.intValue
+        rotationRadians = payload["rotationRadians"]?.intValue
+    }
+
+    private static let pngMagic: [UInt8] = [0x89, 0x50, 0x4E, 0x47]
+}

--- a/Sources/iOSDeviceBackend/AXAudit/AXAuditElement.swift
+++ b/Sources/iOSDeviceBackend/AXAudit/AXAuditElement.swift
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+import Foundation
+
+/// A handle to one on-device accessibility element.
+///
+/// `token` is the daemon's `PlatformElementValue_v1` — an opaque 20-byte blob
+/// that encodes a live pointer, so it is only meaningful within the session
+/// that produced it, and only while the element is still on screen.
+///
+/// The two APIs disagree about staleness, which the call sites must respect:
+/// `performAction` still works on a token captured many focus steps earlier,
+/// while `valueForAttribute` returns nil for anything but a freshly returned or
+/// currently focused element. Re-focusing a stale token is worse than useless —
+/// table-view cells are recycled, so it lands on a different row and reads as a
+/// selection.
+public struct AXAuditElement: Equatable, Hashable, Sendable {
+    public let token: Data
+
+    public init(token: Data) {
+        self.token = token
+    }
+
+    public var encoded: AXAuditValue {
+        .object(tag: "AXAuditElement_v1", fields: [
+            "PlatformElementValue_v1": .scalar(token),
+        ])
+    }
+
+    /// Recovers an element from a reply. Nested `AuditElementValue_v1` wrappers
+    /// appear inside hierarchy nodes, so the search is depth-first rather than
+    /// a fixed key path.
+    public init?(payload: AXAuditValue) {
+        guard let token = Self.firstToken(in: payload) else { return nil }
+        self.init(token: token)
+    }
+
+    private static func firstToken(in value: AXAuditValue) -> Data? {
+        if let token = value["PlatformElementValue_v1"]?.dataValue { return token }
+        switch value.unwrapped {
+        case let .fields(fields):
+            for field in fields.values {
+                if let token = firstToken(in: field) { return token }
+            }
+        case let .list(values):
+            for element in values {
+                if let token = firstToken(in: element) { return token }
+            }
+        case let .object(_, inner):
+            return firstToken(in: inner)
+        default:
+            break
+        }
+        return nil
+    }
+}
+
+/// One node of the hierarchy reply. The daemon reports the view tree, so most
+/// nodes are plain containers; a non-empty `role` marks the ones that are real
+/// accessibility elements.
+public struct AXAuditNode: Equatable, Sendable {
+    public let element: AXAuditElement
+    public let summary: String
+    public let role: String
+    public let isIgnored: Bool
+
+    public init(element: AXAuditElement, summary: String, role: String, isIgnored: Bool) {
+        self.element = element
+        self.summary = summary
+        self.role = role
+        self.isIgnored = isIgnored
+    }
+
+    public var isAccessibilityElement: Bool { !role.isEmpty && !isIgnored }
+}

--- a/Sources/iOSDeviceBackend/AXAudit/AXAuditValue.swift
+++ b/Sources/iOSDeviceBackend/AXAudit/AXAuditValue.swift
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+import Foundation
+
+/// The self-describing envelope every value on the axAuditDaemon wire is
+/// wrapped in: `{"ObjectType": <tag>, "Value": <payload>}`.
+///
+/// Modelling it as a type rather than hand-built dictionaries is deliberate.
+/// The reference Python client mis-nests the element token one level up
+/// (`PlatformElementValue_v1` gets an envelope with no `Value`, and the token
+/// lands in a sibling key); the daemon then receives an empty element, performs
+/// nothing, and — because the call is fire-and-forget — reports success.
+public indirect enum AXAuditValue: Equatable, Sendable {
+    case passthrough(AXAuditValue)
+    case object(tag: String, value: AXAuditValue)
+    case fields([String: AXAuditValue])
+    case string(String)
+    case int(Int)
+    case bool(Bool)
+    case data(Data)
+    case list([AXAuditValue])
+    case null
+
+    private enum Key {
+        static let objectType = "ObjectType"
+        static let value = "Value"
+        static let passthrough = "passthrough"
+    }
+}
+
+// MARK: - Encoding
+
+public extension AXAuditValue {
+    /// Property-list representation handed to `NSKeyedArchiver`.
+    var propertyList: Any {
+        switch self {
+        case let .passthrough(inner):
+            return [Key.objectType: Key.passthrough, Key.value: inner.propertyList]
+        case let .object(tag, value):
+            return [Key.objectType: tag, Key.value: value.propertyList]
+        case let .fields(fields):
+            return fields.mapValues(\.propertyList)
+        case let .string(string):
+            return string
+        case let .int(int):
+            return int
+        case let .bool(bool):
+            return bool
+        case let .data(data):
+            return data
+        case let .list(values):
+            return values.map(\.propertyList)
+        case .null:
+            return NSNull()
+        }
+    }
+
+    /// `passthrough`-wrapped scalar, the shape the daemon expects for every
+    /// leaf inside an object's field dictionary.
+    static func scalar(_ string: String) -> AXAuditValue { .passthrough(.string(string)) }
+    static func scalar(_ int: Int) -> AXAuditValue { .passthrough(.int(int)) }
+    static func scalar(_ bool: Bool) -> AXAuditValue { .passthrough(.bool(bool)) }
+    static func scalar(_ data: Data) -> AXAuditValue { .passthrough(.data(data)) }
+
+    /// A tagged object whose fields are each `passthrough`-wrapped.
+    static func object(tag: String, fields: [String: AXAuditValue]) -> AXAuditValue {
+        .object(tag: tag, value: .passthrough(.fields(fields)))
+    }
+}
+
+// MARK: - Decoding
+
+public extension AXAuditValue {
+    init(propertyList: Any) {
+        if let dictionary = propertyList as? [String: Any] {
+            if let tag = dictionary[Key.objectType] as? String {
+                let inner = dictionary[Key.value].map { AXAuditValue(propertyList: $0) } ?? .null
+                self = tag == Key.passthrough ? .passthrough(inner) : .object(tag: tag, value: inner)
+                return
+            }
+            self = .fields(dictionary.mapValues { AXAuditValue(propertyList: $0) })
+            return
+        }
+        if let values = propertyList as? [Any] {
+            self = .list(values.map { AXAuditValue(propertyList: $0) })
+            return
+        }
+        if let data = propertyList as? Data { self = .data(data); return }
+        if let string = propertyList as? String { self = .string(string); return }
+        if let number = propertyList as? NSNumber {
+            self = CFGetTypeID(number) == CFBooleanGetTypeID() ? .bool(number.boolValue) : .int(number.intValue)
+            return
+        }
+        self = .null
+    }
+
+    /// Strips `passthrough` layers so callers can read a leaf without walking
+    /// the envelope by hand.
+    var unwrapped: AXAuditValue {
+        if case let .passthrough(inner) = self { return inner.unwrapped }
+        return self
+    }
+
+    var stringValue: String? {
+        if case let .string(string) = unwrapped { return string }
+        return nil
+    }
+
+    var intValue: Int? {
+        switch unwrapped {
+        case let .int(int): return int
+        case let .bool(bool): return bool ? 1 : 0
+        default: return nil
+        }
+    }
+
+    var boolValue: Bool? {
+        switch unwrapped {
+        case let .bool(bool): return bool
+        case let .int(int): return int != 0
+        default: return nil
+        }
+    }
+
+    var dataValue: Data? {
+        if case let .data(data) = unwrapped { return data }
+        return nil
+    }
+
+    subscript(field: String) -> AXAuditValue? {
+        switch unwrapped {
+        case let .fields(fields): return fields[field]
+        case let .object(_, value): return value[field]
+        default: return nil
+        }
+    }
+
+    /// Depth-first search for every object carrying `tag`, used to pull nodes
+    /// out of a hierarchy reply without modelling the whole reply shape.
+    func descendants(taggedWith tag: String) -> [AXAuditValue] {
+        var found: [AXAuditValue] = []
+        walk { value in
+            if case let .object(objectTag, _) = value, objectTag == tag { found.append(value) }
+        }
+        return found
+    }
+
+    private func walk(_ visit: (AXAuditValue) -> Void) {
+        visit(self)
+        switch self {
+        case let .passthrough(inner): inner.walk(visit)
+        case let .object(_, value): value.walk(visit)
+        case let .fields(fields): fields.values.forEach { $0.walk(visit) }
+        case let .list(values): values.forEach { $0.walk(visit) }
+        default: break
+        }
+    }
+}

--- a/Sources/iOSDeviceBackend/Domain/DeviceOutline.swift
+++ b/Sources/iOSDeviceBackend/Domain/DeviceOutline.swift
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+import Foundation
+
+/// Renders a device element tree as an indented outline.
+///
+/// There are no frames on this channel, so the outline cannot sort or group by
+/// screen position the way the simulator one does. Nesting and traversal order
+/// carry that structure instead — which is the accessibility reading order, and
+/// is arguably a better ordering to hand an agent than y-coordinates.
+public struct DeviceOutline {
+    public struct Row {
+        public let alias: Int
+        public let depth: Int
+        public let role: String
+        public let label: String
+    }
+
+    public let rows: [Row]
+
+    public init(elements: [DeviceElement]) {
+        var rows: [Row] = []
+        var depths: [Int: Int] = [:]
+
+        for (index, element) in elements.enumerated() {
+            let parentDepth = element.parent.flatMap { depths[$0] } ?? -1
+            guard element.isAccessibilityElement else {
+                depths[index] = parentDepth
+                continue
+            }
+            let depth = parentDepth + 1
+            depths[index] = depth
+            rows.append(Row(
+                alias: rows.count + 1,
+                depth: depth,
+                role: element.role,
+                label: Self.label(from: element.summary, role: element.role)
+            ))
+        }
+        self.rows = rows
+    }
+
+    public func rendered() -> String {
+        rows.map { row in
+            let indent = String(repeating: "  ", count: min(row.depth, 8))
+            let alias = "@\(row.alias)".padding(toLength: 5, withPad: " ", startingAt: 0)
+            return "\(alias)\(indent)\(row.role)  \(row.label.isEmpty ? "" : "\"\(row.label)\"")"
+        }.joined(separator: "\n")
+    }
+
+    /// The daemon's description already ends with the role ("Chats Button,
+    /// Selected"), and repeating it in the rendered row is noise.
+    private static func label(from summary: String, role: String) -> String {
+        guard !role.isEmpty else { return summary }
+        let trimmed = summary.hasSuffix(role)
+            ? String(summary.dropLast(role.count))
+            : summary
+        return trimmed.trimmingCharacters(in: CharacterSet(charactersIn: " ,"))
+    }
+}

--- a/Sources/iOSDeviceBackend/Domain/DeviceTreeFetcher.swift
+++ b/Sources/iOSDeviceBackend/Domain/DeviceTreeFetcher.swift
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+import Foundation
+
+public struct DeviceElement: Sendable {
+    public let element: AXAuditElement
+    public let summary: String
+    public let role: String
+    public let depth: Int
+    public let parent: Int?
+    public let isIgnored: Bool
+
+    public var isAccessibilityElement: Bool { !role.isEmpty && !isIgnored }
+}
+
+/// Walks the on-device element tree breadth-first.
+///
+/// Enumeration goes through `_AXHierarchyElementsAttribute` rather than
+/// inspector focus movement on purpose: focus movement is VoiceOver-style and
+/// scrolls offscreen elements into view, so a focus-based `ui` would leave the
+/// screen scrolled to the bottom — and there is no safe undo, because
+/// re-focusing a stale token lands on a recycled cell and reads as a selection.
+/// The hierarchy walk is inert; measured drift across repeated full walks stays
+/// under 1% of pixels, all of it app animation.
+public struct DeviceTreeFetcher: Sendable {
+    /// Measured on a chat list: 16 halves the wall clock against serial, 32
+    /// adds nothing — the daemon serialises beyond that.
+    public static let defaultConcurrency = 16
+    public static let defaultNodeLimit = 1500
+
+    private let client: AXAuditClient
+    private let concurrency: Int
+    private let nodeLimit: Int
+    private let stopsAtLabelledNodes: Bool
+
+    public init(
+        client: AXAuditClient,
+        concurrency: Int = defaultConcurrency,
+        nodeLimit: Int = defaultNodeLimit,
+        stopsAtLabelledNodes: Bool = false
+    ) {
+        self.client = client
+        self.concurrency = concurrency
+        self.nodeLimit = nodeLimit
+        self.stopsAtLabelledNodes = stopsAtLabelledNodes
+    }
+
+    public func fetchTree() async throws -> [DeviceElement] {
+        let root = try await client.rootElement()
+        var discovered: [DeviceElement] = []
+        var visited: Set<AXAuditElement> = [root]
+        var frontier: [(element: AXAuditElement, index: Int?)] = [(root, nil)]
+        var depth = 0
+
+        while !frontier.isEmpty, discovered.count < nodeLimit {
+            let expansions = await expand(frontier.map(\.element))
+            var next: [(element: AXAuditElement, index: Int?)] = []
+
+            for (offset, children) in expansions.enumerated() {
+                let parent = frontier[offset].index
+                for child in children where visited.insert(child.element).inserted {
+                    discovered.append(DeviceElement(
+                        element: child.element,
+                        summary: child.summary,
+                        role: child.role,
+                        depth: depth,
+                        parent: parent,
+                        isIgnored: child.isIgnored
+                    ))
+                    // Expanding every node — labelled ones included — is the
+                    // default because a labelled node still has labelled
+                    // descendants: stopping at them is around a third fewer
+                    // round trips but loses a fifth of the real elements.
+                    if !stopsAtLabelledNodes || child.role.isEmpty {
+                        next.append((child.element, discovered.count - 1))
+                    }
+                }
+            }
+
+            frontier = next
+            depth += 1
+        }
+
+        return discovered
+    }
+
+    private func expand(_ elements: [AXAuditElement]) async -> [[AXAuditNode]] {
+        await withTaskGroup(of: (Int, [AXAuditNode]).self) { group in
+            var results = [[AXAuditNode]](repeating: [], count: elements.count)
+            var next = 0
+
+            func addTask(_ index: Int) {
+                group.addTask {
+                    let children = try? await client.children(of: elements[index])
+                    return (index, children ?? [])
+                }
+            }
+
+            while next < min(concurrency, elements.count) {
+                addTask(next)
+                next += 1
+            }
+            while let (index, children) = await group.next() {
+                results[index] = children
+                if next < elements.count {
+                    addTask(next)
+                    next += 1
+                }
+            }
+            return results
+        }
+    }
+}

--- a/Sources/iOSDeviceBackend/Transport/DTXConnection.swift
+++ b/Sources/iOSDeviceBackend/Transport/DTXConnection.swift
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+import Darwin
+import FBControlCore
+import FBDeviceControl
+import Foundation
+import os
+
+/// A DTX control channel over one lockdown service connection.
+///
+/// Requests are pipelined: each carries its own message identifier and a
+/// reader task hands replies back to whoever is waiting on that identifier. A
+/// tree walk can therefore have many hierarchy reads in flight, which is most
+/// of the difference between a snappy `ui` and a sluggish one.
+///
+/// This is only safe because the transport talks to the raw socket. Reading and
+/// writing `FBAMDServiceConnection` itself from two threads fails the socket
+/// with `Protocol not supported`; a plain fd is full duplex.
+///
+/// The daemon also pushes unsolicited events (focus changes, app state) down
+/// the same channel; those carry identifiers nobody is waiting on and are
+/// dropped.
+public final class DTXConnection: DTXInvoking, Sendable {
+    private struct State {
+        var pending: [UInt32: CheckedContinuation<DTXFraming.Reply, Error>] = [:]
+        var nextIdentifier: UInt32 = 1
+        var isClosed = false
+        var reader: Task<Void, Never>?
+    }
+
+    private let socket: Int32
+    private let state = OSAllocatedUnfairLock(initialState: State())
+    /// Held across the blocking write so two senders cannot interleave frames.
+    private let writeGate = OSAllocatedUnfairLock(initialState: ())
+
+    /// Talks to the raw socket rather than `FBAMDServiceConnection`'s own
+    /// send/receive. Those push bytes through the connection's SSL context,
+    /// but this daemon wants the DTX stream in plaintext once lockdown has
+    /// finished starting the service — encrypted frames make the device hang
+    /// up on the first message.
+    public init(connection: FBAMDServiceConnection) throws {
+        guard let getSocket = connection.calls.ServiceConnectionGetSocket,
+              let reference = connection.connection else {
+            throw DTXError.connectionClosed
+        }
+        socket = getSocket(reference)
+        guard socket >= 0 else { throw DTXError.connectionClosed }
+    }
+
+    /// Announces host capabilities. The daemon answers with its channel list,
+    /// which this client does not need — everything it calls lives on the
+    /// control channel.
+    public func handshake() throws {
+        try write(try DTXFraming.encodeRequest(
+            selector: "_notifyOfPublishedCapabilities:",
+            arguments: [["com.apple.private.DTXBlockCompression": 2, "com.apple.private.DTXConnection": 1]],
+            identifier: claimIdentifier(),
+            expectsReply: false
+        ))
+        startReading()
+    }
+
+    public func invoke(
+        _ selector: String,
+        arguments: [AXAuditValue],
+        expectsReply: Bool
+    ) async throws -> AXAuditValue {
+        let identifier = claimIdentifier()
+        let request = try DTXFraming.encodeRequest(
+            selector: selector,
+            arguments: arguments.map(\.propertyList),
+            identifier: identifier,
+            expectsReply: expectsReply
+        )
+
+        guard expectsReply else {
+            try write(request)
+            return .null
+        }
+
+        let reply: DTXFraming.Reply = try await withCheckedThrowingContinuation { continuation in
+            let accepted = state.withLock { state -> Bool in
+                guard !state.isClosed else { return false }
+                state.pending[identifier] = continuation
+                return true
+            }
+            guard accepted else {
+                continuation.resume(throwing: DTXError.connectionClosed)
+                return
+            }
+            do {
+                try write(request)
+            } catch {
+                resume(identifier: identifier, with: .failure(error))
+            }
+        }
+        guard let returnValue = reply.returnValue else { return .null }
+        return AXAuditValue(propertyList: returnValue)
+    }
+
+    public func close(because error: Error? = nil) {
+        let (waiting, reader) = state.withLock { state -> ([CheckedContinuation<DTXFraming.Reply, Error>], Task<Void, Never>?) in
+            state.isClosed = true
+            let waiting = Array(state.pending.values)
+            state.pending.removeAll()
+            let reader = state.reader
+            state.reader = nil
+            return (waiting, reader)
+        }
+        reader?.cancel()
+        let reason = error ?? DTXError.connectionClosed
+        waiting.forEach { $0.resume(throwing: reason) }
+    }
+
+    // MARK: - Socket
+
+    private func claimIdentifier() -> UInt32 {
+        state.withLock { state in
+            state.nextIdentifier += 1
+            return state.nextIdentifier
+        }
+    }
+
+    private func write(_ data: Data) throws {
+        try writeGate.withLock { _ in
+            try data.withUnsafeBytes { raw in
+                var offset = 0
+                while offset < raw.count {
+                    let written = Darwin.write(socket, raw.baseAddress!.advanced(by: offset), raw.count - offset)
+                    guard written > 0 else { throw DTXError.connectionClosed }
+                    offset += written
+                }
+            }
+        }
+    }
+
+    private func read(exactly count: Int) throws -> Data {
+        guard count > 0 else { return Data() }
+        var buffer = [UInt8](repeating: 0, count: count)
+        var offset = 0
+        while offset < count {
+            let received = buffer.withUnsafeMutableBytes { raw in
+                Darwin.read(socket, raw.baseAddress!.advanced(by: offset), count - offset)
+            }
+            guard received > 0 else { throw DTXError.connectionClosed }
+            offset += received
+        }
+        return Data(buffer)
+    }
+
+    /// Detached because the loop parks in a blocking `read(2)` for the life of
+    /// the session; leaving it on a structured child would hold whichever task
+    /// spawned it hostage.
+    private func startReading() {
+        let reader = Task.detached(priority: .userInitiated) { [self] in
+            while !Task.isCancelled {
+                do {
+                    let (header, payload) = try readMessage()
+                    guard !payload.isEmpty else { continue }
+                    resume(identifier: header.identifier, with: .success(try DTXFraming.decodePayload(payload)))
+                } catch {
+                    close(because: error)
+                    return
+                }
+            }
+        }
+        state.withLock { $0.reader = reader }
+    }
+
+    private func readMessage() throws -> (DTXFraming.Header, Data) {
+        var payload = Data()
+        var header = DTXFraming.Header()
+        header.fragmentCount = .max
+
+        while header.fragmentID < header.fragmentCount - 1 {
+            guard let decoded = DTXFraming.Header(decoding: try read(exactly: DTXFraming.headerSize)) else {
+                throw DTXError.connectionClosed
+            }
+            header = decoded
+            // The lead fragment of a split message carries sizing only.
+            if header.fragmentCount > 1, header.fragmentID == 0 { continue }
+            payload.append(try read(exactly: Int(header.length)))
+        }
+        return (header, payload)
+    }
+
+    private func resume(identifier: UInt32, with result: Result<DTXFraming.Reply, Error>) {
+        let continuation = state.withLock { $0.pending.removeValue(forKey: identifier) }
+        continuation?.resume(with: result)
+    }
+}

--- a/Sources/iOSDeviceBackend/Transport/DTXFraming.swift
+++ b/Sources/iOSDeviceBackend/Transport/DTXFraming.swift
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: Apache-2.0
+import Foundation
+
+/// Wire format for Apple's DTX message protocol, as spoken by the developer
+/// services behind a lockdown connection.
+///
+/// Byte-level layout only — no I/O — so the framing can be tested without a
+/// device. Layout matches idb's `FBInstrumentsClient`, which in turn follows
+/// the ios_instruments_client reverse engineering.
+enum DTXFraming {
+    static let magic: UInt32 = 0x1F3D_5B79
+    static let headerSize = 32
+
+    struct Header: Equatable {
+        var magic: UInt32 = DTXFraming.magic
+        var headerLength: UInt32 = UInt32(DTXFraming.headerSize)
+        var fragmentID: UInt16 = 0
+        var fragmentCount: UInt16 = 1
+        var length: UInt32 = 0
+        var identifier: UInt32 = 0
+        var conversationIndex: UInt32 = 0
+        var channelCode: UInt32 = 0
+        var expectsReply: UInt32 = 0
+
+        var encoded: Data {
+            var data = Data(capacity: DTXFraming.headerSize)
+            data.appendLittleEndian(magic)
+            data.appendLittleEndian(headerLength)
+            data.appendLittleEndian(fragmentID)
+            data.appendLittleEndian(fragmentCount)
+            data.appendLittleEndian(length)
+            data.appendLittleEndian(identifier)
+            data.appendLittleEndian(conversationIndex)
+            data.appendLittleEndian(channelCode)
+            data.appendLittleEndian(expectsReply)
+            return data
+        }
+
+        init() {}
+
+        init?(decoding data: Data) {
+            guard data.count >= DTXFraming.headerSize else { return nil }
+            var cursor = DataCursor(data)
+            magic = cursor.readUInt32()
+            headerLength = cursor.readUInt32()
+            fragmentID = cursor.readUInt16()
+            fragmentCount = cursor.readUInt16()
+            length = cursor.readUInt32()
+            identifier = cursor.readUInt32()
+            conversationIndex = cursor.readUInt32()
+            channelCode = cursor.readUInt32()
+            expectsReply = cursor.readUInt32()
+            guard magic == DTXFraming.magic else { return nil }
+        }
+    }
+
+    /// `flags` carries the compression nibble; anything non-zero means the
+    /// payload is compressed, which this client never negotiates.
+    private struct PayloadHeader {
+        var flags: UInt32
+        var auxiliaryLength: UInt32
+        var totalLength: UInt64
+
+        var encoded: Data {
+            var data = Data(capacity: 16)
+            data.appendLittleEndian(flags)
+            data.appendLittleEndian(auxiliaryLength)
+            data.appendLittleEndian(totalLength)
+            return data
+        }
+    }
+
+    private static let argumentMagic: UInt64 = 0x1F0
+    private static let emptyDictionaryKey: UInt32 = 10
+    private static let objectArgumentType: UInt32 = 2
+
+    static func encodeRequest(
+        selector: String,
+        arguments: [Any],
+        identifier: UInt32,
+        channelCode: UInt32 = 0,
+        expectsReply: Bool
+    ) throws -> Data {
+        let auxiliary = try encodeAuxiliary(arguments)
+        let selectorData = try NSKeyedArchiver.archivedData(withRootObject: selector, requiringSecureCoding: false)
+
+        let payloadHeader = PayloadHeader(
+            flags: 0x2 | (expectsReply ? 0x1000 : 0),
+            auxiliaryLength: UInt32(auxiliary.count),
+            totalLength: UInt64(auxiliary.count + selectorData.count)
+        )
+        var header = Header()
+        header.length = UInt32(16 + payloadHeader.totalLength)
+        header.identifier = identifier
+        header.channelCode = channelCode
+        header.expectsReply = expectsReply ? 1 : 0
+
+        return header.encoded + payloadHeader.encoded + auxiliary + selectorData
+    }
+
+    private static func encodeAuxiliary(_ arguments: [Any]) throws -> Data {
+        guard !arguments.isEmpty else { return Data() }
+        var body = Data()
+        for argument in arguments {
+            let archived = try NSKeyedArchiver.archivedData(withRootObject: argument, requiringSecureCoding: false)
+            body.appendLittleEndian(emptyDictionaryKey)
+            body.appendLittleEndian(objectArgumentType)
+            body.appendLittleEndian(UInt32(archived.count))
+            body.append(archived)
+        }
+        var data = Data()
+        data.appendLittleEndian(argumentMagic)
+        data.appendLittleEndian(UInt64(body.count))
+        data.append(body)
+        return data
+    }
+
+    struct Reply {
+        var returnValue: Any?
+        var auxiliaryValues: [Any]
+    }
+
+    static func decodePayload(_ payload: Data) throws -> Reply {
+        var cursor = DataCursor(payload)
+        let flags = cursor.readUInt32()
+        let auxiliaryLength = Int(cursor.readUInt32())
+        let totalLength = Int(cursor.readUInt64())
+        guard (flags & 0xFF000) >> 12 == 0 else { throw DTXError.compressedPayload }
+
+        let auxiliary = cursor.read(auxiliaryLength)
+        let returnValueData = cursor.read(max(0, totalLength - auxiliaryLength))
+
+        return Reply(
+            returnValue: returnValueData.isEmpty ? nil : try unarchive(returnValueData),
+            auxiliaryValues: auxiliary.isEmpty ? [] : try decodeAuxiliary(auxiliary)
+        )
+    }
+
+    private static func decodeAuxiliary(_ data: Data) throws -> [Any] {
+        guard data.count >= 16 else { return [] }
+        var cursor = DataCursor(data)
+        _ = cursor.readUInt64()
+        _ = cursor.readUInt64()
+
+        var values: [Any] = []
+        while cursor.remaining > 12 {
+            _ = cursor.readUInt32()
+            let type = cursor.readUInt32()
+            guard type == objectArgumentType else { throw DTXError.unsupportedArgumentType(type) }
+            let length = Int(cursor.readUInt32())
+            values.append(try unarchive(cursor.read(length)))
+        }
+        return values
+    }
+
+    /// The daemon's replies are plain plist containers — the `AXAudit*` names
+    /// are tags inside dictionaries, not archived ObjC classes — so allowing
+    /// the container and leaf classes is sufficient.
+    private static func unarchive(_ data: Data) throws -> Any {
+        let classes: [AnyClass] = [
+            NSDictionary.self, NSArray.self, NSString.self, NSNumber.self,
+            NSData.self, NSDate.self, NSError.self, NSNull.self,
+        ]
+        guard let value = try NSKeyedUnarchiver.unarchivedObject(ofClasses: classes, from: data) else {
+            throw DTXError.undecodableValue
+        }
+        if let error = value as? NSError { throw error }
+        return value
+    }
+}
+
+enum DTXError: Error, LocalizedError, CustomStringConvertible {
+    case compressedPayload
+    case unsupportedArgumentType(UInt32)
+    case undecodableValue
+    case connectionClosed
+
+    var errorDescription: String? { description }
+
+    var description: String {
+        switch self {
+        case .compressedPayload: return "the device negotiated a compressed DTX payload"
+        case let .unsupportedArgumentType(type): return "unsupported DTX argument type \(type)"
+        case .undecodableValue: return "could not decode a DTX value"
+        case .connectionClosed: return "the DTX connection closed"
+        }
+    }
+}
+
+private struct DataCursor {
+    private let data: Data
+    private var offset: Int
+
+    init(_ data: Data) {
+        self.data = data
+        offset = data.startIndex
+    }
+
+    var remaining: Int { data.endIndex - offset }
+
+    mutating func read(_ count: Int) -> Data {
+        let end = min(offset + count, data.endIndex)
+        defer { offset = end }
+        return data[offset..<end]
+    }
+
+    mutating func readUInt16() -> UInt16 { readInteger() }
+    mutating func readUInt32() -> UInt32 { readInteger() }
+    mutating func readUInt64() -> UInt64 { readInteger() }
+
+    private mutating func readInteger<T: FixedWidthInteger>() -> T {
+        let width = MemoryLayout<T>.size
+        let slice = read(width)
+        guard slice.count == width else { return 0 }
+        return slice.reduce(T(0)) { accumulated, byte in
+            (accumulated >> 8) | (T(byte) << ((width - 1) * 8))
+        }
+    }
+}
+
+private extension Data {
+    mutating func appendLittleEndian<T: FixedWidthInteger>(_ value: T) {
+        var little = value.littleEndian
+        Swift.withUnsafeBytes(of: &little) { append(contentsOf: $0) }
+    }
+}

--- a/Sources/iOSDeviceBackend/Transport/DeviceSession.swift
+++ b/Sources/iOSDeviceBackend/Transport/DeviceSession.swift
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+import FBControlCore
+import FBDeviceControl
+import Foundation
+
+public enum DeviceSessionError: Error, LocalizedError, CustomStringConvertible {
+    case deviceNotFound(udid: String, available: [String])
+    case serviceUnavailable(underlying: Error)
+
+    public var errorDescription: String? { description }
+
+    public var description: String {
+        switch self {
+        case let .deviceNotFound(udid, available):
+            let known = available.isEmpty ? "none connected" : available.joined(separator: ", ")
+            return "no physical iOS device with UDID \(udid) (connected: \(known))"
+        case let .serviceUnavailable(underlying):
+            return "could not open the accessibility service on the device: \(underlying.localizedDescription)"
+        }
+    }
+}
+
+/// Opens the accessibility audit daemon on a physical device and scopes it to
+/// one piece of work.
+///
+/// Nothing is installed on the device and nothing is signed: the service is
+/// reached over plain usbmux lockdown. The device does need to be unlocked —
+/// a locked screen answers connections but reports no elements.
+public enum DeviceSession {
+    /// The `.DVTSecureSocketProxy` variant terminates TLS on the lockdown side,
+    /// so the DTX stream underneath is plaintext. Without it the daemon expects
+    /// a stripped-SSL channel and the first frame decodes as garbage.
+    /// There is no `.DVTSecureSocketProxy` variant of this service — lockdown
+    /// rejects it with "the service is invalid" — so TLS is stripped on our
+    /// side instead, in `DTXConnection`.
+    static let serviceName = "com.apple.accessibility.axAuditDaemon.remoteserver"
+
+    public struct DeviceSummary: Sendable {
+        public let udid: String
+        public let name: String
+        public let osVersion: String
+        public let state: String
+    }
+
+    public static func connectedDevices(logger: FBControlCoreLogger? = nil) async throws -> [DeviceSummary] {
+        let set = try await MainActor.run { try deviceSet(logger: logger) }
+        return await settled(set).map {
+            DeviceSummary(
+                udid: $0.identity,
+                name: $0.name,
+                osVersion: $0.osVersion.name.rawValue,
+                state: FBiOSTargetStateStringFromState($0.state).rawValue
+            )
+        }
+    }
+
+    public static func withClient<Result>(
+        udid: String?,
+        connections poolSize: Int = 1,
+        logger: FBControlCoreLogger? = nil,
+        body: (AXAuditClient) async throws -> Result
+    ) async throws -> Result {
+        let set = try await MainActor.run { try deviceSet(logger: logger) }
+        let device = try resolve(udid, among: await settled(set))
+
+        do {
+            return try await withConnections(to: device, count: max(1, poolSize)) { dtx in
+                let client = AXAuditClient(transport: PooledTransport(connections: dtx))
+                try await client.prepare()
+                // Not `defer`: the teardown has to complete while the
+                // connections are still open, and a detached task would race
+                // them shut.
+                do {
+                    let result = try await body(client)
+                    await client.finish()
+                    return result
+                } catch {
+                    await client.finish()
+                    throw error
+                }
+            }
+        } catch let error as DeviceSessionError {
+            throw error
+        } catch {
+            throw DeviceSessionError.serviceUnavailable(underlying: error)
+        }
+    }
+
+    /// Opens `count` service connections and tears them all down afterwards.
+    /// Nesting the contexts keeps each one scoped without hand-rolled cleanup.
+    private static func withConnections<Result>(
+        to device: FBDevice,
+        count: Int,
+        body: ([DTXConnection]) async throws -> Result
+    ) async throws -> Result {
+        var opened: [DTXConnection] = []
+
+        func open(_ remaining: Int) async throws -> Result {
+            guard remaining > 0 else { return try await body(opened) }
+            return try await withFBFutureContext(device.startService(serviceName)) { connection in
+                let dtx = try DTXConnection(connection: connection)
+                defer { dtx.close() }
+                try dtx.handshake()
+                opened.append(dtx)
+                return try await open(remaining - 1)
+            }
+        }
+        return try await open(count)
+    }
+
+    /// AMDevice attachment is delivered through CFRunLoop sources on the thread
+    /// that subscribed, and `FBDeviceSet` subscribes on the main queue. A CLI
+    /// that never spins the main run loop therefore only ever sees the
+    /// restorable-device half of a connected phone, and `startService:` then
+    /// fails with "not AMDevice backed". Pumping the loop here is what lets the
+    /// attachment land.
+    @MainActor
+    private static func attachedDevices(_ set: FBDeviceSet, timeout: TimeInterval = 5) -> [FBDevice] {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            let attached = set.allDevices.filter { $0.amDevice != nil }
+            if !attached.isEmpty { return attached }
+            CFRunLoopRunInMode(.defaultMode, 0.05, true)
+        }
+        return set.allDevices
+    }
+
+    /// AMDevice does not publish the lockdown UDID until a session is opened,
+    /// so a connected device is identified by its ECID until then. Accept
+    /// either, and default to the only device when there is just one.
+    private static func resolve(_ identifier: String?, among devices: [FBDevice]) throws -> FBDevice {
+        guard let identifier else {
+            guard devices.count == 1, let only = devices.first else {
+                throw DeviceSessionError.deviceNotFound(
+                    udid: "<unspecified>",
+                    available: devices.map { $0.identity }
+                )
+            }
+            return only
+        }
+        guard let device = devices.first(where: { $0.udid == identifier || $0.uniqueIdentifier == identifier }) else {
+            throw DeviceSessionError.deviceNotFound(udid: identifier, available: devices.map { $0.identity })
+        }
+        return device
+    }
+
+    /// `FBDeviceSet` discovers devices through AMDevice notifications delivered
+    /// on the main queue, so a set read immediately after construction is
+    /// always empty. Yield until the first device lands.
+    private static func settled(_ set: FBDeviceSet) async -> [FBDevice] {
+        await MainActor.run { attachedDevices(set) }
+    }
+
+    @MainActor
+    private static func deviceSet(logger: FBControlCoreLogger?) throws -> FBDeviceSet {
+        try FBDeviceSet(
+            logger: logger ?? FBControlCoreGlobalConfiguration.defaultLogger,
+            delegate: nil,
+            ecidFilter: nil
+        )
+    }
+}
+
+extension FBDevice {
+    var identity: String { udid != "unknown" ? udid : uniqueIdentifier }
+}

--- a/Sources/iOSDeviceBackend/Transport/PooledTransport.swift
+++ b/Sources/iOSDeviceBackend/Transport/PooledTransport.swift
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+import Foundation
+import os
+
+/// Spreads requests over several DTX connections.
+///
+/// One connection saturates at roughly eight in-flight requests — the daemon
+/// serialises them on its side, so raising the in-flight count alone buys
+/// nothing. Whether separate connections are served in parallel is a property
+/// of the daemon, and this type is how that gets exercised.
+public struct PooledTransport: DTXInvoking {
+    private let connections: [DTXConnection]
+    private let cursor = OSAllocatedUnfairLock(initialState: 0)
+
+    public init(connections: [DTXConnection]) {
+        precondition(!connections.isEmpty)
+        self.connections = connections
+    }
+
+    public func invoke(
+        _ selector: String,
+        arguments: [AXAuditValue],
+        expectsReply: Bool
+    ) async throws -> AXAuditValue {
+        try await next().invoke(selector, arguments: arguments, expectsReply: expectsReply)
+    }
+
+    private func next() -> DTXConnection {
+        let index = cursor.withLock { cursor -> Int in
+            cursor = (cursor + 1) % connections.count
+            return cursor
+        }
+        return connections[index]
+    }
+}

--- a/Sources/iOSDeviceBackend/Verbs/IOSDeviceCommand.swift
+++ b/Sources/iOSDeviceBackend/Verbs/IOSDeviceCommand.swift
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+import ArgumentParser
+import Foundation
+
+public struct IOSDeviceCommand: AsyncParsableCommand {
+    public static let configuration = CommandConfiguration(
+        commandName: "ios-device",
+        abstract: "Physical iOS device subcommands (experimental).",
+        discussion: """
+        Drives a connected iPhone or iPad through the accessibility audit
+        daemon. Nothing is installed on the device and nothing is signed, but
+        the device must be unlocked — a locked screen accepts the connection
+        and then reports no elements.
+
+        Element geometry is not available on this channel, so there is no
+        coordinate tap, swipe or gesture here; interaction goes through
+        accessibility actions instead.
+        """,
+        subcommands: [Devices.self, UI.self, Tap.self]
+    )
+
+    public init() {}
+
+    struct DeviceOptions: ParsableArguments {
+        @Option(
+            name: [.customLong("device"), .customLong("udid")],
+            help: "UDID or ECID of the device. Optional when exactly one is connected."
+        )
+        var udid: String?
+    }
+
+    struct Devices: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "devices",
+            abstract: "List connected physical iOS devices."
+        )
+
+        func run() async throws {
+            let devices = try await DeviceSession.connectedDevices()
+            if devices.isEmpty {
+                print("No physical iOS devices connected.")
+                return
+            }
+            devices.forEach { print("\($0.udid)  \($0.name)  \($0.osVersion)  \($0.state)") }
+        }
+    }
+
+    struct UI: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "ui",
+            abstract: "Print an outline of the foreground app's accessibility tree."
+        )
+
+        @OptionGroup var device: DeviceOptions
+
+        @Option(help: "Number of hierarchy reads to keep in flight.")
+        var concurrency: Int = DeviceTreeFetcher.defaultConcurrency
+
+        @Option(help: "Number of DTX connections to spread reads over.")
+        var connections: Int = 1
+
+        @Flag(help: "Stop descending at labelled elements. Faster, but misses nested text.")
+        var fast = false
+
+        func run() async throws {
+            let started = Date()
+            let (outline, total) = try await DeviceSession.withClient(udid: device.udid, connections: connections) { client in
+                let elements = try await DeviceTreeFetcher(client: client, concurrency: concurrency, stopsAtLabelledNodes: fast).fetchTree()
+                return (DeviceOutline(elements: elements), elements.count)
+            }
+            print(outline.rendered())
+            let elapsed = Int(Date().timeIntervalSince(started) * 1000)
+            print("\n\(outline.rows.count) elements (\(total) nodes) in \(elapsed) ms")
+        }
+    }
+
+    struct Tap: AsyncParsableCommand {
+        static let configuration = CommandConfiguration(
+            commandName: "tap",
+            abstract: "Activate the first element whose label contains the given text.",
+            discussion: """
+            The element is resolved and activated inside a single connection:
+            element handles encode a live pointer, so they cannot be carried
+            across processes the way a simulator alias can.
+            """
+        )
+
+        @OptionGroup var device: DeviceOptions
+
+        @Option(name: .customLong("text"), help: "Substring to match against element labels.")
+        var text: String
+
+        func run() async throws {
+            let matched = try await DeviceSession.withClient(udid: device.udid) { client -> String? in
+                let elements = try await DeviceTreeFetcher(client: client).fetchTree()
+                guard let target = elements.first(where: {
+                    $0.isAccessibilityElement && $0.summary.localizedCaseInsensitiveContains(text)
+                }) else { return nil }
+                try await client.perform(.activate, on: target.element)
+                return target.summary
+            }
+            guard let matched else {
+                throw ValidationError("no accessibility element matching '\(text)' on screen")
+            }
+            print("✓ Activated \(matched)")
+        }
+    }
+}

--- a/Tests/AXAuditPayloadTests.swift
+++ b/Tests/AXAuditPayloadTests.swift
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+import Foundation
+import Testing
+@testable import iOSDeviceBackend
+
+/// The daemon accepts a malformed element without complaining — it performs
+/// nothing and, since actions are fire-and-forget, the caller sees success.
+/// These tests pin the envelope shape so that failure mode cannot come back.
+@Suite("AXAudit payload envelope")
+struct AXAuditPayloadTests {
+    private let token = Data([0x1A, 0x36, 0x00, 0x00, 0x00, 0x76, 0xAA, 0x16])
+
+    @Test("element carries its token inside PlatformElementValue_v1")
+    func elementTokenNesting() throws {
+        let encoded = AXAuditElement(token: token).encoded.propertyList as? [String: Any]
+        let outer = try #require(encoded)
+        #expect(outer["ObjectType"] as? String == "AXAuditElement_v1")
+
+        let passthrough = try #require(outer["Value"] as? [String: Any])
+        #expect(passthrough["ObjectType"] as? String == "passthrough")
+
+        let fields = try #require(passthrough["Value"] as? [String: Any])
+        // The regression: the token must not appear as a sibling of
+        // PlatformElementValue_v1, and PlatformElementValue_v1 must not be an
+        // envelope with no Value of its own.
+        #expect(fields["Value"] == nil)
+
+        let platform = try #require(fields["PlatformElementValue_v1"] as? [String: Any])
+        #expect(platform["ObjectType"] as? String == "passthrough")
+        #expect(platform["Value"] as? Data == token)
+    }
+
+    @Test("an element survives a round trip through the wire representation")
+    func elementRoundTrip() throws {
+        let original = AXAuditElement(token: token)
+        let decoded = AXAuditValue(propertyList: original.encoded.propertyList)
+        #expect(AXAuditElement(payload: decoded) == original)
+    }
+
+    @Test("activate is the action the device advertises")
+    func activateDescriptor() throws {
+        let fields = try #require(
+            (AXAuditAttribute.activate.encoded.propertyList as? [String: Any])?["Value"] as? [String: Any]
+        )
+        let inner = try #require(fields["Value"] as? [String: Any])
+        #expect((inner["AttributeNameValue_v1"] as? [String: Any])?["Value"] as? String == "AXAction-2010")
+        #expect((inner["PerformsActionValue_v1"] as? [String: Any])?["Value"] as? Int == 1)
+        #expect((inner["ValueTypeValue_v1"] as? [String: Any])?["Value"] as? Int == 1)
+    }
+
+    @Test("scroll actions use the codes read back from the daemon")
+    func scrollDescriptors() {
+        #expect(AXAuditAttribute.scrollDown.name == "AXAction-2006")
+        #expect(AXAuditAttribute.scrollUp.name == "AXAction-2007")
+        #expect(AXAuditAttribute.scrollDown.isScrollAction)
+        #expect(!AXAuditAttribute.activate.isScrollAction)
+    }
+
+    @Test("hierarchy nodes decode into elements with role and label")
+    func hierarchyDecoding() throws {
+        let node = AXAuditValue.object(tag: "AXAuditNode_v1", fields: [
+            "AuditElementValue_v1": AXAuditElement(token: token).encoded,
+            "HumanReadableDescriptionValue_v1": .scalar("Chats Button, Selected"),
+            "HumanReadableRoleDescriptionValue_v1": .scalar("Button"),
+            "IsIgnoredValue_v1": .scalar(false),
+        ])
+        let reply = AXAuditValue.passthrough(.fields(["ChildrenValue_v1": .list([node])]))
+
+        let found = reply.descendants(taggedWith: "AXAuditNode_v1")
+        #expect(found.count == 1)
+        #expect(found[0]["HumanReadableRoleDescriptionValue_v1"]?.stringValue == "Button")
+        #expect(AXAuditElement(payload: try #require(found[0]["AuditElementValue_v1"]))?.token == token)
+    }
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -491,7 +491,7 @@ function build_sim_use_executable() {
 function verify_xcframework_inputs() {
   local output_base_dir="$1"
   local xcframeworks_dir="${output_base_dir}/XCFrameworks"
-  local expected_frameworks=("FBControlCore" "XCTestBootstrap" "FBSimulatorControl" "CompanionUtilities")
+  local expected_frameworks=("FBControlCore" "XCTestBootstrap" "FBSimulatorControl" "FBDeviceControl" "CompanionUtilities")
 
   print_subsection "🧪" "Validating XCFramework inputs"
 
@@ -523,7 +523,7 @@ function verify_release_architectures() {
   local output_base_dir="$1"
   local frameworks_dir="${output_base_dir}/Frameworks"
   local executable_path="${output_base_dir}/sim-use"
-  local expected_frameworks=("FBControlCore" "XCTestBootstrap" "FBSimulatorControl" "CompanionUtilities")
+  local expected_frameworks=("FBControlCore" "XCTestBootstrap" "FBSimulatorControl" "FBDeviceControl" "CompanionUtilities")
 
   print_subsection "🧪" "Validating release artifact architectures"
   verify_macho_has_arch "${executable_path}" "arm64"
@@ -613,7 +613,8 @@ Commands:
     Clean previous build products and derived data.
 
   frameworks
-    Build all IDB frameworks (CompanionUtilities, FBControlCore, XCTestBootstrap, FBSimulatorControl).
+    Build all IDB frameworks (CompanionUtilities, FBControlCore, XCTestBootstrap,
+    FBSimulatorControl, FBDeviceControl).
 
   install
     Install built frameworks and the idb PrivateHeaders modules to build_products/.
@@ -677,6 +678,7 @@ function cmd_frameworks() {
   framework_build "FBControlCore" "${FBSIMCONTROL_PROJECT}" "${BUILD_OUTPUT_DIR}"
   framework_build "XCTestBootstrap" "${FBSIMCONTROL_PROJECT}" "${BUILD_OUTPUT_DIR}"
   framework_build "FBSimulatorControl" "${FBSIMCONTROL_PROJECT}" "${BUILD_OUTPUT_DIR}"
+  framework_build "FBDeviceControl" "${FBSIMCONTROL_PROJECT}" "${BUILD_OUTPUT_DIR}"
 }
 
 function cmd_install() {
@@ -685,6 +687,7 @@ function cmd_install() {
   install_framework "FBControlCore" "${BUILD_OUTPUT_DIR}"
   install_framework "XCTestBootstrap" "${BUILD_OUTPUT_DIR}"
   install_framework "FBSimulatorControl" "${BUILD_OUTPUT_DIR}"
+  install_framework "FBDeviceControl" "${BUILD_OUTPUT_DIR}"
   install_private_headers "${BUILD_OUTPUT_DIR}"
 }
 
@@ -694,6 +697,7 @@ function cmd_xcframeworks() {
   create_xcframework "FBControlCore" "${BUILD_OUTPUT_DIR}"
   create_xcframework "XCTestBootstrap" "${BUILD_OUTPUT_DIR}"
   create_xcframework "FBSimulatorControl" "${BUILD_OUTPUT_DIR}"
+  create_xcframework "FBDeviceControl" "${BUILD_OUTPUT_DIR}"
 }
 
 function cmd_executable() {

--- a/skills/sim-use/SKILL.md
+++ b/skills/sim-use/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sim-use
-description: Drive iOS Simulator and Android emulator/device screens for AI agents. Use when asked to automate a simulator or emulator, tap/swipe/type on a device, describe UI, take a screenshot, or interact with a mobile app.
+description: Drive iOS Simulator, Android emulator/device, and physical iPhone/iPad screens for AI agents. Use when asked to automate a simulator or emulator, drive a real iOS device, tap/swipe/type on a device, describe UI, take a screenshot, or interact with a mobile app.
 ---
 
 ## 0. Preflight
@@ -83,6 +83,26 @@ Every byte of command output you read costs context. Defaults that keep the loop
 | Pinch zoom in | `sim-use gesture pinch-out --device <UDID>` (two-finger spread) |
 | Rotate | `sim-use gesture rotate-cw --angle 90 --device <UDID>` |
 | Record evidence GIF | `sim-use record-video --output demo.gif --device <UDID>` — stop with SIGINT/SIGTERM (never SIGKILL); transcodes after stop; auto-plays inline in PRs |
+
+### Physical iOS devices (experimental)
+
+A connected iPhone or iPad uses a **separate command surface**, `sim-use ios-device`. The top-level verbs do not route to it.
+
+```bash
+sim-use ios-device devices          # UDID or ECID; --device optional when one is attached
+sim-use ios-device ui               # outline of the foreground app
+sim-use ios-device ui --fast        # ~40% quicker, ~25% fewer elements
+sim-use ios-device tap --text "Friends"
+```
+
+The loop is observe → act → verify as usual, but four things differ and they change how you drive it:
+
+1. **The device must be unlocked.** Locked looks like success: the connection is accepted and then every element query comes back empty.
+2. **Tap by text, not by alias.** Element handles die with the connection, so `@N` from a previous `ui` is meaningless. `tap --text` re-resolves the target inside one session.
+3. **No coordinates.** There is no frame data, so no coordinate tap, `swipe`, `gesture` or `multi-touch`. Reach things by activating them; scrolling and app-defined swipe actions are accessibility actions here.
+4. **Budget seconds, not milliseconds.** A full tree is a few seconds — the device serialises the requests. Don't poll it in a tight loop.
+
+Everything else (`screenshot`, `record-video`, the simulator verbs) is unavailable on this surface for now.
 
 ## 2. Pitfalls
 


### PR DESCRIPTION
## Motivation

sim-use drives simulators and Android devices, but not a physical iPhone or iPad. Every existing tool for real iOS devices — Appium, Maestro, agent-device, devicekit-ios — goes through an XCUITest runner, which means building a runner app, code signing it with the user's team and mounting a Developer Disk Image. Adopting that would have cost sim-use its "install it and go" property on exactly the platform where setup friction hurts most.

## Change

Adds `sim-use ios-device` (`devices` / `ui` / `tap`) as a third backend. A connected device is reached through `com.apple.accessibility.axAuditDaemon.remoteserver` over usbmux lockdown: **nothing is installed on the device, nothing is code signed, and no Developer Disk Image is mounted.** The device only has to be unlocked.

```
$ sim-use ios-device ui
@4   Button  "Chats Button, Selected"
@5   Button  "Friends"
...
117 elements (316 nodes) in 6647 ms

$ sim-use ios-device tap --text "Friends"
✓ Activated Friends Button
```

Layering mirrors the existing backends: `Transport/` (DTX framing and the lockdown service connection), `AXAudit/` (selector layer — FB*-free and unit-testable behind a `DTXInvoking` protocol), `Domain/` (tree walk, outline), `Verbs/`.

## What this surface deliberately lacks

iOS serves no element geometry on this channel; Xcode's own Accessibility Inspector shows no Frame row for a physical device either. So there is no coordinate tap, `swipe`, `gesture` or `multi-touch` — interaction goes through accessibility actions, and the outline follows the accessibility reading order rather than screen position. Element handles encode a live pointer and die with the connection, so `tap` resolves by `--text` within one session instead of reusing an `@N` alias from a previous `ui`.

## Notes for review

Three behaviours that are invisible in the diff and cost the most to find, all measured against iOS 27:

- **Plaintext DTX.** `FBAMDServiceConnection`'s send/receive push bytes through the connection's SSL context, but the daemon wants the stream in plaintext once lockdown has started the service — encrypted frames make the device hang up on the first message. The transport therefore uses the raw socket. There is no `.DVTSecureSocketProxy` variant of this service.
- **Main run loop.** `FBDeviceSet` receives AMDevice attachment through CFRunLoop sources on the main queue, so discovery pumps that loop. Without it a CLI only ever sees the restorable half of the device and `startService:` fails with "not AMDevice backed".
- **Session teardown.** A session has to release the daemon's inspector state on the way out. Skipping it leaves the device answering every element query with nothing, which reads exactly like a locked screen.

Requests are pipelined over one connection (~1.4x). Past that the daemon serialises — raising the in-flight count or spreading load over several connections buys nothing — so `--fast` is the remaining lever, trading about a quarter of the elements for 40% off the wall clock.

## Verification

- `make test` — 993 tests pass, including 5 new ones pinning the wire envelope shape. That shape is the whole reason `AXAuditValue` is a type rather than hand-built dictionaries: the reference Python client mis-nests the element token, and the daemon answers a malformed element by doing nothing and reporting success.
- Verified on a physical iPhone (iOS 27): `ui` renders the foreground app, `tap --text` flips a segmented control, and the follow-up `ui` shows the new selection.
- `make e2e-ios` — 22 of 23 suites pass. Six suites failed on the first run and passed on a re-run after clearing a wedged daemon. `RemoteContentRecoveryTests` fails deterministically for a reason unrelated to this change: it matches the document picker with `--label-regex '选取文件|Choose File'`, and on a Japanese-locale simulator the picker renders as `ファイルを選択`. Fixed separately.
