### PR TITLE
feat: bracket GIF exports with opt-in START/END marker cards

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,10 +139,13 @@ jobs:
       # depends on, including the sim-use executable the smoke step
       # runs. make picks xcsift up from PATH and condenses the output
       # to a TOON summary itself; SIM_USE_RAW_LOG additionally saves
-      # the raw swift output, kept as a failure-only artifact for
-      # forensics the condensed view can't serve (e.g. grepping daemon
-      # log lines).
+      # the raw swift output, kept as an artifact on failure or
+      # cancellation for forensics the condensed view can't serve
+      # (e.g. grepping daemon log lines, or finding the last test that
+      # started before a hang). The step timeout bounds a wedged test
+      # run well below the job timeout so the artifact still uploads.
       - name: Run unit tests
+        timeout-minutes: 20
         run: make test
         env:
           SIM_USE_RAW_LOG: ${{ runner.temp }}/test.log
@@ -165,8 +168,11 @@ jobs:
             } >> "${GITHUB_STEP_SUMMARY}"
           fi
 
+      # failure() is false when a step or job times out (that's a
+      # cancellation), and a hang is exactly when the partial raw log
+      # matters most — cover both.
       - name: Upload raw logs on failure
-        if: failure()
+        if: failure() || cancelled()
         uses: actions/upload-artifact@v7
         with:
           name: raw-swift-logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `record-video` GIFs are bracketed with START/END marker cards (~1 s each) so the forever-looping clip has a visible boundary. On by default for `--format gif` on all three surfaces; opt out with `--no-gif-markers`. A failed card render degrades to a marker-less GIF instead of failing the transcode.
+- `record-video --gif-markers` (all three surfaces): bracket a GIF with START/END marker cards (~1 s each) so the forever-looping clip has a visible boundary. Opt-in — the default output remains a faithful capture of the screen. A failed card render degrades to a marker-less GIF instead of failing the transcode.
 
 ## [0.13.0] - 2026-08-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `record-video` GIFs are bracketed with START/END marker cards (~1 s each) so the forever-looping clip has a visible boundary. On by default for `--format gif` on all three surfaces; opt out with `--no-gif-markers`. A failed card render degrades to a marker-less GIF instead of failing the transcode.
+
 ## [0.13.0] - 2026-08-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -338,7 +338,9 @@ to wall-clock. If the transcode fails, the intermediate MP4 is preserved
 and its path reported, so the footage is never lost. GIF is meant for
 short clips: the encoder holds every frame in memory until the file is
 written, so for sessions beyond a few hundred frames prefer a lower
-`--fps` or `--format mp4`.
+`--fps` or `--format mp4`. Because the GIF loops forever, the clip is
+bracketed with START/END marker cards (~1 s each) so the boundary is
+visible; disable with `--no-gif-markers`.
 
 ### Accessibility inspection
 

--- a/README.md
+++ b/README.md
@@ -338,9 +338,9 @@ to wall-clock. If the transcode fails, the intermediate MP4 is preserved
 and its path reported, so the footage is never lost. GIF is meant for
 short clips: the encoder holds every frame in memory until the file is
 written, so for sessions beyond a few hundred frames prefer a lower
-`--fps` or `--format mp4`. Because the GIF loops forever, the clip is
-bracketed with START/END marker cards (~1 s each) so the boundary is
-visible; disable with `--no-gif-markers`.
+`--fps` or `--format mp4`. Because the GIF loops forever, `--gif-markers`
+can bracket the clip with START/END marker cards (~1 s each) so the
+boundary is visible.
 
 ### Accessibility inspection
 

--- a/Sources/AndroidBackend/Verbs/AndroidRecordVideoCommand.swift
+++ b/Sources/AndroidBackend/Verbs/AndroidRecordVideoCommand.swift
@@ -113,7 +113,7 @@ public struct AndroidRecordVideoCommand: SimUseExecutableCommand {
         fps: Int?,
         quality: Int,
         scale: Double?,
-        gifMarkers: Bool = false
+        gifMarkers: Bool
     ) async throws -> URL {
         let adb = Adb()
         try assertAdbDeviceOnline(adb: adb, serial: serial)

--- a/Sources/AndroidBackend/Verbs/AndroidRecordVideoCommand.swift
+++ b/Sources/AndroidBackend/Verbs/AndroidRecordVideoCommand.swift
@@ -44,8 +44,8 @@ public struct AndroidRecordVideoCommand: SimUseExecutableCommand {
     @Option(help: "Output format: mp4, gif. Defaults to the --output extension when recognized, else mp4.")
     public var format: RecordingFormat?
 
-    @Flag(inversion: .prefixedNo, help: "Bracket a GIF with START/END marker frames (default: enabled; ignored for mp4).")
-    public var gifMarkers: Bool = true
+    @Flag(help: "Bracket a GIF with START/END marker frames (opt-in; ignored for mp4).")
+    public var gifMarkers: Bool = false
 
     @Option(help: "Output file path. Defaults to sim-use-video-<timestamp>.<format> in the current directory.")
     public var output: String?
@@ -113,7 +113,7 @@ public struct AndroidRecordVideoCommand: SimUseExecutableCommand {
         fps: Int?,
         quality: Int,
         scale: Double?,
-        gifMarkers: Bool = true
+        gifMarkers: Bool = false
     ) async throws -> URL {
         let adb = Adb()
         try assertAdbDeviceOnline(adb: adb, serial: serial)

--- a/Sources/AndroidBackend/Verbs/AndroidRecordVideoCommand.swift
+++ b/Sources/AndroidBackend/Verbs/AndroidRecordVideoCommand.swift
@@ -44,6 +44,9 @@ public struct AndroidRecordVideoCommand: SimUseExecutableCommand {
     @Option(help: "Output format: mp4, gif. Defaults to the --output extension when recognized, else mp4.")
     public var format: RecordingFormat?
 
+    @Flag(inversion: .prefixedNo, help: "Bracket a GIF with START/END marker frames (default: enabled; ignored for mp4).")
+    public var gifMarkers: Bool = true
+
     @Option(help: "Output file path. Defaults to sim-use-video-<timestamp>.<format> in the current directory.")
     public var output: String?
 
@@ -81,7 +84,8 @@ public struct AndroidRecordVideoCommand: SimUseExecutableCommand {
             format: format,
             fps: fps,
             quality: quality,
-            scale: scale
+            scale: scale,
+            gifMarkers: gifMarkers
         )
         return ExecutionResult(path: outputURL.path)
     }
@@ -108,14 +112,15 @@ public struct AndroidRecordVideoCommand: SimUseExecutableCommand {
         format: RecordingFormat?,
         fps: Int?,
         quality: Int,
-        scale: Double?
+        scale: Double?,
+        gifMarkers: Bool = true
     ) async throws -> URL {
         let adb = Adb()
         try assertAdbDeviceOnline(adb: adb, serial: serial)
 
         // GIF is transcoded from a finished MP4 (see GIFTranscoder); the
         // capture loop itself always writes H.264, to plan.recordTarget.
-        let plan = try RecordingOutputPlan(format: format, output: output, fps: fps, scale: scale)
+        let plan = try RecordingOutputPlan(format: format, output: output, fps: fps, scale: scale, gifMarkers: gifMarkers)
         let options = plan.options
         let recordTarget = plan.recordTarget
         // Native screenrecord capture is variable-frame-rate either way;

--- a/Sources/SimUse/Commands/RecordVideo.swift
+++ b/Sources/SimUse/Commands/RecordVideo.swift
@@ -36,8 +36,8 @@ struct RecordVideo: SimUseExecutableCommand {
     @Option(help: "Output format: mp4, gif. Defaults to the --output extension when recognized, else mp4.")
     var format: RecordingFormat?
 
-    @Flag(inversion: .prefixedNo, help: "Bracket a GIF with START/END marker frames (default: enabled; ignored for mp4).")
-    var gifMarkers: Bool = true
+    @Flag(help: "Bracket a GIF with START/END marker frames (opt-in; ignored for mp4).")
+    var gifMarkers: Bool = false
 
     @Option(help: "Output file path. Defaults to sim-use-video-<timestamp>.<format> in the current directory.")
     var output: String?

--- a/Sources/SimUse/Commands/RecordVideo.swift
+++ b/Sources/SimUse/Commands/RecordVideo.swift
@@ -36,6 +36,9 @@ struct RecordVideo: SimUseExecutableCommand {
     @Option(help: "Output format: mp4, gif. Defaults to the --output extension when recognized, else mp4.")
     var format: RecordingFormat?
 
+    @Flag(inversion: .prefixedNo, help: "Bracket a GIF with START/END marker frames (default: enabled; ignored for mp4).")
+    var gifMarkers: Bool = true
+
     @Option(help: "Output file path. Defaults to sim-use-video-<timestamp>.<format> in the current directory.")
     var output: String?
 
@@ -86,6 +89,7 @@ struct RecordVideo: SimUseExecutableCommand {
         sub.quality = quality
         sub.scale = scale
         sub.format = format
+        sub.gifMarkers = gifMarkers
         sub.output = output
         sub.device = device
         sub.json = json
@@ -99,7 +103,8 @@ struct RecordVideo: SimUseExecutableCommand {
             format: format,
             fps: fps,
             quality: quality,
-            scale: scale
+            scale: scale,
+            gifMarkers: gifMarkers
         )
         return ExecutionResult(path: outputURL.path)
     }

--- a/Sources/SimUseVideo/GIFTranscoder.swift
+++ b/Sources/SimUseVideo/GIFTranscoder.swift
@@ -136,7 +136,7 @@ public enum GIFTranscoder {
     /// has a visible boundary. Returns the number of frames actually
     /// written, marker cards included.
     @discardableResult
-    public static func transcode(mp4URL: URL, to gifURL: URL, fps: Int, markers: Bool = false) async throws -> Int {
+    public static func transcode(mp4URL: URL, to gifURL: URL, fps: Int, markers: Bool) async throws -> Int {
         let asset = AVURLAsset(url: mp4URL)
         guard let track = try await asset.loadTracks(withMediaType: .video).first else {
             throw GIFTranscoderError.noVideoTrack
@@ -203,7 +203,7 @@ public enum GIFTranscoder {
     /// captured footage) while removing the partially written GIF, which
     /// would otherwise read as a successful recording to any
     /// does-the-file-exist check.
-    public static func transcodeRecording(tempMP4: URL, to gifURL: URL, fps: Int, markers: Bool = false) async throws {
+    public static func transcodeRecording(tempMP4: URL, to gifURL: URL, fps: Int, markers: Bool) async throws {
         FileHandle.standardError.write(Data("Transcoding to GIF...\n".utf8))
         do {
             let frames = try await transcode(mp4URL: tempMP4, to: gifURL, fps: fps, markers: markers)

--- a/Sources/SimUseVideo/GIFTranscoder.swift
+++ b/Sources/SimUseVideo/GIFTranscoder.swift
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import Foundation
 import AVFoundation
+import CoreText
 import ImageIO
 import UniformTypeIdentifiers
 import VideoToolbox
@@ -124,11 +125,18 @@ public enum GIFTranscoder {
         return SamplingPlan(timestamps: kept, delays: delays)
     }
 
+    /// How long each START/END marker card holds on screen. Long enough
+    /// to register before the loop restarts, short enough not to pad a
+    /// typical few-second repro clip.
+    static let markerDelay: Double = 1.0
+
     /// Transcode `mp4URL` into an animated GIF at `gifURL`, sampling at
-    /// `fps` (capped at `maximumFPS`). Returns the number of frames
-    /// actually written.
+    /// `fps` (capped at `maximumFPS`). With `markers` (the default), the
+    /// clip is bracketed by START/END card frames so a forever-looping
+    /// GIF has a visible boundary. Returns the number of frames actually
+    /// written, marker cards included.
     @discardableResult
-    public static func transcode(mp4URL: URL, to gifURL: URL, fps: Int) async throws -> Int {
+    public static func transcode(mp4URL: URL, to gifURL: URL, fps: Int, markers: Bool = true) async throws -> Int {
         let asset = AVURLAsset(url: mp4URL)
         guard let track = try await asset.loadTracks(withMediaType: .video).first else {
             throw GIFTranscoderError.noVideoTrack
@@ -142,10 +150,24 @@ public enum GIFTranscoder {
             FileHandle.standardError.write(Data("warning: GIF has \(plan.timestamps.count) frames; the encoder holds all of them in memory until the file is written — for long sessions prefer a lower --fps or --format mp4\n".utf8))
         }
 
+        // Marker cards match the encoded frame size. A failed render
+        // falls back to a marker-less GIF rather than failing the
+        // transcode — the footage matters more than the chrome.
+        var cards: (start: CGImage, end: CGImage)?
+        if markers {
+            let size = try await track.load(.naturalSize)
+            if let start = Self.makeMarkerCard(width: Int(abs(size.width)), height: Int(abs(size.height)), label: "START"),
+               let end = Self.makeMarkerCard(width: Int(abs(size.width)), height: Int(abs(size.height)), label: "END") {
+                cards = (start, end)
+            } else {
+                FileHandle.standardError.write(Data("warning: could not render START/END marker frames; writing the GIF without them\n".utf8))
+            }
+        }
+
         guard let destination = CGImageDestinationCreateWithURL(
             gifURL as CFURL,
             UTType.gif.identifier as CFString,
-            plan.timestamps.count,
+            plan.timestamps.count + (cards == nil ? 0 : 2),
             nil
         ) else {
             throw GIFTranscoderError.cannotCreateDestination(gifURL.path)
@@ -158,15 +180,21 @@ public enum GIFTranscoder {
         ]
         CGImageDestinationSetProperties(destination, gifProperties as CFDictionary)
 
+        if let cards {
+            Self.append(cards.start, delay: Self.markerDelay, to: destination)
+        }
         let appended = try Self.appendSampledFrames(asset: asset, track: track, plan: plan, to: destination)
         guard appended > 0 else {
             throw GIFTranscoderError.noFrames
+        }
+        if let cards {
+            Self.append(cards.end, delay: Self.markerDelay, to: destination)
         }
 
         guard CGImageDestinationFinalize(destination) else {
             throw GIFTranscoderError.finalizeFailed
         }
-        return appended
+        return appended + (cards == nil ? 0 : 2)
     }
 
     /// Convenience wrapper for the record-video post-step: transcodes and
@@ -175,10 +203,10 @@ public enum GIFTranscoder {
     /// captured footage) while removing the partially written GIF, which
     /// would otherwise read as a successful recording to any
     /// does-the-file-exist check.
-    public static func transcodeRecording(tempMP4: URL, to gifURL: URL, fps: Int) async throws {
+    public static func transcodeRecording(tempMP4: URL, to gifURL: URL, fps: Int, markers: Bool = true) async throws {
         FileHandle.standardError.write(Data("Transcoding to GIF...\n".utf8))
         do {
-            let frames = try await transcode(mp4URL: tempMP4, to: gifURL, fps: fps)
+            let frames = try await transcode(mp4URL: tempMP4, to: gifURL, fps: fps, markers: markers)
             try? FileManager.default.removeItem(at: tempMP4)
             FileHandle.standardError.write(Data("GIF written (\(frames) frames)\n".utf8))
         } catch {
@@ -257,13 +285,7 @@ public enum GIFTranscoder {
             VTCreateCGImageFromCVPixelBuffer(pixelBuffer, options: nil, imageOut: &cgImage)
             guard let cgImage else { continue }
 
-            let frameProperties: [CFString: Any] = [
-                kCGImagePropertyGIFDictionary: [
-                    kCGImagePropertyGIFDelayTime: plan.delays[slot],
-                    kCGImagePropertyGIFUnclampedDelayTime: plan.delays[slot]
-                ]
-            ]
-            CGImageDestinationAddImage(destination, cgImage, frameProperties as CFDictionary)
+            Self.append(cgImage, delay: plan.delays[slot], to: destination)
             appended += 1
         }
         if reader.status == .failed {
@@ -271,5 +293,53 @@ public enum GIFTranscoder {
         }
         reader.cancelReading()
         return appended
+    }
+
+    private static func append(_ image: CGImage, delay: Double, to destination: CGImageDestination) {
+        let frameProperties: [CFString: Any] = [
+            kCGImagePropertyGIFDictionary: [
+                kCGImagePropertyGIFDelayTime: delay,
+                kCGImagePropertyGIFUnclampedDelayTime: delay
+            ]
+        ]
+        CGImageDestinationAddImage(destination, image, frameProperties as CFDictionary)
+    }
+
+    /// A solid card with a centered white label, matching the encoded
+    /// frame size, used to bracket the clip. Internal for tests.
+    static func makeMarkerCard(width: Int, height: Int, label: String) -> CGImage? {
+        guard width > 0, height > 0,
+              let context = CGContext(
+                  data: nil,
+                  width: width,
+                  height: height,
+                  bitsPerComponent: 8,
+                  bytesPerRow: 0,
+                  space: CGColorSpaceCreateDeviceRGB(),
+                  bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue
+              )
+        else { return nil }
+
+        context.setFillColor(CGColor(red: 0.08, green: 0.09, blue: 0.11, alpha: 1.0))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+
+        // Size the label to the card so it reads at any recording scale.
+        let fontSize = CGFloat(min(width, height)) / 5.0
+        let font = CTFontCreateWithName("HelveticaNeue-Bold" as CFString, fontSize, nil)
+        let attributes: [CFString: Any] = [
+            kCTFontAttributeName: font,
+            kCTForegroundColorAttributeName: CGColor(red: 1, green: 1, blue: 1, alpha: 1)
+        ]
+        guard let attributed = CFAttributedStringCreate(nil, label as CFString, attributes as CFDictionary) else {
+            return nil
+        }
+        let line = CTLineCreateWithAttributedString(attributed)
+        let bounds = CTLineGetBoundsWithOptions(line, .useOpticalBounds)
+        context.textPosition = CGPoint(
+            x: (CGFloat(width) - bounds.width) / 2 - bounds.minX,
+            y: (CGFloat(height) - bounds.height) / 2 - bounds.minY
+        )
+        CTLineDraw(line, context)
+        return context.makeImage()
     }
 }

--- a/Sources/SimUseVideo/GIFTranscoder.swift
+++ b/Sources/SimUseVideo/GIFTranscoder.swift
@@ -131,12 +131,12 @@ public enum GIFTranscoder {
     static let markerDelay: Double = 1.0
 
     /// Transcode `mp4URL` into an animated GIF at `gifURL`, sampling at
-    /// `fps` (capped at `maximumFPS`). With `markers` (the default), the
-    /// clip is bracketed by START/END card frames so a forever-looping
-    /// GIF has a visible boundary. Returns the number of frames actually
+    /// `fps` (capped at `maximumFPS`). With `markers` (opt-in), the clip
+    /// is bracketed by START/END card frames so a forever-looping GIF
+    /// has a visible boundary. Returns the number of frames actually
     /// written, marker cards included.
     @discardableResult
-    public static func transcode(mp4URL: URL, to gifURL: URL, fps: Int, markers: Bool = true) async throws -> Int {
+    public static func transcode(mp4URL: URL, to gifURL: URL, fps: Int, markers: Bool = false) async throws -> Int {
         let asset = AVURLAsset(url: mp4URL)
         guard let track = try await asset.loadTracks(withMediaType: .video).first else {
             throw GIFTranscoderError.noVideoTrack
@@ -203,7 +203,7 @@ public enum GIFTranscoder {
     /// captured footage) while removing the partially written GIF, which
     /// would otherwise read as a successful recording to any
     /// does-the-file-exist check.
-    public static func transcodeRecording(tempMP4: URL, to gifURL: URL, fps: Int, markers: Bool = true) async throws {
+    public static func transcodeRecording(tempMP4: URL, to gifURL: URL, fps: Int, markers: Bool = false) async throws {
         FileHandle.standardError.write(Data("Transcoding to GIF...\n".utf8))
         do {
             let frames = try await transcode(mp4URL: tempMP4, to: gifURL, fps: fps, markers: markers)

--- a/Sources/SimUseVideo/RecordingFormat.swift
+++ b/Sources/SimUseVideo/RecordingFormat.swift
@@ -39,14 +39,17 @@ public struct ResolvedRecordingOptions: Equatable, Sendable {
     /// The rate GIF sampling runs at — always resolved, so the default
     /// lives here and nowhere else.
     public let gifSampleFPS: Int
+    /// Whether a GIF is bracketed with START/END marker frames.
+    public let gifMarkers: Bool
 
-    public init(format: RecordingFormat?, output: String?, fps: Int?, scale: Double?) {
+    public init(format: RecordingFormat?, output: String?, fps: Int?, scale: Double?, gifMarkers: Bool = true) {
         let resolvedFormat = format ?? RecordingFormat.infer(fromOutput: output) ?? .mp4
         let sampleFPS = fps ?? 10
         self.format = resolvedFormat
         self.gifSampleFPS = sampleFPS
         self.fps = fps ?? (resolvedFormat == .gif ? sampleFPS : nil)
         self.scale = scale ?? (resolvedFormat == .gif ? 0.5 : 1.0)
+        self.gifMarkers = gifMarkers
     }
 
     /// Where the H.264 capture should land: the final URL for mp4, an
@@ -69,8 +72,8 @@ public struct RecordingOutputPlan {
     public let outputURL: URL
     public let recordTarget: URL
 
-    public init(format: RecordingFormat?, output: String?, fps: Int?, scale: Double?) throws {
-        options = ResolvedRecordingOptions(format: format, output: output, fps: fps, scale: scale)
+    public init(format: RecordingFormat?, output: String?, fps: Int?, scale: Double?, gifMarkers: Bool = true) throws {
+        options = ResolvedRecordingOptions(format: format, output: output, fps: fps, scale: scale, gifMarkers: gifMarkers)
         RecordingFormat.warnIfOverridingExtension(explicit: format, output: output)
         outputURL = try VideoOutputFile.prepareOutputURL(output: output, fileExtension: options.format.rawValue)
         recordTarget = options.recordTarget(for: outputURL)
@@ -84,6 +87,11 @@ public struct RecordingOutputPlan {
     /// invalidated, so a stuck transcode stays interruptible.
     public func finalizeRecording() async throws {
         guard options.format == .gif else { return }
-        try await GIFTranscoder.transcodeRecording(tempMP4: recordTarget, to: outputURL, fps: options.gifSampleFPS)
+        try await GIFTranscoder.transcodeRecording(
+            tempMP4: recordTarget,
+            to: outputURL,
+            fps: options.gifSampleFPS,
+            markers: options.gifMarkers
+        )
     }
 }

--- a/Sources/SimUseVideo/RecordingFormat.swift
+++ b/Sources/SimUseVideo/RecordingFormat.swift
@@ -39,10 +39,13 @@ public struct ResolvedRecordingOptions: Equatable, Sendable {
     /// The rate GIF sampling runs at — always resolved, so the default
     /// lives here and nowhere else.
     public let gifSampleFPS: Int
-    /// Whether a GIF is bracketed with START/END marker frames.
+    /// Whether a GIF is bracketed with START/END marker frames. No
+    /// default here or downstream — the opt-in policy lives on the
+    /// `--gif-markers` flag of the three command surfaces, and every
+    /// internal caller passes it explicitly.
     public let gifMarkers: Bool
 
-    public init(format: RecordingFormat?, output: String?, fps: Int?, scale: Double?, gifMarkers: Bool = false) {
+    public init(format: RecordingFormat?, output: String?, fps: Int?, scale: Double?, gifMarkers: Bool) {
         let resolvedFormat = format ?? RecordingFormat.infer(fromOutput: output) ?? .mp4
         let sampleFPS = fps ?? 10
         self.format = resolvedFormat
@@ -72,7 +75,7 @@ public struct RecordingOutputPlan {
     public let outputURL: URL
     public let recordTarget: URL
 
-    public init(format: RecordingFormat?, output: String?, fps: Int?, scale: Double?, gifMarkers: Bool = false) throws {
+    public init(format: RecordingFormat?, output: String?, fps: Int?, scale: Double?, gifMarkers: Bool) throws {
         options = ResolvedRecordingOptions(format: format, output: output, fps: fps, scale: scale, gifMarkers: gifMarkers)
         RecordingFormat.warnIfOverridingExtension(explicit: format, output: output)
         outputURL = try VideoOutputFile.prepareOutputURL(output: output, fileExtension: options.format.rawValue)

--- a/Sources/SimUseVideo/RecordingFormat.swift
+++ b/Sources/SimUseVideo/RecordingFormat.swift
@@ -42,7 +42,7 @@ public struct ResolvedRecordingOptions: Equatable, Sendable {
     /// Whether a GIF is bracketed with START/END marker frames.
     public let gifMarkers: Bool
 
-    public init(format: RecordingFormat?, output: String?, fps: Int?, scale: Double?, gifMarkers: Bool = true) {
+    public init(format: RecordingFormat?, output: String?, fps: Int?, scale: Double?, gifMarkers: Bool = false) {
         let resolvedFormat = format ?? RecordingFormat.infer(fromOutput: output) ?? .mp4
         let sampleFPS = fps ?? 10
         self.format = resolvedFormat
@@ -72,7 +72,7 @@ public struct RecordingOutputPlan {
     public let outputURL: URL
     public let recordTarget: URL
 
-    public init(format: RecordingFormat?, output: String?, fps: Int?, scale: Double?, gifMarkers: Bool = true) throws {
+    public init(format: RecordingFormat?, output: String?, fps: Int?, scale: Double?, gifMarkers: Bool = false) throws {
         options = ResolvedRecordingOptions(format: format, output: output, fps: fps, scale: scale, gifMarkers: gifMarkers)
         RecordingFormat.warnIfOverridingExtension(explicit: format, output: output)
         outputURL = try VideoOutputFile.prepareOutputURL(output: output, fileExtension: options.format.rawValue)

--- a/Sources/iOSSimBackend/Verbs/IOSSimRecordVideoCommand.swift
+++ b/Sources/iOSSimBackend/Verbs/IOSSimRecordVideoCommand.swift
@@ -50,8 +50,8 @@ public struct IOSSimRecordVideoCommand: SimUseExecutableCommand {
     @Option(help: "Output format: mp4, gif. Defaults to the --output extension when recognized, else mp4.")
     public var format: RecordingFormat?
 
-    @Flag(inversion: .prefixedNo, help: "Bracket a GIF with START/END marker frames (default: enabled; ignored for mp4).")
-    public var gifMarkers: Bool = true
+    @Flag(help: "Bracket a GIF with START/END marker frames (opt-in; ignored for mp4).")
+    public var gifMarkers: Bool = false
 
     @Option(help: "Output file path. Defaults to sim-use-video-<timestamp>.<format> in the current directory.")
     public var output: String?

--- a/Sources/iOSSimBackend/Verbs/IOSSimRecordVideoCommand.swift
+++ b/Sources/iOSSimBackend/Verbs/IOSSimRecordVideoCommand.swift
@@ -50,6 +50,9 @@ public struct IOSSimRecordVideoCommand: SimUseExecutableCommand {
     @Option(help: "Output format: mp4, gif. Defaults to the --output extension when recognized, else mp4.")
     public var format: RecordingFormat?
 
+    @Flag(inversion: .prefixedNo, help: "Bracket a GIF with START/END marker frames (default: enabled; ignored for mp4).")
+    public var gifMarkers: Bool = true
+
     @Option(help: "Output file path. Defaults to sim-use-video-<timestamp>.<format> in the current directory.")
     public var output: String?
 
@@ -100,7 +103,7 @@ public struct IOSSimRecordVideoCommand: SimUseExecutableCommand {
 
         // GIF is transcoded from a finished MP4 (see GIFTranscoder); the
         // capture loop itself always writes H.264, to plan.recordTarget.
-        let plan = try RecordingOutputPlan(format: format, output: output, fps: fps, scale: scale)
+        let plan = try RecordingOutputPlan(format: format, output: output, fps: fps, scale: scale, gifMarkers: gifMarkers)
         let options = plan.options
         let recordTarget = plan.recordTarget
         FileHandle.standardError.write(Data("Recording simulator \(targetSimulator.udid) to \(plan.outputURL.path)\n".utf8))

--- a/Tests/GIFTranscoderTests.swift
+++ b/Tests/GIFTranscoderTests.swift
@@ -111,7 +111,7 @@ struct GIFTranscoderTests {
         #expect(gif.fps == 10)
         #expect(gif.gifSampleFPS == 10)
         #expect(gif.scale == 0.5)
-        #expect(gif.gifMarkers) // default on
+        #expect(!gif.gifMarkers) // opt-in, default off
 
         let inferred = Options(format: nil, output: "demo.gif", fps: nil, scale: nil)
         #expect(inferred.format == .gif)
@@ -202,7 +202,7 @@ struct GIFTranscoderTests {
             .appendingPathComponent("gif-transcoder-test-\(UUID().uuidString).gif")
         defer { try? FileManager.default.removeItem(at: gifURL) }
 
-        let written = try await GIFTranscoder.transcode(mp4URL: mp4URL, to: gifURL, fps: 10, markers: false)
+        let written = try await GIFTranscoder.transcode(mp4URL: mp4URL, to: gifURL, fps: 10)
 
         let source = try #require(CGImageSourceCreateWithURL(gifURL as CFURL, nil))
         let type = try #require(CGImageSourceGetType(source) as String?)
@@ -234,12 +234,12 @@ struct GIFTranscoderTests {
             .appendingPathComponent("gif-transcoder-test-\(UUID().uuidString).gif")
         defer { try? FileManager.default.removeItem(at: gifURL) }
 
-        let written = try await GIFTranscoder.transcode(mp4URL: mp4URL, to: gifURL, fps: 10, markers: false)
+        let written = try await GIFTranscoder.transcode(mp4URL: mp4URL, to: gifURL, fps: 10)
         #expect(written >= 8 && written <= 12)
         #expect(CGImageSourceGetCount(try #require(CGImageSourceCreateWithURL(gifURL as CFURL, nil))) == written)
     }
 
-    @Test("Markers bracket the GIF with START/END cards by default")
+    @Test("Opt-in markers bracket the GIF with START/END cards")
     func transcodeAddsMarkerCards() async throws {
         let mp4URL = try await makeSyntheticMP4(frameCount: 10, fps: 10)
         defer { try? FileManager.default.removeItem(at: mp4URL) }
@@ -247,7 +247,7 @@ struct GIFTranscoderTests {
             .appendingPathComponent("gif-transcoder-test-\(UUID().uuidString).gif")
         defer { try? FileManager.default.removeItem(at: gifURL) }
 
-        let written = try await GIFTranscoder.transcode(mp4URL: mp4URL, to: gifURL, fps: 10)
+        let written = try await GIFTranscoder.transcode(mp4URL: mp4URL, to: gifURL, fps: 10, markers: true)
 
         let source = try #require(CGImageSourceCreateWithURL(gifURL as CFURL, nil))
         let frameCount = CGImageSourceGetCount(source)

--- a/Tests/GIFTranscoderTests.swift
+++ b/Tests/GIFTranscoderTests.swift
@@ -101,22 +101,21 @@ struct GIFTranscoderTests {
     func resolvedOptionsDefaults() {
         typealias Options = ResolvedRecordingOptions
 
-        let mp4 = Options(format: nil, output: nil, fps: nil, scale: nil)
+        let mp4 = Options(format: nil, output: nil, fps: nil, scale: nil, gifMarkers: false)
         #expect(mp4.format == .mp4)
         #expect(mp4.fps == nil) // capture-path default (30 native / 10 fallback)
         #expect(mp4.scale == 1.0)
 
-        let gif = Options(format: .gif, output: nil, fps: nil, scale: nil)
+        let gif = Options(format: .gif, output: nil, fps: nil, scale: nil, gifMarkers: false)
         #expect(gif.format == .gif)
         #expect(gif.fps == 10)
         #expect(gif.gifSampleFPS == 10)
         #expect(gif.scale == 0.5)
-        #expect(!gif.gifMarkers) // opt-in, default off
 
-        let inferred = Options(format: nil, output: "demo.gif", fps: nil, scale: nil)
+        let inferred = Options(format: nil, output: "demo.gif", fps: nil, scale: nil, gifMarkers: false)
         #expect(inferred.format == .gif)
 
-        let explicit = Options(format: .mp4, output: "demo.gif", fps: 24, scale: 0.8)
+        let explicit = Options(format: .mp4, output: "demo.gif", fps: 24, scale: 0.8, gifMarkers: false)
         #expect(explicit.format == .mp4) // explicit --format beats the extension
         #expect(explicit.fps == 24)
         #expect(explicit.gifSampleFPS == 24)
@@ -134,7 +133,7 @@ struct GIFTranscoderTests {
         let stale = URL(fileURLWithPath: base.path + ".recording.mp4")
         try Data([0x00]).write(to: stale)
 
-        let plan = try RecordingOutputPlan(format: nil, output: base.path, fps: nil, scale: nil)
+        let plan = try RecordingOutputPlan(format: nil, output: base.path, fps: nil, scale: nil, gifMarkers: false)
         #expect(plan.options.format == .gif)
         #expect(plan.recordTarget == stale)
         #expect(!FileManager.default.fileExists(atPath: stale.path))
@@ -145,7 +144,7 @@ struct GIFTranscoderTests {
         let base = FileManager.default.temporaryDirectory
             .appendingPathComponent("gif-plan-test-\(UUID().uuidString).mp4")
         defer { try? FileManager.default.removeItem(at: base) }
-        let plan = try RecordingOutputPlan(format: nil, output: base.path, fps: nil, scale: nil)
+        let plan = try RecordingOutputPlan(format: nil, output: base.path, fps: nil, scale: nil, gifMarkers: false)
         #expect(plan.recordTarget == plan.outputURL)
     }
 
@@ -202,7 +201,7 @@ struct GIFTranscoderTests {
             .appendingPathComponent("gif-transcoder-test-\(UUID().uuidString).gif")
         defer { try? FileManager.default.removeItem(at: gifURL) }
 
-        let written = try await GIFTranscoder.transcode(mp4URL: mp4URL, to: gifURL, fps: 10)
+        let written = try await GIFTranscoder.transcode(mp4URL: mp4URL, to: gifURL, fps: 10, markers: false)
 
         let source = try #require(CGImageSourceCreateWithURL(gifURL as CFURL, nil))
         let type = try #require(CGImageSourceGetType(source) as String?)
@@ -234,7 +233,7 @@ struct GIFTranscoderTests {
             .appendingPathComponent("gif-transcoder-test-\(UUID().uuidString).gif")
         defer { try? FileManager.default.removeItem(at: gifURL) }
 
-        let written = try await GIFTranscoder.transcode(mp4URL: mp4URL, to: gifURL, fps: 10)
+        let written = try await GIFTranscoder.transcode(mp4URL: mp4URL, to: gifURL, fps: 10, markers: false)
         #expect(written >= 8 && written <= 12)
         #expect(CGImageSourceGetCount(try #require(CGImageSourceCreateWithURL(gifURL as CFURL, nil))) == written)
     }
@@ -302,7 +301,7 @@ struct GIFTranscoderTests {
             .appendingPathComponent("gif-transcoder-test-\(UUID().uuidString).gif")
 
         await #expect(throws: (any Error).self) {
-            try await GIFTranscoder.transcode(mp4URL: bogusURL, to: gifURL, fps: 10)
+            try await GIFTranscoder.transcode(mp4URL: bogusURL, to: gifURL, fps: 10, markers: false)
         }
     }
 
@@ -317,7 +316,7 @@ struct GIFTranscoderTests {
         try Data([0x47, 0x49, 0x46]).write(to: gifURL) // partial/garbage GIF on disk
 
         await #expect(throws: (any Error).self) {
-            try await GIFTranscoder.transcodeRecording(tempMP4: bogusURL, to: gifURL, fps: 10)
+            try await GIFTranscoder.transcodeRecording(tempMP4: bogusURL, to: gifURL, fps: 10, markers: false)
         }
         #expect(FileManager.default.fileExists(atPath: bogusURL.path)) // footage preserved
         #expect(!FileManager.default.fileExists(atPath: gifURL.path)) // garbage removed

--- a/Tests/GIFTranscoderTests.swift
+++ b/Tests/GIFTranscoderTests.swift
@@ -111,6 +111,7 @@ struct GIFTranscoderTests {
         #expect(gif.fps == 10)
         #expect(gif.gifSampleFPS == 10)
         #expect(gif.scale == 0.5)
+        #expect(gif.gifMarkers) // default on
 
         let inferred = Options(format: nil, output: "demo.gif", fps: nil, scale: nil)
         #expect(inferred.format == .gif)
@@ -201,7 +202,7 @@ struct GIFTranscoderTests {
             .appendingPathComponent("gif-transcoder-test-\(UUID().uuidString).gif")
         defer { try? FileManager.default.removeItem(at: gifURL) }
 
-        let written = try await GIFTranscoder.transcode(mp4URL: mp4URL, to: gifURL, fps: 10)
+        let written = try await GIFTranscoder.transcode(mp4URL: mp4URL, to: gifURL, fps: 10, markers: false)
 
         let source = try #require(CGImageSourceCreateWithURL(gifURL as CFURL, nil))
         let type = try #require(CGImageSourceGetType(source) as String?)
@@ -233,9 +234,62 @@ struct GIFTranscoderTests {
             .appendingPathComponent("gif-transcoder-test-\(UUID().uuidString).gif")
         defer { try? FileManager.default.removeItem(at: gifURL) }
 
-        let written = try await GIFTranscoder.transcode(mp4URL: mp4URL, to: gifURL, fps: 10)
+        let written = try await GIFTranscoder.transcode(mp4URL: mp4URL, to: gifURL, fps: 10, markers: false)
         #expect(written >= 8 && written <= 12)
         #expect(CGImageSourceGetCount(try #require(CGImageSourceCreateWithURL(gifURL as CFURL, nil))) == written)
+    }
+
+    @Test("Markers bracket the GIF with START/END cards by default")
+    func transcodeAddsMarkerCards() async throws {
+        let mp4URL = try await makeSyntheticMP4(frameCount: 10, fps: 10)
+        defer { try? FileManager.default.removeItem(at: mp4URL) }
+        let gifURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gif-transcoder-test-\(UUID().uuidString).gif")
+        defer { try? FileManager.default.removeItem(at: gifURL) }
+
+        let written = try await GIFTranscoder.transcode(mp4URL: mp4URL, to: gifURL, fps: 10)
+
+        let source = try #require(CGImageSourceCreateWithURL(gifURL as CFURL, nil))
+        let frameCount = CGImageSourceGetCount(source)
+        #expect(frameCount == written)
+        // 10 sampled content frames (±2 encoder variance) + 2 marker cards.
+        #expect(frameCount >= 10 && frameCount <= 12)
+
+        // Marker cards hold for the marker delay; content frames pace at 0.1 s.
+        for index in [0, frameCount - 1] {
+            let props = try #require(CGImageSourceCopyPropertiesAtIndex(source, index, nil) as? [CFString: Any])
+            let gif = try #require(props[kCGImagePropertyGIFDictionary] as? [CFString: Any])
+            let delay = try #require(gif[kCGImagePropertyGIFUnclampedDelayTime] as? Double)
+            #expect(abs(delay - GIFTranscoder.markerDelay) < 0.02)
+        }
+
+        // The cards match the content frame size.
+        let first = try #require(CGImageSourceCreateImageAtIndex(source, 0, nil))
+        #expect(first.width == 64 && first.height == 64)
+    }
+
+    @Test("Marker card renders a light label on a dark background")
+    func markerCardRendering() throws {
+        let card = try #require(GIFTranscoder.makeMarkerCard(width: 120, height: 60, label: "START"))
+        #expect(card.width == 120 && card.height == 60)
+
+        var pixels = [UInt8](repeating: 0, count: 120 * 60 * 4)
+        let context = try #require(CGContext(
+            data: &pixels,
+            width: 120,
+            height: 60,
+            bitsPerComponent: 8,
+            bytesPerRow: 120 * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ))
+        context.draw(card, in: CGRect(x: 0, y: 0, width: 120, height: 60))
+
+        // Corner pixel is background (dark); the card must also contain
+        // bright text pixels somewhere.
+        #expect(pixels[0] < 60 && pixels[1] < 60 && pixels[2] < 60)
+        let hasBrightPixel = stride(from: 0, to: pixels.count, by: 4).contains { pixels[$0] > 200 }
+        #expect(hasBrightPixel)
     }
 
     @Test("A file with no video track throws noVideoTrack")

--- a/Tests/GIFTranscoderTests.swift
+++ b/Tests/GIFTranscoderTests.swift
@@ -7,7 +7,14 @@ import ImageIO
 import UniformTypeIdentifiers
 @testable import SimUseVideo
 
-@Suite("GIFTranscoder")
+// .serialized: the round-trip tests each drive a real VideoToolbox
+// H.264 encode session (makeSyntheticMP4). Two such sessions ran
+// concurrently for weeks of green CI; the third one added with the
+// marker feature deadlocked the encoder on GitHub's virtualized
+// macOS runners in 4 of 4 runs (#100/#101), wedging the entire
+// swift-test process until the job timeout. One session at a time
+// costs well under a second locally.
+@Suite("GIFTranscoder", .serialized)
 struct GIFTranscoderTests {
     // MARK: - Sampling plan (pure logic)
 

--- a/Tests/RecordVideoForwarderTests.swift
+++ b/Tests/RecordVideoForwarderTests.swift
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+@testable import SimUse
+@testable import iOSSimBackend
+import AndroidBackend
+import ArgumentParser
+import Foundation
+import SimUseCore
+import SimUseVideo
+import Testing
+
+// Pins the `--gif-markers` contract between top-level `RecordVideo`,
+// `IOSSimRecordVideoCommand`, and `AndroidRecordVideoCommand`: the flag
+// is opt-in on every surface, parses identically, and reaches the
+// backends. The recording layers below take `gifMarkers` as a required
+// parameter, so the compiler already rejects an unwired Android
+// forwarder; the shape check makes that contract explicit.
+@Suite("RecordVideo forwarder")
+struct RecordVideoForwarderTests {
+    private let iosUDID = "9CD7C6E7-45B3-4E59-BBF2-4D12A9457CD0"
+
+    // MARK: - Flag-surface parity
+
+    @Test("--gif-markers defaults to off on all three surfaces")
+    func gifMarkersDefaultOff() throws {
+        #expect(try RecordVideo.parse([]).gifMarkers == false)
+        #expect(try IOSSimRecordVideoCommand.parse([]).gifMarkers == false)
+        #expect(try AndroidRecordVideoCommand.parse([]).gifMarkers == false)
+    }
+
+    @Test("--gif-markers parses as true on all three surfaces")
+    func gifMarkersParsesTrue() throws {
+        #expect(try RecordVideo.parse(["--gif-markers"]).gifMarkers == true)
+        #expect(try IOSSimRecordVideoCommand.parse(["--gif-markers"]).gifMarkers == true)
+        #expect(try AndroidRecordVideoCommand.parse(["--gif-markers"]).gifMarkers == true)
+    }
+
+    // MARK: - Forwarding
+
+    @Test("Top-level forwarder copies --gif-markers to the iOS subcommand")
+    func gifMarkersForwardsToIOS() throws {
+        let on = try RecordVideo.parse(["--gif-markers", "--udid", iosUDID])
+        #expect(on.makeIOSSubcommand().gifMarkers == true)
+
+        let off = try RecordVideo.parse(["--udid", iosUDID])
+        #expect(off.makeIOSSubcommand().gifMarkers == false)
+    }
+
+    @Test("AndroidRecordVideoCommand.record requires gifMarkers in the forwarder's argument shape")
+    func androidRecordContract() {
+        let _: (
+            String,
+            String?,
+            RecordingFormat?,
+            Int?,
+            Int,
+            Double?,
+            Bool
+        ) async throws -> URL = AndroidRecordVideoCommand.record
+    }
+}

--- a/skills/sim-use/SKILL.md
+++ b/skills/sim-use/SKILL.md
@@ -82,7 +82,7 @@ Every byte of command output you read costs context. Defaults that keep the loop
 | Swipe | `sim-use swipe --from 50,500 --to 350,500 --device <UDID>` |
 | Pinch zoom in | `sim-use gesture pinch-out --device <UDID>` (two-finger spread) |
 | Rotate | `sim-use gesture rotate-cw --angle 90 --device <UDID>` |
-| Record evidence GIF | `sim-use record-video --output demo.gif --device <UDID>` — stop with SIGINT/SIGTERM (never SIGKILL); transcodes after stop; auto-plays inline in PRs |
+| Record evidence GIF | `sim-use record-video --output demo.gif --device <UDID>` — stop with SIGINT/SIGTERM (never SIGKILL); transcodes after stop; auto-plays inline in PRs; add `--gif-markers` for START/END loop-boundary cards |
 
 ## 2. Pitfalls
 

--- a/skills/sim-use/references/cheatsheet.md
+++ b/skills/sim-use/references/cheatsheet.md
@@ -124,7 +124,7 @@ sim-use touch -x 150 -y 250 --down --up --delay 1.0  # long press
 sim-use screenshot --output shot.png
 sim-use record-video --output recording.mp4             # H.264, 30 fps default; Ctrl+C to stop
 sim-use record-video --output smooth.mp4 --fps 60       # iOS: constant rate up to 60 fps (Android ignores --fps, native rate)
-sim-use record-video --output demo.gif                  # animated GIF (inferred from extension, or --format gif); 10 fps + 0.5 scale defaults; START/END marker cards (--no-gif-markers to skip); transcoded after Ctrl+C
+sim-use record-video --output demo.gif                  # animated GIF (inferred from extension, or --format gif); 10 fps + 0.5 scale defaults; add --gif-markers for START/END boundary cards; transcoded after Ctrl+C
 sim-use stream-video --fps 10 --format mjpeg > out.mjpeg  # live JPEG stream (both platforms)
 sim-use stream-video --format h264 | ffplay -f h264 -      # Android only: native H.264 passthrough (VFR)
 ```

--- a/skills/sim-use/references/cheatsheet.md
+++ b/skills/sim-use/references/cheatsheet.md
@@ -124,7 +124,7 @@ sim-use touch -x 150 -y 250 --down --up --delay 1.0  # long press
 sim-use screenshot --output shot.png
 sim-use record-video --output recording.mp4             # H.264, 30 fps default; Ctrl+C to stop
 sim-use record-video --output smooth.mp4 --fps 60       # iOS: constant rate up to 60 fps (Android ignores --fps, native rate)
-sim-use record-video --output demo.gif                  # animated GIF (inferred from extension, or --format gif); 10 fps + 0.5 scale defaults; transcoded after Ctrl+C
+sim-use record-video --output demo.gif                  # animated GIF (inferred from extension, or --format gif); 10 fps + 0.5 scale defaults; START/END marker cards (--no-gif-markers to skip); transcoded after Ctrl+C
 sim-use stream-video --fps 10 --format mjpeg > out.mjpeg  # live JPEG stream (both platforms)
 sim-use stream-video --format h264 | ffplay -f h264 -      # Android only: native H.264 passthrough (VFR)
 ```


### PR DESCRIPTION
Supersedes #100, carrying @kws0210's commits forward unchanged — thanks for the feature and the quick opt-in turnaround! This PR adds the remaining review follow-ups plus CI-hang forensics.

## What

- `record-video --gif-markers`: opt-in START/END marker cards (~1 s each) bracketing GIF exports, on all three surfaces (@kws0210's original work, commits preserved).
- Review follow-ups from #100:
  - `gifMarkers` is a required parameter through `ResolvedRecordingOptions` / `RecordingOutputPlan` / `GIFTranscoder` / `AndroidRecordVideoCommand.record`. The opt-in default lives only on the three `--gif-markers` flag declarations, and an unwired internal caller is now a compile error.
  - Focused parity coverage (`Tests/RecordVideoForwarderTests.swift`): default-off and `--gif-markers` parsing on the top-level, iOS, and Android surfaces; the top-level → iOS forwarder copy; the argument shape of `AndroidRecordVideoCommand.record` the Android forwarder compiles against.
  - `skills/sim-use/SKILL.md`'s evidence-GIF entry now documents the flag (the cheatsheet alone did not cover the primary skill entry).

## CI hang investigation

`Unit tests (macOS)` hit the 60-minute job timeout twice on #100. Established so far:

- Not the runner tooling drift: the last green main run (Aug 6) installed the same xcsift 1.3.1, and the adb orphan process also appears on green runs.
- Not locally reproducible: the full suite passes in ~12 s of test time on a dev machine.
- Zero forensics from either timeout: the raw-log artifact was gated on `failure()`, which is false when the job is cancelled by its timeout.

This PR therefore bounds the test step at 20 minutes and uploads the raw `test.log` on cancellation as well — if the hang reproduces on this run, the partial log will name the wedged test. A rerun of the #100 head is in flight in parallel to confirm determinism; prime suspect is the CoreText path in `makeMarkerCard` (first CoreText use in this codebase, and `CTFontCreateWithName` goes through fontd XPC, which a headless runner can plausibly wedge).

## Testing

- `make build` green; `make test` locally: 1299 passed (the single red is an uncommitted local-workspace test edit unrelated to this branch — CI runs the clean tree).
- Live GIF behavior is unchanged from #100's validated head; this PR only removes default arguments, adds tests, and touches docs/CI.
