### PR TITLE
fix: emit JPEG frames for default video streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Screenshot-backed `stream-video` formats now emit actual JPEG frames at the default quality and scale on both iOS and Android, instead of forwarding PNG screenshots unchanged; MJPEG frame payloads now match their `image/jpeg` MIME type.
+
 ## [0.13.0] - 2026-08-06
 
 ### Added

--- a/Sources/SimUseVideo/VideoCommandSupport.swift
+++ b/Sources/SimUseVideo/VideoCommandSupport.swift
@@ -2,6 +2,7 @@
 import Foundation
 import AVFoundation
 import ImageIO
+import UniformTypeIdentifiers
 import os
 import SimUseCore
 
@@ -72,10 +73,18 @@ public struct VideoFrameUtilities {
     public static func processJPEGData(_ data: Data, scale: Double, quality: Int) async throws -> Data {
         if scale < 1.0 {
             return try await scaleJPEGData(data, scale: scale, quality: quality)
-        } else if quality != 80 {
+        } else if quality != 80 || !isJPEG(data) {
             return try await reencodeJPEGData(data, quality: quality)
         }
         return data
+    }
+
+    private static func isJPEG(_ data: Data) -> Bool {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+              let typeIdentifier = CGImageSourceGetType(source) as String? else {
+            return false
+        }
+        return UTType(typeIdentifier)?.conforms(to: .jpeg) == true
     }
 
     public static func computeDimensions(for image: CGImage, scale: Double) -> (width: Int, height: Int) {

--- a/Tests/AndroidStreamVideoTests.swift
+++ b/Tests/AndroidStreamVideoTests.swift
@@ -20,9 +20,10 @@ struct AndroidStreamVideoTests {
         let result = try await streamForDuration(format: "mjpeg", duration: 4.0)
 
         #expect(isAcceptableStreamExitCode(result.exitCode), "Unexpected exit code: \(result.exitCode)")
-        let text = String(decoding: result.stdout.prefix(4096), as: UTF8.self)
-        #expect(text.contains("--mjpegstream"))
-        #expect(text.contains("Content-Type: image/jpeg"))
+        let frame = try firstMJPEGFrame(in: result.stdout)
+        #expect(frame.contentType == "image/jpeg")
+        #expect(frame.contentLength == frame.payload.count)
+        #expect(frame.payload.starts(with: [0xFF, 0xD8]))
         #expect(result.stderr.contains("Format: mjpeg"))
     }
 

--- a/Tests/MJPEGTestSupport.swift
+++ b/Tests/MJPEGTestSupport.swift
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+import Foundation
+import Testing
+
+struct MJPEGTestFrame {
+    let contentType: String
+    let contentLength: Int
+    let payload: Data
+}
+
+func firstMJPEGFrame(in stream: Data) throws -> MJPEGTestFrame {
+    let headerTerminator = Data("\r\n\r\n".utf8)
+    let outerHeader = try #require(
+        stream.range(of: headerTerminator),
+        "MJPEG stream is missing its outer HTTP header"
+    )
+    let boundary = Data("--mjpegstream\r\n".utf8)
+    let partBoundary = try #require(
+        stream.range(of: boundary, in: outerHeader.upperBound..<stream.endIndex),
+        "MJPEG stream is missing its first frame boundary"
+    )
+    let partHeaderStart = partBoundary.upperBound
+    let partHeader = try #require(
+        stream.range(of: headerTerminator, in: partHeaderStart..<stream.endIndex),
+        "MJPEG frame is missing its header terminator"
+    )
+    let headerText = String(decoding: stream[partHeaderStart..<partHeader.lowerBound], as: UTF8.self)
+
+    func headerValue(_ name: String) -> String? {
+        let prefix = "\(name):"
+        return headerText.components(separatedBy: "\r\n")
+            .first { $0.hasPrefix(prefix) }
+            .map { String($0.dropFirst(prefix.count)).trimmingCharacters(in: .whitespaces) }
+    }
+
+    let contentType = try #require(headerValue("Content-Type"), "MJPEG frame is missing Content-Type")
+    let lengthText = try #require(headerValue("Content-Length"), "MJPEG frame is missing Content-Length")
+    let contentLength = try #require(Int(lengthText), "MJPEG frame has an invalid Content-Length")
+    let payloadStart = partHeader.upperBound
+    let nextBoundaryPrefix = Data("\r\n--mjpegstream".utf8)
+    let nextBoundary = try #require(
+        stream.range(of: nextBoundaryPrefix, in: payloadStart..<stream.endIndex),
+        "MJPEG stream is missing the boundary after its first frame"
+    )
+
+    return MJPEGTestFrame(
+        contentType: contentType,
+        contentLength: contentLength,
+        payload: Data(stream[payloadStart..<nextBoundary.lowerBound])
+    )
+}

--- a/Tests/StreamVideoTests.swift
+++ b/Tests/StreamVideoTests.swift
@@ -12,6 +12,10 @@ struct StreamVideoTests {
         #expect(!result.output.isEmpty, "Should have stderr messages")
         #expect(result.output.contains("Starting screenshot-based video stream"))
         #expect(result.output.contains("Format: mjpeg"))
+        let frame = try firstMJPEGFrame(in: result.data)
+        #expect(frame.contentType == "image/jpeg")
+        #expect(frame.contentLength == frame.payload.count)
+        #expect(frame.payload.starts(with: [0xFF, 0xD8]))
     }
 
     @Test("Stream video outputs raw JPEG data for ffmpeg format")

--- a/Tests/VideoFrameProcessingTests.swift
+++ b/Tests/VideoFrameProcessingTests.swift
@@ -88,14 +88,22 @@ struct VideoFrameProcessingTests {
         #expect(tiny.height >= 2)
     }
 
-    @Test("processJPEGData passes data through untouched at default settings")
-    func processPassthrough() async throws {
-        // Pins the intentional fast path shared with iOS streaming: at
-        // scale 1.0 / quality 80 the frame is forwarded byte-for-byte
-        // (no decode/re-encode), whatever its container format.
+    @Test("processJPEGData encodes default PNG input as JPEG")
+    func processEncodesDefaultPNG() async throws {
         let png = try makePNG(width: 32, height: 32)
         let out = try await VideoFrameUtilities.processJPEGData(png, scale: 1.0, quality: 80)
-        #expect(out == png)
+        #expect(out.prefix(2) == Data([0xFF, 0xD8]))
+        let encoded = try #require(VideoFrameUtilities.makeCGImage(from: out))
+        #expect(encoded.width == 32)
+        #expect(encoded.height == 32)
+    }
+
+    @Test("processJPEGData passes default JPEG input through untouched")
+    func processPassesThroughDefaultJPEG() async throws {
+        let png = try makePNG(width: 32, height: 32)
+        let jpeg = try await VideoFrameUtilities.processJPEGData(png, scale: 1.0, quality: 90)
+        let out = try await VideoFrameUtilities.processJPEGData(jpeg, scale: 1.0, quality: 80)
+        #expect(out == jpeg)
     }
 
     @Test("non-default quality re-encodes to JPEG")


### PR DESCRIPTION
## Summary

- ensure screenshot-backed streams encode PNG captures as JPEG at the default `scale=1.0` / `quality=80` settings
- preserve byte-for-byte passthrough when the input is already JPEG
- add shared regression coverage plus iOS and Android MJPEG E2E assertions for MIME, Content-Length, and JPEG magic bytes
- document the fix under `Unreleased`

## Root cause

Both the iOS screenshot API and Android `screencap -p` produce PNG data. The shared frame processor treated the default scale and quality as an unconditional passthrough fast path, while both MJPEG writers labeled every frame as `image/jpeg`. This produced PNG payloads with a JPEG MIME type.

The fast path now checks the source container with ImageIO and only passes through actual JPEG input. PNG captures are re-encoded as JPEG. The shared `raw` and `ffmpeg` screenshot-backed formats now also consistently emit the JPEG frames their command descriptions promise.

## User impact

Strict MJPEG clients no longer receive PNG frames mislabeled as JPEG at default settings. Non-default quality and scale behavior is unchanged.

## Validation

- `swift test --filter VideoFrameProcessingTests`: 9 passed
- `make build`: passed
- Standards/spec review: passed
- `make test`: all 306 tests passed, then the Swift test process aborted during teardown with `freed pointer was not the last allocation`; the same post-test abort reproduces on unchanged `origin/main`
- Device E2E not run locally: no booted iOS simulator and no `adb` on PATH
