### PR TITLE
fix: reject incompatible CLI in skill preflight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 ## Code quality
 - No `Any` types unless absolutely necessary; upgrade dependencies rather than downgrading code to work around type errors.
 - Follow Swift best practices and match the style of surrounding code.
-- When adding or removing commands/options, update the README and `skills/sim-use/SKILL.md`.
+- When adding or removing commands/options, update the README and `skills/sim-use/SKILL.md`. If the Skill starts relying on behavior newer than its current compatibility floor, also bump `MINIMUM_SIM_USE_VERSION` in `skills/sim-use/scripts/preflight.py` and extend `PreflightScriptTests`.
 
 ## Changelog
 `CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). Add entries under `## [Unreleased]` as you land changes. Subsection order: `### Added` / `### Changed` / `### Fixed` / `### Removed`. Never modify already-released version sections.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The bundled skill preflight now rejects an older `sim-use` CLI before device discovery and prints the Homebrew upgrade command, instead of misdiagnosing newly documented device types as disconnected.
+
 ## [0.14.0] - 2026-08-27
 
 ### Added

--- a/Tests/PreflightScriptTests.swift
+++ b/Tests/PreflightScriptTests.swift
@@ -6,70 +6,98 @@ import Testing
 struct PreflightScriptTests {
     @Test("device listing does not receive device-scoped options")
     func deviceListingDoesNotReceiveDeviceScopedOptions() async throws {
-        let tempRoot = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        let logFile = tempRoot.appendingPathComponent("sim-use-args.log")
-        let fakeSimUse = tempRoot.appendingPathComponent("sim-use")
+        let fixture = try makeFakeSimUse(versionStamp: "0.14.0")
+        defer { try? FileManager.default.removeItem(at: fixture.tempRoot) }
 
-        defer {
-            try? FileManager.default.removeItem(at: tempRoot)
-        }
-
-        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
-        try fakeSimUseScript(logFile: logFile.path).write(to: fakeSimUse, atomically: true, encoding: .utf8)
-        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: fakeSimUse.path)
-
-        let result = try await CommandRunner.run(
-            "python3 skills/sim-use/scripts/preflight.py --device target-device --sim-use-bin \(fakeSimUse.path)",
-            allowFailure: true
-        )
+        let result = try await runPreflight(fakeSimUse: fixture.executable)
 
         #expect(result.exitCode == 0, "preflight should pass with fake sim-use: \(result.output)")
         #expect(result.output.contains("All checks passed"))
 
-        let log = try String(contentsOf: logFile, encoding: .utf8)
+        let log = try String(contentsOf: fixture.logFile, encoding: .utf8)
         #expect(log.contains("--version\n"))
         #expect(log.contains("devices --json\n"))
         #expect(!log.contains("devices --json --device target-device"))
         #expect(log.contains("ui --json --device target-device"))
     }
 
-    @Test("incompatible CLI versions fail before device discovery")
-    func incompatibleVersionFailsBeforeDeviceDiscovery() async throws {
-        let tempRoot = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        let logFile = tempRoot.appendingPathComponent("sim-use-args.log")
-        let fakeSimUse = tempRoot.appendingPathComponent("sim-use")
+    @Test("version compatibility follows release normalization", arguments: [
+        (stamp: "0.14.0", versionExitCode: 0, expectedPass: true),
+        (stamp: "0.15.0", versionExitCode: 0, expectedPass: true),
+        (stamp: "v0.14.0", versionExitCode: 0, expectedPass: true),
+        (stamp: "v0.14.0-3-gabc1234-dirty", versionExitCode: 0, expectedPass: true),
+        (stamp: "dev", versionExitCode: 0, expectedPass: true),
+        (stamp: "0.13.0", versionExitCode: 0, expectedPass: false),
+        (stamp: "v0.13.0-5-gabc1234", versionExitCode: 0, expectedPass: true),
+        (stamp: "0.14.0", versionExitCode: 7, expectedPass: false),
+    ])
+    func versionCompatibility(
+        _ testCase: (stamp: String, versionExitCode: Int, expectedPass: Bool)
+    ) async throws {
+        let fixture = try makeFakeSimUse(
+            versionStamp: testCase.stamp,
+            versionExitCode: testCase.versionExitCode
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.tempRoot) }
 
-        defer {
-            try? FileManager.default.removeItem(at: tempRoot)
+        let result = try await runPreflight(fakeSimUse: fixture.executable)
+        let expectedExitCode = testCase.expectedPass ? 0 : 1
+        #expect(
+            result.exitCode == expectedExitCode,
+            "unexpected preflight result for version stamp \(testCase.stamp): \(result.output)"
+        )
+
+        let log = try String(contentsOf: fixture.logFile, encoding: .utf8)
+        if testCase.expectedPass {
+            #expect(result.output.contains("All checks passed"))
+            #expect(log.contains("devices --json\n"))
+            #expect(log.contains("ui --json --device target-device\n"))
+        } else {
+            #expect(result.output.contains("FAIL  sim-use version is compatible with this skill"))
+            #expect(result.output.contains("brew upgrade lycorp-jp/tap/sim-use"))
+            #expect(log == "--version\n")
         }
+    }
 
-        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
-        try outdatedSimUseScript(logFile: logFile.path).write(to: fakeSimUse, atomically: true, encoding: .utf8)
-        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: fakeSimUse.path)
-
-        let result = try await CommandRunner.run(
+    private func runPreflight(fakeSimUse: URL) async throws -> (output: String, exitCode: Int32) {
+        try await CommandRunner.run(
             "python3 skills/sim-use/scripts/preflight.py --device target-device --sim-use-bin \(fakeSimUse.path)",
             allowFailure: true
         )
-
-        #expect(result.exitCode == 1)
-        #expect(result.output.contains("FAIL  sim-use version is compatible with this skill"))
-        #expect(result.output.contains("brew upgrade lycorp-jp/tap/sim-use"))
-
-        let log = try String(contentsOf: logFile, encoding: .utf8)
-        #expect(log == "--version\n")
     }
 
-    private func fakeSimUseScript(logFile: String) -> String {
+    private func makeFakeSimUse(
+        versionStamp: String,
+        versionExitCode: Int = 0
+    ) throws -> (tempRoot: URL, executable: URL, logFile: URL) {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let logFile = tempRoot.appendingPathComponent("sim-use-args.log")
+        let executable = tempRoot.appendingPathComponent("sim-use")
+
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        try fakeSimUseScript(
+            logFile: logFile.path,
+            versionStamp: versionStamp,
+            versionExitCode: versionExitCode
+        ).write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+        return (tempRoot, executable, logFile)
+    }
+
+    private func fakeSimUseScript(
+        logFile: String,
+        versionStamp: String,
+        versionExitCode: Int
+    ) -> String {
         """
         #!/bin/bash
         printf '%s\\n' "$*" >> "\(logFile)"
 
         if [[ "$1" == "--version" ]]; then
-          echo "0.14.0"
-          exit 0
+          echo "\(versionStamp)"
+          exit \(versionExitCode)
         fi
 
         if [[ "$1" == "devices" ]]; then
@@ -87,21 +115,6 @@ struct PreflightScriptTests {
             exit 3
           fi
           echo '{"ok":true,"data":{"outline":"App: Test"}}'
-          exit 0
-        fi
-
-        echo "unexpected command: $*" >&2
-        exit 4
-        """
-    }
-
-    private func outdatedSimUseScript(logFile: String) -> String {
-        """
-        #!/bin/bash
-        printf '%s\\n' "$*" >> "\(logFile)"
-
-        if [[ "$1" == "--version" ]]; then
-          echo "0.13.0"
           exit 0
         fi
 

--- a/Tests/PreflightScriptTests.swift
+++ b/Tests/PreflightScriptTests.swift
@@ -28,15 +28,49 @@ struct PreflightScriptTests {
         #expect(result.output.contains("All checks passed"))
 
         let log = try String(contentsOf: logFile, encoding: .utf8)
+        #expect(log.contains("--version\n"))
         #expect(log.contains("devices --json\n"))
         #expect(!log.contains("devices --json --device target-device"))
         #expect(log.contains("ui --json --device target-device"))
+    }
+
+    @Test("incompatible CLI versions fail before device discovery")
+    func incompatibleVersionFailsBeforeDeviceDiscovery() async throws {
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let logFile = tempRoot.appendingPathComponent("sim-use-args.log")
+        let fakeSimUse = tempRoot.appendingPathComponent("sim-use")
+
+        defer {
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        try outdatedSimUseScript(logFile: logFile.path).write(to: fakeSimUse, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: fakeSimUse.path)
+
+        let result = try await CommandRunner.run(
+            "python3 skills/sim-use/scripts/preflight.py --device target-device --sim-use-bin \(fakeSimUse.path)",
+            allowFailure: true
+        )
+
+        #expect(result.exitCode == 1)
+        #expect(result.output.contains("FAIL  sim-use version is compatible with this skill"))
+        #expect(result.output.contains("brew upgrade lycorp-jp/tap/sim-use"))
+
+        let log = try String(contentsOf: logFile, encoding: .utf8)
+        #expect(log == "--version\n")
     }
 
     private func fakeSimUseScript(logFile: String) -> String {
         """
         #!/bin/bash
         printf '%s\\n' "$*" >> "\(logFile)"
+
+        if [[ "$1" == "--version" ]]; then
+          echo "0.14.0"
+          exit 0
+        fi
 
         if [[ "$1" == "devices" ]]; then
           if [[ "$*" == *"--device"* ]]; then
@@ -53,6 +87,21 @@ struct PreflightScriptTests {
             exit 3
           fi
           echo '{"ok":true,"data":{"outline":"App: Test"}}'
+          exit 0
+        fi
+
+        echo "unexpected command: $*" >&2
+        exit 4
+        """
+    }
+
+    private func outdatedSimUseScript(logFile: String) -> String {
+        """
+        #!/bin/bash
+        printf '%s\\n' "$*" >> "\(logFile)"
+
+        if [[ "$1" == "--version" ]]; then
+          echo "0.13.0"
           exit 0
         fi
 

--- a/skills/sim-use/SKILL.md
+++ b/skills/sim-use/SKILL.md
@@ -11,9 +11,9 @@ Before first interaction with a device, run the preflight check:
 python3 scripts/preflight.py --device <UDID>
 ```
 
-This verifies sim-use is installed, the device is reachable, and the daemon is healthy. If you don't have the script, do the checks manually:
+This verifies sim-use is installed and compatible with the skill, the device is reachable, and the daemon is healthy. If you don't have the script, do the checks manually:
 
-1. `sim-use --version` — confirm sim-use is on PATH.
+1. `sim-use --version` — confirm sim-use is on PATH and supports the skill's documented commands.
 2. `sim-use devices` — confirm the target device is listed and booted/connected.
 3. `sim-use ui --device <UDID>` — confirm you can read the screen.
 

--- a/skills/sim-use/scripts/preflight.py
+++ b/skills/sim-use/scripts/preflight.py
@@ -13,11 +13,15 @@ Usage:
 
 import argparse
 import json
+import re
 import shutil
 import subprocess
 import sys
 from dataclasses import dataclass, field
 from typing import Callable, Optional
+
+
+MINIMUM_SIM_USE_VERSION = (0, 14, 0)
 
 
 # ---------------------------------------------------------------------------
@@ -90,6 +94,24 @@ def run_checks(checks: list[Check], ctx: Ctx) -> bool:
 
 def check_sim_use_installed(ctx: Ctx) -> bool:
     return shutil.which(ctx.sim_use_bin) is not None
+
+
+def parse_version(value: str) -> Optional[tuple[int, int, int]]:
+    match = re.search(r"(?:^|\s)(\d+)\.(\d+)\.(\d+)(?:\s|$)", value.strip())
+    if not match:
+        return None
+    return tuple(int(part) for part in match.groups())
+
+
+def check_sim_use_compatible(ctx: Ctx) -> bool:
+    result = subprocess.run(
+        [ctx.sim_use_bin, "--version"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        return False
+    version = parse_version(result.stdout or result.stderr)
+    return version is not None and version >= MINIMUM_SIM_USE_VERSION
 
 
 def check_device_listed(ctx: Ctx) -> bool:
@@ -166,11 +188,21 @@ def shared_checks() -> list[Check]:
             fix_hint="Install sim-use: brew tap lycorp-jp/tap && brew install lycorp-jp/tap/sim-use (run 'brew trust lycorp-jp/tap' first if you see an untrusted-tap error)",
         ),
         Check(
+            id="sim_use_compatible",
+            description="sim-use version is compatible with this skill",
+            run=check_sim_use_compatible,
+            on_fail="abort",
+            fix_hint=(
+                f"Upgrade sim-use to >= {'.'.join(map(str, MINIMUM_SIM_USE_VERSION))}: "
+                "brew update && brew upgrade lycorp-jp/tap/sim-use"
+            ),
+        ),
+        Check(
             id="device_listed",
             description="target device is listed and reachable",
             run=check_device_listed,
             on_fail="abort",
-            fix_hint="Boot a simulator or connect an Android device, then retry.",
+            fix_hint="Boot a simulator, connect and unlock a physical iPhone/iPad, or connect an Android device, then retry.",
         ),
         Check(
             id="ui_responds",

--- a/skills/sim-use/scripts/preflight.py
+++ b/skills/sim-use/scripts/preflight.py
@@ -96,11 +96,9 @@ def check_sim_use_installed(ctx: Ctx) -> bool:
     return shutil.which(ctx.sim_use_bin) is not None
 
 
-def parse_version(value: str) -> Optional[tuple[int, int, int]]:
-    match = re.search(r"(?:^|\s)(\d+)\.(\d+)\.(\d+)(?:\s|$)", value.strip())
-    if not match:
-        return None
-    return tuple(int(part) for part in match.groups())
+def parse_version(value: str) -> Optional[tuple[int, ...]]:
+    match = re.fullmatch(r"v?(\d+)\.(\d+)\.(\d+)", value.strip())
+    return tuple(int(part) for part in match.groups()) if match else None
 
 
 def check_sim_use_compatible(ctx: Ctx) -> bool:
@@ -111,7 +109,9 @@ def check_sim_use_compatible(ctx: Ctx) -> bool:
     if result.returncode != 0:
         return False
     version = parse_version(result.stdout or result.stderr)
-    return version is not None and version >= MINIMUM_SIM_USE_VERSION
+    # Dev and dirty stamps are unparseable by design. Only release builds are
+    # gated, matching the Swift-side ReleaseVersion / BridgeClient behavior.
+    return version is None or version >= MINIMUM_SIM_USE_VERSION
 
 
 def check_device_listed(ctx: Ctx) -> bool:


### PR DESCRIPTION
## Summary

- add an explicit minimum CLI compatibility check before device discovery
- report the Homebrew upgrade command when the bundled skill is newer than the installed CLI
- mention physical iOS devices in the device-discovery remediation
- cover compatible and outdated CLI paths in `PreflightScriptTests`

## Motivation

The official `sim-use init` path installs the Skill bundled with the executable and therefore keeps the two versions paired. The mismatch can still occur when a user manually installs the Skill from source or a cross-harness Skill manager updates the repository content independently of the CLI. In that case the v0.14 Skill can document physical iOS routing while a v0.13 CLI silently omits physical devices, and the current preflight misdiagnoses the result as a disconnected device even when `devicectl` can see it.

This check is defense in depth for externally managed Skill installations; it does not replace or change the recommended `sim-use init` flow.

## Verification

- `python3 -m py_compile skills/sim-use/scripts/preflight.py`
- standalone fake-CLI scenarios for v0.14 success and v0.13 early failure
- real physical iPhone preflight with sim-use v0.14.0
- `./scripts/build.sh dev`
- `swift test --filter PreflightScriptTests` — device-list test and all 8 version cases passed
- GitHub Actions: DCO, bridge protocol parity, bridge unit tests, and macOS unit tests all passed