### PR TITLE
fix: surface remote content recovery in skill preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The bundled skill preflight now surfaces `remote_content_recovery` as a content warning instead of reporting an unqualified pass. Successful reads still exit successfully, with conditional iOS simulator accessibility guidance when visible app controls are missing.
 - The bundled skill preflight now rejects an older `sim-use` CLI before device discovery and prints the Homebrew upgrade command, instead of misdiagnosing newly documented device types as disconnected.
 
 ## [0.14.0] - 2026-08-27

--- a/Tests/PreflightScriptTests.swift
+++ b/Tests/PreflightScriptTests.swift
@@ -59,6 +59,76 @@ struct PreflightScriptTests {
         }
     }
 
+    @Test("remote content recovery warns without failing or restarting the daemon", arguments: [
+        #"{"ok":true,"advisory":{"kind":"remote_content_recovery"},"data":{"platform":"ios","screen":{"width":0,"height":0},"entries":[{"role":"StaticText","label":"12:00"}]}}"#,
+        #"{"ok":true,"advisory":{"kind":"remote_content_recovery"},"data":{"platform":"ios","entries":[{"role":"Button","label":"Browse"},{"role":"Button","label":"Cancel"}]}}"#,
+    ])
+    func remoteContentRecoveryWarns(uiResponse: String) async throws {
+        let fixture = try makeFakeSimUse(versionStamp: "0.14.0", uiResponse: uiResponse)
+        defer { try? FileManager.default.removeItem(at: fixture.tempRoot) }
+
+        let result = try await runPreflight(fakeSimUse: fixture.executable)
+
+        #expect(result.exitCode == 0)
+        #expect(result.output.contains("PASS  sim-use ui returns a valid response"))
+        #expect(result.output.contains("WARN"))
+        #expect(result.output.contains("remote_content_recovery"))
+        #expect(result.output.contains("system picker"))
+        #expect(result.output.contains("If visible app controls are missing"))
+        #expect(result.output.contains("ApplicationAccessibilityEnabled"))
+        #expect(result.output.contains("relaunch"))
+        #expect(result.output.contains("Preflight passed with a content warning"))
+        #expect(!result.output.contains("All checks passed"))
+        #expect(!result.output.contains("FAIL"))
+        #expect(!result.output.contains("FIX"))
+
+        let log = try String(contentsOf: fixture.logFile, encoding: .utf8)
+        #expect(log == "--version\ndevices --json\nui --json --device target-device\n")
+    }
+
+    @Test("successful reads without the recovery advisory keep the existing result", arguments: [
+        #"{"ok":true,"data":{"platform":"ios","entries":[{"role":"StaticText","label":"12:00"}]}}"#,
+        #"{"ok":true,"advisory":null,"data":{"outline":"App: Test"}}"#,
+        #"{"ok":true,"advisory":{"kind":"orientation_uncertain"},"data":{"outline":"App: Test"}}"#,
+        #"{"ok":true,"data":{"platform":"android","entries":[]}}"#,
+        #"{"ok":true,"data":{"kind":"physical","outline":"Button: Close"}}"#,
+    ])
+    func successfulReadWithoutRecoveryDoesNotWarn(uiResponse: String) async throws {
+        let fixture = try makeFakeSimUse(versionStamp: "0.14.0", uiResponse: uiResponse)
+        defer { try? FileManager.default.removeItem(at: fixture.tempRoot) }
+
+        let result = try await runPreflight(fakeSimUse: fixture.executable)
+
+        #expect(result.exitCode == 0)
+        #expect(result.output.contains("All checks passed"))
+        #expect(!result.output.contains("WARN"))
+        #expect(!result.output.contains("ApplicationAccessibilityEnabled"))
+    }
+
+    @Test("unsuccessful UI reads still retry and fail", arguments: [
+        (response: #"{"ok":false,"advisory":{"kind":"remote_content_recovery"}}"#, exitCode: 0),
+        (response: #"{"ok":true,"advisory":{"kind":"remote_content_recovery"}}"#, exitCode: 7),
+        (response: "invalid JSON", exitCode: 0),
+    ])
+    func unsuccessfulReadStillFails(_ testCase: (response: String, exitCode: Int)) async throws {
+        let fixture = try makeFakeSimUse(
+            versionStamp: "0.14.0",
+            uiResponse: testCase.response,
+            uiExitCode: testCase.exitCode
+        )
+        defer { try? FileManager.default.removeItem(at: fixture.tempRoot) }
+
+        let result = try await runPreflight(fakeSimUse: fixture.executable)
+
+        #expect(result.exitCode == 1)
+        #expect(result.output.contains("FAIL  sim-use ui returns a valid response"))
+        #expect(result.output.contains("Preflight failed: ui_responds"))
+        #expect(!result.output.contains("WARN"))
+
+        let log = try String(contentsOf: fixture.logFile, encoding: .utf8)
+        #expect(log == "--version\ndevices --json\nui --json --device target-device\ndaemon stop --all\nui --json --device target-device\n")
+    }
+
     private func runPreflight(fakeSimUse: URL) async throws -> (output: String, exitCode: Int32) {
         try await CommandRunner.run(
             "python3 skills/sim-use/scripts/preflight.py --device target-device --sim-use-bin \(fakeSimUse.path)",
@@ -68,7 +138,9 @@ struct PreflightScriptTests {
 
     private func makeFakeSimUse(
         versionStamp: String,
-        versionExitCode: Int = 0
+        versionExitCode: Int = 0,
+        uiResponse: String = #"{"ok":true,"data":{"outline":"App: Test"}}"#,
+        uiExitCode: Int = 0
     ) throws -> (tempRoot: URL, executable: URL, logFile: URL) {
         let tempRoot = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -79,7 +151,9 @@ struct PreflightScriptTests {
         try fakeSimUseScript(
             logFile: logFile.path,
             versionStamp: versionStamp,
-            versionExitCode: versionExitCode
+            versionExitCode: versionExitCode,
+            uiResponse: uiResponse,
+            uiExitCode: uiExitCode
         ).write(to: executable, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
 
@@ -89,7 +163,9 @@ struct PreflightScriptTests {
     private func fakeSimUseScript(
         logFile: String,
         versionStamp: String,
-        versionExitCode: Int
+        versionExitCode: Int,
+        uiResponse: String,
+        uiExitCode: Int
     ) -> String {
         """
         #!/bin/bash
@@ -114,7 +190,13 @@ struct PreflightScriptTests {
             echo "ui must receive --device" >&2
             exit 3
           fi
-          echo '{"ok":true,"data":{"outline":"App: Test"}}'
+          cat <<'PREFLIGHT_UI_RESPONSE'
+        \(uiResponse)
+        PREFLIGHT_UI_RESPONSE
+          exit \(uiExitCode)
+        fi
+
+        if [[ "$*" == "daemon stop --all" ]]; then
           exit 0
         fi
 

--- a/skills/sim-use/SKILL.md
+++ b/skills/sim-use/SKILL.md
@@ -17,6 +17,8 @@ This verifies sim-use is installed and compatible with the skill, the device is 
 2. `sim-use devices` — confirm the target device is listed and booted/connected.
 3. `sim-use ui --device <UDID>` — confirm you can read the screen.
 
+A successful response does not guarantee that the outline contains the expected app controls. Preflight reports `remote_content_recovery` as a content warning and still exits successfully; recovery can be normal for a system picker. Compare the outline with the visible screen. If app controls are missing, follow [Missing app controls after remote content recovery](references/pitfalls.md#missing-app-controls-after-remote-content-recovery). The warning does not change settings or restart anything.
+
 `--device` is optional when only one simulator is booted or one daemon is running. For Android, run `sim-use android init --device <serial>` once to install the bridge APK. Attached physical iPhones/iPads appear in `sim-use devices` with kind `physical` and route through the top-level verbs too — but only `ui`, selector-based `tap` and `screenshot`; every other verb rejects on that target. See *Physical iOS devices* below before driving one.
 
 ## 1. The observe-act loop

--- a/skills/sim-use/references/pitfalls.md
+++ b/skills/sim-use/references/pitfalls.md
@@ -54,7 +54,7 @@ Detailed solutions for common sim-use issues. The symptom index in SKILL.md poin
 
 **Recipe:**
 1. Compare the outline with the visible screen. If it contains the expected picker controls, continue normally.
-2. If visible app controls are missing on an iOS simulator, check whether app accessibility was enabled before the app launched. The current preference value alone does not establish the state at launch. See [idb's accessibility guidance](https://github.com/facebook/idb/blob/main/website/docs/accessibility.mdx).
+2. If visible app controls are missing on an iOS simulator, check whether app accessibility was enabled before the app launched. The current preference value alone does not establish the state at launch. See [idb's accessibility guidance](https://github.com/facebook/idb/blob/main/website/docs/idb/accessibility.mdx).
 3. If needed, enable app accessibility for that simulator, then relaunch the target app and re-read `ui`:
 
    ```bash

--- a/skills/sim-use/references/pitfalls.md
+++ b/skills/sim-use/references/pitfalls.md
@@ -46,6 +46,25 @@ Detailed solutions for common sim-use issues. The symptom index in SKILL.md poin
 2. Dismiss it: tap the appropriate button (`Allow`, `Don't Allow`, `Cancel`), or `sim-use button home` to go home.
 3. Re-run `ui` to confirm you're back in the app.
 
+## Missing app controls after remote content recovery
+
+**Symptom:** Preflight passes with a content warning, or `ui --json --no-raw` returns `ok: true` with `advisory.kind: remote_content_recovery`.
+
+**Why:** The app tree was empty, so sim-use recovered accessibility content from other processes. This can be normal for a system picker; the advisory alone does not mean the app is broken.
+
+**Recipe:**
+1. Compare the outline with the visible screen. If it contains the expected picker controls, continue normally.
+2. If visible app controls are missing on an iOS simulator, check whether app accessibility was enabled before the app launched. The current preference value alone does not establish the state at launch. See [idb's accessibility guidance](https://github.com/facebook/idb/blob/main/website/docs/accessibility.mdx).
+3. If needed, enable app accessibility for that simulator, then relaunch the target app and re-read `ui`:
+
+   ```bash
+   xcrun simctl spawn <UDID> defaults write com.apple.Accessibility ApplicationAccessibilityEnabled -bool true
+   ```
+
+4. If controls are still missing, inspect the app with Accessibility Inspector or VoiceOver to check what it exposes.
+
+This setting applies to iOS simulators. Preflight only prints guidance; it does not apply the setting, relaunch the app, or restart the daemon for a content warning.
+
 ## iOS: paste drops text
 
 **Symptom:** `sim-use paste 'text'` succeeds but the text field stays empty.

--- a/skills/sim-use/scripts/preflight.py
+++ b/skills/sim-use/scripts/preflight.py
@@ -43,6 +43,7 @@ class Ctx:
     device: Optional[str] = None
     sim_use_bin: str = "sim-use"
     platform: Optional[str] = None  # "ios" or "android", detected
+    remote_content_recovered: bool = False
     errors: list = field(default_factory=list)
 
     def run_sim_use(self, *args: str, check: bool = False) -> subprocess.CompletedProcess:
@@ -163,8 +164,15 @@ def autofix_boot_simulator(ctx: Ctx) -> bool:
 
 
 def check_ui_responds(ctx: Ctx) -> bool:
+    ctx.remote_content_recovered = False
     envelope = ctx.run_sim_use_json("ui")
-    return envelope is not None and envelope.get("ok") is True
+    if envelope is None or envelope.get("ok") is not True:
+        return False
+    advisory = envelope.get("advisory")
+    ctx.remote_content_recovered = (
+        isinstance(advisory, dict) and advisory.get("kind") == "remote_content_recovery"
+    )
+    return True
 
 
 def autofix_daemon_restart(ctx: Ctx) -> bool:
@@ -229,12 +237,19 @@ def main():
 
     print("sim-use preflight\n")
     passed = run_checks(shared_checks(), ctx)
+    if ctx.remote_content_recovered:
+        print("  WARN  UI content: remote_content_recovery")
+        print("        The app tree was empty; content was recovered from other processes.")
+        print("        This can be normal for a system picker. Compare the outline with the visible screen.")
+        print("        If visible app controls are missing on an iOS simulator, check")
+        print("        ApplicationAccessibilityEnabled in com.apple.Accessibility before an app relaunch.")
     print()
 
     if passed:
         device_label = ctx.device or "(auto-resolved)"
         platform_label = ctx.platform or "unknown"
-        print(f"All checks passed. Device: {device_label} ({platform_label})")
+        summary = "Preflight passed with a content warning" if ctx.remote_content_recovered else "All checks passed"
+        print(f"{summary}. Device: {device_label} ({platform_label})")
         sys.exit(0)
     else:
         print(f"Preflight failed: {', '.join(ctx.errors)}")


### PR DESCRIPTION
When `ui` returns `ok: true` with a `remote_content_recovery` advisory, the skill preflight currently discards the advisory and reports "All checks passed". The read succeeded, but the recovered outline can omit visible app controls. A system document picker can also produce this advisory during normal operation.

This change keeps the successful read and exit code `0`, prints a separate content warning, and qualifies the final summary. The warning asks the user to compare the outline with the screen and conditionally check `ApplicationAccessibilityEnabled` before an app relaunch if visible controls are missing on an iOS simulator. It reuses the existing response and performs no recovery action for this warning. The existing retry path for unsuccessful reads is unchanged.

The skill links to a focused troubleshooting recipe, and the changelog records the change. Regression cases cover clock-only recovery, normal picker recovery, successful responses without this advisory, and unsuccessful reads.

### Validation

- `swift test --filter PreflightScriptTests` passed. The new recovery cases failed against the original script before the implementation.
- `SIM_USE_XCSIFT=0 make build` passed.
- `SIM_USE_XCSIFT=0 make test` passed on rerun: 310 XCTest tests and a Swift Testing run reporting 1078 tests. The first run had one unrelated timing failure in `cancellableSleepEarlyWake` while a fresh simulator boot and fixture build were running; no test code was changed to obtain the passing rerun.
- Live iPhone 17 / iOS 26.4: the Playground and regular Safari page passed normally; Safari's document picker produced the content warning with exit code `0`; dismissing the picker restored the normal summary. A command log confirmed one `ui` read per preflight run and no restart calls. The smoke check used the local build in direct mode, with a wrapper that permitted only read commands for the dedicated test device.
- Natural-language skill evaluations were not run in this session.
