### PR TITLE
ci: capture the raw test log on cancellation and bound the test step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,10 +139,13 @@ jobs:
       # depends on, including the sim-use executable the smoke step
       # runs. make picks xcsift up from PATH and condenses the output
       # to a TOON summary itself; SIM_USE_RAW_LOG additionally saves
-      # the raw swift output, kept as a failure-only artifact for
-      # forensics the condensed view can't serve (e.g. grepping daemon
-      # log lines).
+      # the raw swift output, kept as an artifact on failure or
+      # cancellation for forensics the condensed view can't serve
+      # (e.g. grepping daemon log lines, or finding the last test that
+      # started before a hang). The step timeout bounds a wedged test
+      # run well below the job timeout so the artifact still uploads.
       - name: Run unit tests
+        timeout-minutes: 20
         run: make test
         env:
           SIM_USE_RAW_LOG: ${{ runner.temp }}/test.log
@@ -165,8 +168,11 @@ jobs:
             } >> "${GITHUB_STEP_SUMMARY}"
           fi
 
+      # failure() is false when a step or job times out (that's a
+      # cancellation), and a hang is exactly when the partial raw log
+      # matters most — cover both.
       - name: Upload raw logs on failure
-        if: failure()
+        if: failure() || cancelled()
         uses: actions/upload-artifact@v7
         with:
           name: raw-swift-logs


### PR DESCRIPTION
The unit-test job timed out twice on #100 (and once on #101) with zero forensics: the raw-log artifact was gated on `failure()`, which is false when a job is cancelled by its timeout — exactly the case where the partial log matters most. This uploads on `failure() || cancelled()` and bounds the test step at 20 minutes (a healthy run is ~3), so a wedged `swift test` leaves the job time to publish the artifact instead of eating the 60-minute job timeout.

## Doubles as a diagnostic probe

This branch is `main` + this workflow change only — no product or test code. The #100/#101 hang evidence currently points away from the PR content and at the runner image (green main last ran on image 20260720; every hang is on 20260728; macOS 26.5.2 and Xcode 26.6 17F113 are identical across both):

- The #101 partial log shows XCTest completing 306/306, the new CoreText marker-card test **passing**, and output freezing mid-line at ~2.2 s of test time — consistent with a few suspended tests leaving the rest of the output stuck in the writer's stdio buffer.
- The started-but-unfinished set centers on the three tests that round-trip real video through VideoToolbox H.264 encoding (`makeSyntheticMP4`), two of which predate #100 and were green on Aug 6.

If this run hangs the same way on the current image, the hang is a runner-image regression in the AVFoundation/VideoToolbox path and #100/#101 are exonerated; the artifact this PR adds will name the wedged tests either way. If it stays green, suspicion moves back to the #101 content and we bisect there.

## Testing

- `make test` locally: full suite green (this change touches only the workflow).
